### PR TITLE
Prepare v1.5.0 preview release candidate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 [![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](LICENSE) [![GitHub release](https://img.shields.io/github/v/release/koagaroon/ssaHdrify-tauri?include_prereleases)](https://github.com/koagaroon/ssaHdrify-tauri/releases) ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-blue)
 
-> **SSA HDRify 是一款桌面工具，用于将正确的 HDR 色彩数据写入 SSA/ASS 字幕，同时附带有时间轴偏移、字体嵌入和批量重命名功能。** 本工具是基于 [gky99/ssaHdrify](https://github.com/gky99/ssaHdrify)（Python 原版）的 Tauri 桌面重写版。
+> **SSA HDRify 是一款桌面工具，可为 SSA/ASS 字幕写入适合 HDR 播放的色彩值，并提供时间轴偏移、字体嵌入和批量重命名等辅助功能。** 它是 [gky99/ssaHdrify](https://github.com/gky99/ssaHdrify)（Python 原版）的 Tauri 桌面重写版。
 >
-> _SSA HDRify is a desktop tool that writes the correct HDR color data into SSA/ASS subtitles, along with timing shift, font embedding, and batch rename._ It is a Tauri desktop rewrite of [gky99/ssaHdrify](https://github.com/gky99/ssaHdrify) (the original Python version).
+> _SSA HDRify is a desktop tool for writing HDR-ready color values into SSA/ASS subtitles, with companion tools for timing shift, font embedding, and batch renaming._ It is a Tauri desktop rewrite of [gky99/ssaHdrify](https://github.com/gky99/ssaHdrify) (the original Python version).
 
 ### 浅色主题（中文）/ Light Theme (Chinese)
 
@@ -45,17 +45,17 @@
 
 ## 下载 | Download
 
-Windows 用户可从 [Releases](https://github.com/koagaroon/ssaHdrify-tauri/releases/latest) 页面下载便携式 exe 文件：
+Windows 用户可从 [Releases](https://github.com/koagaroon/ssaHdrify-tauri/releases/latest) 页面下载免安装的便携版 exe：
 
 - **`ssahdrify*.exe`** — 图形界面（GUI），适合手动操作
-- **`ssahdrify-cli*.exe`** — 命令行（CLI），适合 pipeline / 批处理 / 脚本化场景
+- **`ssahdrify-cli*.exe`** — 命令行（CLI），适合自动化流水线、批处理和脚本化场景
 
 macOS / Linux 用户请参考下方「从源码构建」。
 
-Windows users can download portable exe files from [Releases](https://github.com/koagaroon/ssaHdrify-tauri/releases/latest):
+Windows users can download portable, no-installer exe files from [Releases](https://github.com/koagaroon/ssaHdrify-tauri/releases/latest):
 
 - **`ssahdrify*.exe`** — graphical interface (GUI), for manual workflows
-- **`ssahdrify-cli*.exe`** — command line (CLI), for pipeline / batch / scripting
+- **`ssahdrify-cli*.exe`** — command line (CLI), for automation pipelines, batch jobs, and scripts
 
 macOS / Linux users, see "Build from Source" below.
 
@@ -63,17 +63,17 @@ macOS / Linux users, see "Build from Source" below.
 
 ## 功能 | Features
 
-| 标签页 / Tab                            | 功能 / Function                                                                                                                                                                                                                                                                                                        |
+| 标签页 / Tab                            | 功能 / Description                                                                                                                                                                                                                                                                                                     |
 | --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **HDR 色彩转换 / HDR Color Conversion** | 为字幕附加对应的 BT.2100 PQ 或 HLG 色彩空间数据 / Attach the matching BT.2100 PQ or HLG color-space data to subtitles                                                                                                                                                                                                  |
-| **时间轴偏移 / Timing Shift**           | 批量偏移字幕时间戳；可指定时间点后才开始偏移，并支持实时预览 / Batch-offset subtitle timestamps; the shift can begin from a chosen timestamp, with live preview                                                                                                                                                        |
-| **字体嵌入 / Font Embedding**           | 自动检测字幕用到的字体，与系统字体库或本地字体源匹配，并以子集化形式嵌入 ASS 文件 / Auto-detect fonts referenced in the subtitle, match against system fonts or local sources, and embed them (subset) into the ASS                                                                                                    |
-| **批量重命名 / Batch Rename**           | 自动匹配视频文件和字幕文件，按视频文件名重命名字幕；同一视频文件有多个对应字幕时，用户可自由选择字幕文件，手动调整配对 / Auto-match video and subtitle files and rename subs to match the video filename; when a video has multiple subtitle candidates, the user can pick the desired one and adjust pairing manually |
+| **HDR 色彩转换 / HDR Color Conversion** | 将字幕颜色转换为匹配 BT.2100 PQ 或 HLG 的 HDR 色彩值 / Convert subtitle colors to HDR-ready BT.2100 PQ or HLG values                                                                                                                                                                                                   |
+| **时间轴偏移 / Timing Shift**           | 批量调整字幕时间戳；可从指定时间点之后开始偏移，并实时预览效果 / Batch-adjust subtitle timestamps; optionally start after a chosen timestamp, with live preview                                                                                                                                                         |
+| **字体嵌入 / Font Embedding**           | 自动检测字幕引用的字体，在系统字体库或本地字体源中匹配，并把子集化后的字体嵌入 ASS 文件 / Detect fonts referenced by the subtitle, match them from system or local font sources, and embed subset fonts into the ASS file                                                                                              |
+| **批量重命名 / Batch Rename**           | 自动匹配视频和字幕，并按视频文件名重命名字幕；如果同一视频匹配到多个字幕候选，可手动选择并调整配对 / Automatically match videos with subtitles and rename subtitles to match the video filename; when multiple subtitle candidates match the same video, choose and adjust the pairing manually                         |
 
 > [!TIP]
-> **中文路径完全支持** — 包含中文或其他非 ASCII 字符的文件路径不会引起任何问题。Tauri 和 Rust 底层使用 Unicode API，不受传统 ANSI 编码限制。
+> **完整支持中文路径** — 包含中文、日文或其他非 ASCII 字符的文件路径都可以正常处理。Tauri 和 Rust 底层使用 Unicode API，不受传统 ANSI 编码限制。
 >
-> **Non-ASCII paths fully supported** — File paths containing Chinese, Japanese, or other non-ASCII characters work correctly. Tauri and Rust use native Unicode APIs under the hood.
+> **Non-ASCII paths are supported** — File paths containing Chinese, Japanese, or other non-ASCII characters are handled correctly. Tauri and Rust use native Unicode APIs under the hood.
 
 ---
 
@@ -84,66 +84,66 @@ macOS / Linux users, see "Build from Source" below.
 1. 选择 EOTF 曲线（PQ 或 HLG）/ Select EOTF curve (PQ or HLG)
 2. 设置字幕目标亮度（默认 203 nits）/ Set target subtitle brightness (default: 203 nits)
 3. 选择字幕文件（支持多选）/ Select subtitle files (multi-select supported)
-4. 点击转换 / Click convert
-5. 默认输出文件扩展名为 `.hdr.ass`（可修改）/ Default output extension is `.hdr.ass` (customizable)
+4. 点击「转换」/ Click **Convert**
+5. 默认输出扩展名为 `.hdr.ass`（可修改）/ Default output extension is `.hdr.ass` (customizable)
 
 > **参数说明 | Parameter Guide**
 >
 > | 参数 / Parameter  | 默认值 / Default | 说明 / Description                                                                                                                        |
 > | ----------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-> | EOTF curve        | PQ               | PQ (ST 2084) 用于 HDR10/杜比视界；HLG 用于广播 HDR / PQ for HDR10/Dolby Vision; HLG for broadcast HDR                                     |
-> | Target brightness | 203 nits         | SDR 字幕亮度峰值（BT.2408 标准值）。字幕太亮就调低，太暗就调高 / Peak brightness per BT.2408. Decrease if too bright, increase if too dim |
+> | EOTF curve        | PQ               | PQ (ST 2084) 用于 HDR10/杜比视界；HLG 用于广播 HDR / PQ for HDR10/Dolby Vision; HLG for broadcast HDR                                                  |
+> | Target brightness | 203 nits         | SDR 字幕峰值亮度（BT.2408 标准值）。如果字幕太亮就调低，太暗就调高 / Peak SDR subtitle brightness (BT.2408 reference value). Lower it if too bright; raise it if too dim |
 
 ### 时间轴偏移 / Timing Shift
 
 1. 选择字幕文件 / Select a subtitle file
-2. 输入偏移量（毫秒），选择方向：「提前」或「延后」/ Enter offset amount (ms), then pick direction: Faster or Slower
-3. 可选：启用阈值过滤，仅偏移特定时间点后的字幕 / Optional: enable threshold to shift only captions after a specific timestamp
-4. 实时预览调整效果 / Preview changes in real time
+2. 输入偏移量（毫秒），并选择「提前」或「延后」/ Enter offset amount (ms), then choose Faster or Slower
+3. 可选：只偏移指定时间点之后的字幕行 / Optionally shift only lines after a specific timestamp
+4. 实时预览调整结果 / Preview the result in real time
 5. 导出 / Export
 
 ### 字体嵌入 / Font Embedding
 
-1. 点击「选择字幕文件 / Select Subtitle File」选择 ASS 字幕文件 / Click **Select Subtitle File** to pick an ASS file
-2. 工具自动检测字幕用到的字体，先尝试从系统字体库匹配 / Tool auto-detects fonts referenced in the subtitle and first tries to match them against the system font library
-3. 主面板实时显示本地来源覆盖（覆盖 N / M）和尚未匹配的字体；每条字体标注来源（本地 / 系统）和匹配状态（已找到 / 缺失）/ The main panel shows live local-source coverage (Coverage: N / M) and lists any still-missing families; each detected font is tagged with its source (Local / System) and status (Found / Missing)
-4. 点击「嵌入已选字体」，字体数据（子集化后）写入 ASS 文件 / Click **Embed Selected Fonts** to write the subset font data into the ASS file
+1. 点击「选择字幕文件 / Select Subtitle File」，选择 ASS 字幕文件 / Click **Select Subtitle File** to pick an ASS file
+2. 工具会自动检测字幕引用的字体，并优先尝试从系统字体库匹配 / The tool detects fonts referenced by the subtitle and first tries to match them against the system font library
+3. 主面板会实时显示本地字体源覆盖情况（覆盖 N / M）和尚未匹配的字体；每个字体都会标注来源（本地 / 系统）和状态（已找到 / 缺失）/ The main panel shows live local-source coverage (Coverage: N / M) and lists any still-missing families; each detected font is tagged with its source (Local / System) and status (Found / Missing)
+4. 点击「嵌入已选字体」，将子集化后的字体数据写入 ASS 文件 / Click **Embed Selected Fonts** to write the subset font data into the ASS file
 
-字幕组排版常用的字体大多未安装在系统中。点击「字体来源 / Font Sources」即可打开本地来源管理面板，添加你想扫描的文件夹，无需安装到系统即可参与匹配。
+字幕组排版常用字体通常没有安装在系统中。打开「字体来源 / Font Sources」面板，添加需要扫描的本地文件夹；这些字体无需系统安装，也可以参与匹配。
 
-Most fonts commonly used in fan-sub typesetting are not installed on the system. Click **Font Sources** to open the local-source manager, then add the folders you want to scan — no system-wide installation needed.
+Fonts used in fan-sub typesetting often are not installed system-wide. Open **Font Sources**, add the local folders you want to scan, and those fonts can be matched without installing them into the OS.
 
-文件夹大小不限，扫描过程会实时显示已读取的字体数量并支持随时取消；选择包含超过 5000 个文件或体积超过 1 GB 的目录前，会弹出确认对话框。
+支持任意大小的文件夹；扫描时会实时显示已读取的字体数量，也可以随时取消。选择包含超过 5000 个文件或容量超过 1 GB 的目录前，程序会先弹出确认对话框。
 
-Any folder size is accepted; the scan shows a real-time count of fonts found and can be cancelled at any time. Before selecting an exceptionally large directory (5000+ files or > 1 GB), a confirmation dialog will appear.
+Folders of any size are accepted; the scan shows a real-time count of fonts found and can be cancelled at any time. Before scanning a directory with over 5000 files or more than 1 GB of content, the app asks for confirmation.
 
 > **字体名称匹配 / Font Name Matching**
 >
-> 工具会读取字体文件的 OpenType `name` 表并索引**所有**语言变体（英文、中文、Typographic 名等）——ASS 脚本引用任何一个名字都能命中同一个字体文件。ASS 的 `@家族名` 竖排前缀也会被正确识别为同一字体。
+> 工具会读取字体文件的 OpenType `name` 表，并索引**所有**语言变体（英文、中文、Typographic 名等）。ASS 脚本无论引用哪个名称，都能匹配到同一个字体文件；`@家族名` 这类竖排前缀也会按同一字体处理。
 >
-> The tool reads each font's OpenType `name` table and indexes **every** localized family-name variant (English, Chinese, Typographic, etc.) — an ASS script referencing any of them resolves to the same file. The ASS `@FamilyName` vertical-writing prefix is correctly treated as the same font.
+> The tool reads each font's OpenType `name` table and indexes **every** localized family-name variant (English, Chinese, Typographic, etc.). An ASS script referencing any of those names resolves to the same font file; the ASS `@FamilyName` vertical-writing prefix is treated as the same font.
 
 ### 批量重命名 / Batch Rename
 
-1. 拖入一个包含视频和字幕的文件夹（或点击「选择文件 / Select Files」手动选择）；程序将按照文件格式自动归类 / Drop a folder containing both videos and subtitles (or click **Select Files** to pick manually); the app categorizes files by format automatically
-2. 系统按字幕组命名习惯做剧集号正则配对，预填配对表 / The app pre-pairs using fan-sub episode regex and fills the pairing table
-3. 若应用错配或漏配，从该行下拉框直接手动选取字幕，选中后自动勾选进入重命名队列 / If the app mispairs or misses a row, swap subtitles via the row's dropdown; the row is auto-checked into the rename queue once selected
-4. 选择输出策略：原文件直接改名 / 复制到当前目录 / 复制到自定义目录 / Pick the output strategy: rename in place, copy to the video's directory, or copy to a custom directory
-5. 点击运行；若目标路径已存在采用相同规则重命名的同名文件，会弹出确认覆盖对话框 / Click Run; if a target path already has a file with the same name produced by the rename rule, an overwrite-confirm dialog appears first
+1. 拖入包含视频和字幕的文件夹（或点击「选择文件 / Select Files」手动选择）；程序会按文件格式自动归类 / Drop a folder containing both videos and subtitles (or click **Select Files** to pick manually); the app categorizes files by format automatically
+2. 应用会按字幕组常见命名方式提取剧集号，并预填配对表 / The app extracts episode numbers from common fan-sub naming patterns and pre-fills the pairing table
+3. 如果出现错配或漏配，可直接在对应行的下拉框中手动选择字幕；选中后该行会自动加入重命名队列 / If the app mispairs or misses a row, choose a subtitle from that row's dropdown; once selected, the row is automatically added to the rename queue
+4. 选择输出策略：原文件直接改名 / 复制到视频所在目录 / 复制到自定义目录 / Pick the output strategy: rename in place, copy to the video's directory, or copy to a custom directory
+5. 点击「运行」；如果目标路径已存在按同一规则生成的同名文件，程序会先弹出覆盖确认对话框 / Click **Run**; if a file with the generated name already exists at the target path, an overwrite confirmation appears first
 
 > **配对算法 | Pairing Algorithm**
 >
-> 流水线：括号清理 → 优先级化的剧集号正则集（`S\d+E\d+`、`][NN][`、`- NN`、`第N话`、`EP\d+`）→ 季度并行扫描 → `(season, episode)` 配对键 → LCS 回退 → 手动选择作为最终安全网。模式覆盖在多组真实的字幕组命名样本（中日双语、外挂多语字幕、季度后缀变体等）上验证过。
+> 处理流程：清理括号内容 → 按优先级尝试剧集号正则（`S\d+E\d+`、`][NN][`、`- NN`、`第N话`、`EP\d+`）→ 分季并行扫描 → `(season, episode)` 配对键 → LCS 回退 → 最后由手动选择兜底。规则已在多组真实字幕组命名样本上验证过，包括中日双语标题、外挂多语字幕、季度后缀变体等。
 >
-> Pipeline: bracket cleanup → priority-ordered episode regex (`S\d+E\d+`, `][NN][`, `- NN`, `第N话`, `EP\d+`) → parallel season scan → `(season, episode)` pairing key → LCS fallback → manual selection as the final safety net. Pattern coverage was validated against representative real-world fan-sub naming variants (bilingual CJK titles, externally-shipped multi-language subs, season-suffix variants, and so on).
+> Pipeline: bracket cleanup → priority-ordered episode regex (`S\d+E\d+`, `][NN][`, `- NN`, `第N话`, `EP\d+`) → parallel season-aware scan → `(season, episode)` pairing key → LCS fallback → manual selection as the final fallback. Pattern coverage was validated against representative real-world fan-sub naming variants, including bilingual CJK titles, externally shipped multi-language subtitles, and season-suffix variants.
 
 ---
 
 ## CLI 使用 | CLI Usage
 
-`ssahdrify-cli` 是 GUI 的命令行（CLI）版本，从同一份源代码构建。四个核心功能（HDR 转换 / 时间轴偏移 / 字体嵌入 / 批量重命名）与 GUI 版对等；CLI 额外提供 `chain`（一次调用串联多步、仅终端步落盘）和 `refresh-fonts`（构建 / 刷新 CLI 字体缓存）两个子命令。
+`ssahdrify-cli` 是 GUI 的命令行版（CLI），与 GUI 从同一份源代码构建。四个核心功能（HDR 转换 / 时间轴偏移 / 字体嵌入 / 批量重命名）和 GUI 版保持对等；CLI 另外提供 `chain`（一次调用串联多个步骤，只有最后一步写入文件）和 `refresh-fonts`（构建或刷新 CLI 字体缓存）两个子命令。
 
-`ssahdrify-cli` is the command-line (CLI) version of the GUI, built from the same source. The four core features (HDR convert / Timing shift / Font embed / Batch rename) match the GUI; the CLI additionally exposes `chain` (multi-step pipeline in one invocation, only the terminal step writes to disk) and `refresh-fonts` (build / refresh the CLI font cache).
+`ssahdrify-cli` is the command-line (CLI) version of the GUI, built from the same source. The four core features (HDR convert / Timing shift / Font embed / Batch rename) stay in parity with the GUI; the CLI additionally exposes `chain` (multiple steps in one invocation, with only the final step writing files) and `refresh-fonts` (build or refresh the CLI font cache).
 
 ### 快速示例 | Quick Examples
 
@@ -154,14 +154,14 @@ ssahdrify-cli hdr --eotf pq input.ass
 # 时间轴偏移 +500ms / Timing shift +500ms
 ssahdrify-cli shift --offset +500ms input.ass
 
-# 字体嵌入：从指定文件夹搜索字体 / Font embed: search a folder for fonts
+# 字体嵌入：从指定文件夹查找字体 / Font embed: search a folder for fonts
 ssahdrify-cli embed --font-dir "C:/Fonts" input.ass
 
-# 持久化字体缓存：先一次性扫描，后续 embed 复用 / Persistent font cache: scan once, reuse on every embed
+# 持久化字体缓存：先扫描一次，后续 embed 复用 / Persistent font cache: scan once, reuse later
 ssahdrify-cli refresh-fonts --font-dir "C:/Fonts"
 ssahdrify-cli embed input.ass            # uses cache automatically
 
-# 链式调用：HDR 转 + 时间轴偏移单次完成，仅终端步落盘 / Chain: HDR + shift in one shot, only terminal step writes
+# 链式调用：一次完成 HDR 转换和时间轴偏移，只有最后一步写文件 / Chain: HDR + shift in one command, only the final step writes
 ssahdrify-cli chain hdr --eotf pq + shift --offset +500ms input.ass
 
 # 批量重命名：默认复制到视频所在目录 / Batch rename (default: copy sub next to video)
@@ -170,7 +170,7 @@ ssahdrify-cli rename "C:/My Series"
 
 ### 全部子命令 | All Subcommands
 
-每个子命令都支持 `--help` 查看完整参数。
+每个子命令都可通过 `--help` 查看完整参数。
 
 Each subcommand supports `--help` for the full parameter reference.
 
@@ -190,32 +190,32 @@ ssahdrify-cli chain          --help
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--lang <en\|zh>`     | 输出语言；不指定时按系统区域设置自动检测（zh\* → zh，否则 en）/ Output language; auto-detected from OS locale when omitted (zh\* → zh, otherwise en)                                                                                                |
 | `--json`              | 为支持的子命令输出机器可读 JSON 报告；详见下方 JSON 模式 / Emit machine-readable JSON for supported subcommands; see JSON Mode below                                                                                                              |
-| `--verbose`           | 显示更多进度细节 / Show more progress detail                                                                                                                                                                                                        |
-| `--quiet`             | 抑制常规进度输出 / Suppress normal progress output                                                                                                                                                                                                  |
-| `--dry-run`           | 预演计划工作但不写文件 / Preview planned work without writing files                                                                                                                                                                                 |
+| `--verbose`           | 显示更详细的进度 / Show more detailed progress                                                                                                                                                                                                      |
+| `--quiet`             | 隐藏常规进度输出 / Suppress normal progress output                                                                                                                                                                                                  |
+| `--dry-run`           | 预览计划执行的操作，不写入文件 / Preview planned work without writing files                                                                                                                                                                         |
 | `--overwrite`         | 允许覆盖已存在的输出文件 / Replace existing output files instead of skipping                                                                                                                                                                        |
-| `--output-dir <DIR>`  | 重定向输出到指定目录 / Redirect output to a specific directory                                                                                                                                                                                      |
-| `--no-cache`          | 跳过本次运行的字体缓存；缓存文件保持不变 / Skip the font cache for this run; cache file untouched                                                                                                                                                   |
-| `--cache-file <PATH>` | 覆盖默认的缓存文件路径 / Override the default cache file path (OS default: see Cache Location below)                                                                                                                                                |
-| `--fail-fast`         | 任一文件失败即中止后续输入；已成功写出的文件保留；失败文件可能留下部分写入产物 / Abort the batch on the first failed file; previously-succeeded outputs are kept, but the failed input itself may leave a partial-write artifact at its destination |
+| `--output-dir <DIR>`  | 将输出重定向到指定目录 / Redirect output to a specific directory                                                                                                                                                                                    |
+| `--no-cache`          | 跳过本次运行的字体缓存；缓存文件本身保持不变 / Skip the font cache for this run; leave the cache file untouched                                                                                                                                     |
+| `--cache-file <PATH>` | 使用指定缓存文件路径，覆盖默认路径 / Use a specific cache file path instead of the OS default (see Cache Location below)                                                                                                                           |
+| `--fail-fast`         | 任一文件失败即停止处理后续输入；已成功写出的文件会保留，失败文件的目标位置可能留下部分写入产物 / Abort the batch on the first failed file; previously-succeeded outputs are kept, but the failed input may leave a partial-write artifact at its destination |
 
 > **JSON 模式 | JSON Mode**
 >
-> `--json` 目前适用于 `hdr` / `shift` / `embed` / `rename`。它输出固定 schema 报告，按文件给出 status (`written` / `planned` / `skipped` / `failed`)、output path、encoding、warnings 等字段；stderr 仍可携带人类可读诊断。`chain` v1 会明确提示不支持 JSON 并改用纯文本报告；`refresh-fonts` 使用 stderr 状态输出。
+> `--json` 目前适用于 `hdr` / `shift` / `embed` / `rename`。它会输出固定 schema 的报告，按文件列出 status (`written` / `planned` / `skipped` / `failed`)、output path、encoding、warnings 等字段；stderr 仍可输出供人阅读的诊断信息。`chain` v1 会明确提示不支持 JSON，并改用纯文本报告；`refresh-fonts` 使用 stderr 输出状态。
 >
-> `--json` currently applies to `hdr` / `shift` / `embed` / `rename`. It emits a fixed-schema report listing per-file status (`written` / `planned` / `skipped` / `failed`), output path, encoding, warnings, etc.; stderr still carries human-readable diagnostics. `chain` v1 explicitly reports that JSON output is not supported and falls back to plain text; `refresh-fonts` uses stderr status output.
+> `--json` currently applies to `hdr` / `shift` / `embed` / `rename`. It emits a fixed-schema report listing per-file status (`written` / `planned` / `skipped` / `failed`), output path, encoding, warnings, and related fields; stderr can still carry human-readable diagnostics. `chain` v1 explicitly reports that JSON output is not supported and falls back to plain text; `refresh-fonts` reports status on stderr.
 >
-> **终端再插值的安全提示 | Terminal-interpolation safety note**
+> **终端再插值安全提示 | Terminal-interpolation safety note**
 >
-> `--json` 输出按 RFC 8259 编码，但 BiDi 控制符（U+200E/U+202E 等）、零宽字符与 U+2028/U+2029 行分隔符在 JSON 字符串里是合法字符，不会被转义。如果你通过 `jq -r` 把 `.input` / `.output` 等字段还原成原始字节再插到终端（`echo`、提示符、其他 CLI 的参数等），来自构造文件名的控制字符可能会污染终端显示。下游脚本应在终端边界自行做一次过滤（jq 的 `gsub` 或包装 shell 工具均可）。CLI 自己的人类可读输出（不带 `--json`）已在打印点统一调用 `sanitize_for_display`，不受此影响。
+> `--json` 按 RFC 8259 输出；BiDi 控制符（U+200E/U+202E 等）、零宽字符，以及 U+2028/U+2029 行分隔符在 JSON 字符串中都是合法字符，因此不会额外转义。如果用 `jq -r` 将 `.input` / `.output` 等字段还原后再插回终端（例如 `echo`、提示符或其他 CLI 参数），恶意构造的文件名可能影响终端显示。下游脚本应在终端输出边界自行过滤（如 jq 的 `gsub` 或 shell 包装工具）。CLI 自身供人阅读的输出（未启用 `--json`）已在所有打印点调用 `sanitize_for_display`，不受此问题影响。
 >
-> `--json` output follows RFC 8259, but BiDi format characters (U+200E/U+202E etc.), zero-width characters, and the U+2028/U+2029 line separators are valid in JSON strings and aren't escaped. If you pipe to `jq -r` to extract `.input` / `.output` as raw bytes and then interpolate into a terminal (echo, prompts, another CLI's arguments), control characters from crafted filenames can corrupt the terminal display. Downstream scripts should sanitize at the terminal boundary (jq's `gsub` or a wrapping shell tool). The CLI's own human-readable output (without `--json`) already passes every print site through `sanitize_for_display` and isn't affected.
+> `--json` output follows RFC 8259, but BiDi format characters (U+200E/U+202E etc.), zero-width characters, and the U+2028/U+2029 line separators are valid in JSON strings and are not additionally escaped. If you pipe to `jq -r` to extract `.input` / `.output` and then interpolate those values back into a terminal (`echo`, prompts, or another CLI's arguments), crafted filenames may affect terminal display. Downstream scripts should sanitize at the terminal boundary (for example with jq's `gsub` or a wrapping shell tool). The CLI's own human-readable output (without `--json`) already passes every print site through `sanitize_for_display` and is not affected.
 
 ### 字体缓存 | Font Cache
 
-`embed` 子命令每次启动都需要扫描 `--font-dir` 里的所有字体文件来构建查表（通常几秒到几十秒，5000+ 字体级别可达分钟级）。**持久化字体缓存**让你只扫描一次：第一次跑 `refresh-fonts` 把元数据写到磁盘上的 SQLite 文件，之后的 `embed` 调用会在缓存有效时复用它做查表，跳过扫描。fan-sub 团队按集打包时尤其有用。
+`embed` 每次启动通常都要扫描每个 `--font-dir` 下的字体文件，构建查找表（一般几秒到几十秒；5000+ 字体可能需要几分钟）。**持久化字体缓存**用于把这件事变成一次性操作：先运行 `refresh-fonts`，将字体元数据写入磁盘上的 SQLite 文件；之后 `embed` 会在缓存仍有效时直接复用它，跳过扫描。对于字幕组按集批量处理尤其有用。
 
-The `embed` subcommand normally rescans every `--font-dir` on every invocation to build its lookup table (seconds to tens of seconds; minutes for 5000+ font collections). The **persistent font cache** lets you scan once: a first `refresh-fonts` run writes metadata to a SQLite file on disk, and later `embed` calls reuse it when the cache is still valid. Especially useful for fan-sub teams encoding episodes in batches.
+The `embed` subcommand normally rescans every `--font-dir` on each invocation to build its lookup table (usually seconds to tens of seconds; minutes for 5000+ font collections). The **persistent font cache** turns that into a one-time step: run `refresh-fonts` to write font metadata into a SQLite file on disk, then later `embed` calls reuse it while the cache is still valid. This is especially useful for fan-sub teams processing episodes in batches.
 
 #### 工作流 | Workflow
 
@@ -223,61 +223,61 @@ The `embed` subcommand normally rescans every `--font-dir` on every invocation t
 # 一次性扫描字体目录，构建缓存 / Scan once to build the cache
 ssahdrify-cli refresh-fonts --font-dir "C:/Fonts/Anime" --font-dir "C:/Fonts/Latin"
 
-# 后续 embed 自动用缓存（不再扫描） / Subsequent embed uses cache (no scan)
+# 后续 embed 自动复用缓存（不再扫描） / Subsequent embed uses cache (no scan)
 ssahdrify-cli embed input.ass
 
-# 仍可加 --font-dir 临时混入额外字体源（cache + 额外目录合并） /
+# 也可以继续加 --font-dir，临时合并额外字体源（缓存 + 额外目录） /
 # You can still pass --font-dir to merge extra dirs with the cache
 ssahdrify-cli embed --font-dir "C:/Fonts/Project-Specific" input.ass
 
-# 强制不用缓存 / Force no-cache for one run
+# 本次强制不用缓存 / Force no-cache for one run
 ssahdrify-cli --no-cache embed --font-dir "C:/Fonts" input.ass
 
-# 字体目录变了之后刷新缓存 / Refresh cache when fonts changed
+# 字体目录变更后刷新缓存 / Refresh cache after fonts change
 ssahdrify-cli refresh-fonts --font-dir "C:/Fonts/Anime" --font-dir "C:/Fonts/Latin"
 ```
 
 #### 缓存位置 | Cache Location
 
-默认按操作系统选择（与 GUI 缓存独立，避免锁竞争）：
+默认位置按操作系统决定（与 GUI 缓存独立，避免锁竞争）：
 
 - Windows: `%APPDATA%/ssahdrify/cli_font_cache.sqlite3`
 - macOS: `$HOME/Library/Application Support/ssahdrify/cli_font_cache.sqlite3`
 - Linux: `${XDG_DATA_HOME:-$HOME/.local/share}/ssahdrify/cli_font_cache.sqlite3`
 
-`--cache-file <PATH>` 可覆盖。
+`--cache-file <PATH>` 可改用指定路径。
 
-OS-specific defaults (separate from the GUI cache to avoid lock contention):
+Default locations are OS-specific and separate from the GUI cache to avoid lock contention:
 
 - Windows: `%APPDATA%/ssahdrify/cli_font_cache.sqlite3`
 - macOS: `$HOME/Library/Application Support/ssahdrify/cli_font_cache.sqlite3`
 - Linux: `${XDG_DATA_HOME:-$HOME/.local/share}/ssahdrify/cli_font_cache.sqlite3`
 
-Override with `--cache-file <PATH>`.
+Use `--cache-file <PATH>` to choose a different path.
 
 #### 漂移检测 | Drift Detection
 
-`embed` 启动时会对缓存做轻量验证：用 `stat()` 检查每个已缓存文件夹的 mtime，如果跟缓存里记录的不一致（说明你添加 / 删除 / 替换 / 重命名了字体文件），CLI 在 stderr 列出哪些文件夹改了，自动 fallback 到无缓存模式（这次 embed 走 `--font-dir` 或系统字体），并提示你跑 `refresh-fonts` 更新。**永远不会自动重建缓存**——缓存动作必须由 `refresh-fonts` 显式触发。
+`embed` 启动时会对缓存做轻量校验：对每个已缓存文件夹执行一次 `stat()`，检查 mtime 是否变化。如果发现漂移（说明你添加 / 删除 / 替换 / 重命名了字体文件），CLI 会在 stderr 列出发生变化的文件夹，本次运行自动退回无缓存模式（使用 `--font-dir` 或系统字体），并提示你运行 `refresh-fonts` 更新。**缓存不会被静默重建**——缓存写入必须由 `refresh-fonts` 显式触发。
 
-`embed` runs a lightweight cache validation at startup: a single `stat()` per cached folder checks mtime drift. If drift is detected (you added / deleted / replaced / renamed font files), the CLI lists the changed folders on stderr, transparently falls back to no-cache for this run (uses `--font-dir` or system fonts), and tells you to run `refresh-fonts`. **The cache is never silently rebuilt** — cache mutations are always explicit via `refresh-fonts`.
+`embed` runs a lightweight cache validation at startup: one `stat()` per cached folder checks for mtime drift. If drift is detected (you added / deleted / replaced / renamed font files), the CLI lists the changed folders on stderr, falls back to no-cache for this run (using `--font-dir` or system fonts), and tells you to run `refresh-fonts`. **The cache is never silently rebuilt** — cache writes are always explicit via `refresh-fonts`.
 
 #### 限制 | Limitations
 
-- 每个 `--font-dir` 一层深扫描（不递归），与 `embed --font-dir` 语义一致。树状字体目录请逐层显式传入。
-- 每个 binary（GUI / CLI）使用各自独立的缓存文件，避免 SQLite 锁竞争；同一 binary 同时只读写一个缓存文件（默认路径或 `--cache-file` 覆盖路径）。`chain` 当前不调用缓存（embed 步永远走显式 `--font-dir` 或系统字体），未来扩展。
-- Schema 升级（不同 release 之间）不自动 migrate；版本不匹配时 CLI 显式提示删文件重跑 `refresh-fonts`。
+- 每个 `--font-dir` 只扫描一层（不递归），与 `embed --font-dir` 语义一致。树状字体目录需要逐层显式传入。
+- GUI 和 CLI 各自使用独立缓存文件，避免 SQLite 锁竞争；同一个可执行文件同时只会读写一个缓存文件（默认路径或 `--cache-file` 覆盖路径）。`chain` v1 暂不读取缓存（其中的 embed 步始终使用显式 `--font-dir` 或系统字体）。
+- 跨版本不会自动迁移缓存结构；版本不匹配时，CLI 会明确提示删除缓存文件并重新运行 `refresh-fonts`。
 
 - Each `--font-dir` is scanned one level deep (non-recursive), matching `embed --font-dir` semantics. Pass each leaf folder explicitly for tree-shaped collections.
-- Per-binary cache file (GUI / CLI use separate paths to avoid SQLite lock contention); a single binary opens exactly one cache at a time (default path or `--cache-file` override). `chain` doesn't consult the cache in v1 (its embed step always uses explicit `--font-dir` or system fonts); future work.
-- No automatic schema migration across releases — version mismatch surfaces as an explicit "delete the cache file and rerun `refresh-fonts`" prompt.
+- GUI and CLI use separate cache files to avoid SQLite lock contention; a single binary opens exactly one cache at a time (default path or `--cache-file` override). `chain` v1 does not consult the cache; its embed step always uses explicit `--font-dir` or system fonts.
+- There is no automatic schema migration across releases. Version mismatch surfaces as an explicit prompt to delete the cache file and rerun `refresh-fonts`.
 
 ---
 
 ## 使用场景 | Background
 
-SSA/ASS 字幕本身不含色彩空间元数据，因此渲染器会按 SDR 模式处理，使字幕看起来过饱和、过亮。播放 HDR 视频时，显示设备会进入 HDR 模式，但字幕却仍以 SDR 方式呈现，色差问题由此产生。
+SSA/ASS 字幕自身不带色彩空间元数据，渲染器通常会按 SDR 处理，结果是字幕在 HDR 画面里显得过饱和、过亮。播放 HDR 视频时，显示设备会进入 HDR 模式，但字幕仍按 SDR 混合，色差就来自这里。
 
-SSA/ASS subtitles lack embedded color space metadata, so renderers treat them as SDR content — making them appear oversaturated and overly bright. When playing HDR video, the display enters HDR mode, but subtitles are still rendered as SDR, causing a noticeable color mismatch.
+SSA/ASS subtitles do not carry color-space metadata, so renderers usually treat them as SDR content, making subtitles look oversaturated and overly bright in HDR video. When an HDR video plays, the display enters HDR mode, but subtitles are still blended as SDR; that is where the color mismatch comes from.
 
 > 如果你的播放器已经能正确处理字幕亮度（例如 mpv 的 `blend-subtitles=video`，或 madVR 配合 xy-SubFilter 的字幕色彩管理），则不需要本工具。
 >
@@ -285,9 +285,9 @@ SSA/ASS subtitles lack embedded color space metadata, so renderers treat them as
 
 _相关讨论 / Related discussion: [libass/libass#297](https://github.com/libass/libass/issues/297)_
 
-相关工具 / Related tool: 视频与字幕的重命名工作流的另一个选项是 [arition/SubRenamer](https://github.com/arition/SubRenamer)（按字母序+下标配对）。本项目的批量重命名（Tab 4）走基于字幕组命名习惯的正则配对路径，独立实现。
+相关工具 / Related tool: [arition/SubRenamer](https://github.com/arition/SubRenamer) 也是视频与字幕重命名工作流的一个选择（按字母序 + 下标配对）。本项目的批量重命名功能（Tab 4）则使用面向字幕组命名习惯的正则配对流程，代码独立实现。
 
-For the subtitle-and-video rename workflow, [arition/SubRenamer](https://github.com/arition/SubRenamer) is another option (alphabetical-index pairing). This project's Batch Rename (Tab 4) uses a fan-sub-aware regex pairing approach, independently implemented.
+For subtitle-and-video rename workflows, [arition/SubRenamer](https://github.com/arition/SubRenamer) is another option (alphabetical + index pairing). This project's Batch Rename feature (Tab 4) uses an independently implemented regex pairing flow built around common fan-sub naming patterns.
 
 ---
 
@@ -311,13 +311,13 @@ SSA/ASS subtitle colors (sRGB)
 
 ### 精度说明 | Accuracy Note
 
-PQ 模式经过验证，与 Python 原版（colour-science）逐像素一致。HLG 模式使用手动实现的 BT.2100 逆 OOTF + OETF（绕过 Color.js 的 rec2100hlg 空间），同样与 Python 原版完全匹配。
+PQ 模式已验证与 Python 原版（colour-science）逐像素一致。HLG 模式使用手动实现的 BT.2100 逆 OOTF + OETF（绕过 Color.js 的 rec2100hlg 空间），同样与 Python 原版完全一致。
 
-PQ mode is verified pixel-exact against the Python version (colour-science). HLG mode uses a manually implemented BT.2100 inverse OOTF + OETF (bypassing Color.js's rec2100hlg space), also exact-matching the Python version.
+PQ mode is verified pixel-exact against the Python version (colour-science). HLG mode uses a manually implemented BT.2100 inverse OOTF + OETF (bypassing Color.js's rec2100hlg space) and also matches the Python version exactly.
 
-由于字幕混合链路与 HDR 显示环境的复杂性（HDMI 元数据协商、显示器色调映射等），实际效果仅能做到"红是红的，蓝是蓝的"，不适用于严格颜色准确性场景。
+由于字幕混合链路和 HDR 显示环境很复杂（HDMI 元数据协商、显示器色调映射等），实际效果主要保证“红还是红、蓝还是蓝”的基础观感，不适合严格校色场景。
 
-Due to the complexity of subtitle blending pipelines and HDR display environments (HDMI metadata negotiation, display tone mapping, etc.), the actual result can only ensure a "red is red, blue is blue" level of correctness — not suited for strict color accuracy requirements.
+Due to the complexity of subtitle blending pipelines and HDR display environments (HDMI metadata negotiation, display tone mapping, etc.), the result is intended to preserve basic color identity, not to satisfy strict color-accuracy or color-grading requirements.
 
 ---
 
@@ -351,11 +351,11 @@ npm run build:cli
 npm run build:all
 ```
 
-便携式 exe 产出于 `src-tauri/target/release/`，可直接运行——无需安装步骤。`tauri.conf.json` 目前设置了 `bundle.active: false`，因此默认生成便携式二进制文件而不是安装包。
+在 Windows 上，便携式 exe 会生成到 `src-tauri/target/release/`，可直接运行，无需安装。`tauri.conf.json` 目前设置了 `bundle.active: false`，因此默认生成便携式二进制文件，而不是安装包。
 
-Portable executables are produced under `src-tauri/target/release/` and are ready to run directly, with no install step required. `tauri.conf.json` currently sets `bundle.active: false`, so the default output is portable binaries rather than installers.
+On Windows, portable executables are produced under `src-tauri/target/release/` and can be run directly, with no install step required. `tauri.conf.json` currently sets `bundle.active: false`, so the default output is portable binaries rather than installers.
 
-Expected release build outputs:
+Expected Windows release build outputs:
 
 ```text
 src-tauri/target/release/ssahdrify.exe
@@ -389,7 +389,7 @@ cargo test --manifest-path src-tauri/Cargo.toml   # Rust 后端测试 / Rust bac
                │                                       │
 ┌──────────────┴───────────────┐ ┌─────────────────────┴───────────────────────┐
 │  GUI binary                  │ │  CLI binary                                 │
-│  ssahdrify.exe               │ │  ssahdrify-cli.exe                         │
+│  ssahdrify.exe               │ │  ssahdrify-cli.exe                          │
 │                              │ │                                             │
 │  Tauri 2 + React +           │ │  clap (argv parsing)                        │
 │  Tailwind frontend           │ │  deno_core / V8 (embedded JS bundle)        │
@@ -440,12 +440,12 @@ This is a Tauri desktop rewrite of [ssaHdrify](https://github.com/gky99/ssaHdrif
 originally created by ying (2021) and later maintained by gky99 (2024-2025).
 The original project is also licensed under GPL-3.0.
 
-HDR 色彩转换算法使用 TypeScript（基于 [Color.js](https://colorjs.io/)）重新实现，参考了 Python 版本的方案（使用 [colour-science](https://www.colour-science.org/)）。未逐字复制代码——实现是全新的，但出于许可证目的视为衍生作品。
+HDR 色彩转换算法由 TypeScript（基于 [Color.js](https://colorjs.io/)）重新实现，方案参考了 Python 原版（使用 [colour-science](https://www.colour-science.org/)）。没有逐字复制代码；实现本身是新的，但按许可证语境仍按衍生作品处理。
 
 The HDR color conversion algorithm was reimplemented in TypeScript (using
 [Color.js](https://colorjs.io/)) based on the approach in the Python version
 (which used [colour-science](https://www.colour-science.org/)). No code was
-copied verbatim — the implementation is new, but the project is treated as a
+copied verbatim; the implementation is new, but the project is treated as a
 derivative work for license purposes.
 
 ### 算法归属 | Algorithm Attribution
@@ -459,7 +459,7 @@ original TypeScript written for this project.
 
 ### 第三方依赖 | Third-Party Dependencies
 
-下表列出主要直接依赖与随应用分发的资产；完整传递依赖以 `package-lock.json` 和 `src-tauri/Cargo.lock` 为准。
+下表列出主要直接依赖和随应用分发的资产；完整传递依赖以 `package-lock.json` 和 `src-tauri/Cargo.lock` 为准。
 
 The tables below list the main direct dependencies and bundled assets; the full transitive dependency set is recorded in `package-lock.json` and `src-tauri/Cargo.lock`.
 
@@ -494,9 +494,9 @@ The tables below list the main direct dependencies and bundled assets; the full 
 | 字体 / Font                                                                                                                   | 许可证 / License                                                                | 用途 / Usage                                                                                    |
 | ----------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------- |
 | [Inter](https://rsms.me/inter/) · © The Inter Project Authors                                                                 | [SIL Open Font License 1.1](src/assets/fonts/inter/LICENSE.txt) · OFL-1.1       | 英文界面正文与标题 / English UI body + display face                                             |
-| [Smiley Sans 得意黑](https://github.com/atelier-anchor/smiley-sans) · © 2022–2024 [atelierAnchor](https://atelier-anchor.com) | [SIL Open Font License 1.1](src/assets/fonts/smiley-sans/LICENSE.txt) · OFL-1.1 | 中文界面标题展示字体（仅作标题用）/ Chinese-mode application title display face (headline only) |
+| [Smiley Sans 得意黑](https://github.com/atelier-anchor/smiley-sans) · © 2022–2024 [atelierAnchor](https://atelier-anchor.com) | [SIL Open Font License 1.1](src/assets/fonts/smiley-sans/LICENSE.txt) · OFL-1.1 | 中文界面标题展示字体（仅用于标题）/ Chinese-mode application title display face (headline only) |
 
-> OFL-1.1 允许这些字体与任何软件捆绑、嵌入、再分发，包括 GPL-3.0 项目；字体及其衍生作品必须保留该许可证，且不得单独销售或使用其保留字体名进行衍生命名。
+> OFL-1.1 允许这些字体与任何软件一起捆绑、嵌入和再分发，包括 GPL-3.0 项目；字体及其衍生作品必须继续使用 OFL，且不得单独销售，也不得在修改版本中沿用其保留字体名。
 >
 > OFL-1.1 allows these fonts to be bundled, embedded, and redistributed alongside any software, including GPL-3.0 projects. The fonts and their derivatives must remain under OFL, must not be sold on their own, and must not reuse the Reserved Font Names (`Inter`, `Smiley`, `得意黑`) for modified versions.
 
@@ -512,4 +512,4 @@ The tables below list the main direct dependencies and bundled assets; the full 
 | [Stylelint](https://stylelint.io/)            | MIT              | CSS 代码检查 / CSS linting                                        |
 | [Prettier](https://prettier.io/)              | MIT              | 代码格式化 / Code formatter                                       |
 | [Vitest](https://vitest.dev/)                 | MIT              | 单元测试 / Unit testing                                           |
-| [esbuild](https://esbuild.github.io/)         | MIT              | engine.js 打包（CLI 嵌入用）/ Bundles engine.js for CLI embedding |
+| [esbuild](https://esbuild.github.io/)         | MIT              | 为 CLI 嵌入打包 engine.js / Bundles engine.js for CLI embedding |

--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@
 
 ## 下载 | Download
 
-从 [Releases](https://github.com/koagaroon/ssaHdrify-tauri/releases/latest) 页面下载最新 exe 文件：
+Windows 用户可从 [Releases](https://github.com/koagaroon/ssaHdrify-tauri/releases/latest) 页面下载便携式 exe 文件：
 
-- **`ssahdrify_*.exe`** — 图形界面（GUI），适合手动操作
-- **`ssahdrify-cli_*.exe`** — 命令行（CLI），适合 pipeline / 批处理 / 脚本化场景
+- **`ssahdrify*.exe`** — 图形界面（GUI），适合手动操作
+- **`ssahdrify-cli*.exe`** — 命令行（CLI），适合 pipeline / 批处理 / 脚本化场景
 
 macOS / Linux 用户请参考下方「从源码构建」。
 
-Download the latest exe files from [Releases](https://github.com/koagaroon/ssaHdrify-tauri/releases/latest):
+Windows users can download portable exe files from [Releases](https://github.com/koagaroon/ssaHdrify-tauri/releases/latest):
 
-- **`ssahdrify_*.exe`** — graphical interface (GUI), for manual workflows
-- **`ssahdrify-cli_*.exe`** — command line (CLI), for pipeline / batch / scripting
+- **`ssahdrify*.exe`** — graphical interface (GUI), for manual workflows
+- **`ssahdrify-cli*.exe`** — command line (CLI), for pipeline / batch / scripting
 
 macOS / Linux users, see "Build from Source" below.
 
@@ -141,9 +141,9 @@ Any folder size is accepted; the scan shows a real-time count of fonts found and
 
 ## CLI 使用 | CLI Usage
 
-`ssahdrify-cli` 是 GUI 的命令行（CLI）版本，从同一份源代码构建。四个核心功能（HDR 转换 / 时间轴偏移 / 字体嵌入 / 批量重命名）与 GUI 版对等；CLI 额外提供 `chain`（一次调用串联多步、仅终端步落盘）和 `refresh-fonts`（持久化字体缓存）两个子命令。
+`ssahdrify-cli` 是 GUI 的命令行（CLI）版本，从同一份源代码构建。四个核心功能（HDR 转换 / 时间轴偏移 / 字体嵌入 / 批量重命名）与 GUI 版对等；CLI 额外提供 `chain`（一次调用串联多步、仅终端步落盘）和 `refresh-fonts`（构建 / 刷新 CLI 字体缓存）两个子命令。
 
-`ssahdrify-cli` is the command-line (CLI) version of the GUI, built from the same source. The four core features (HDR convert / Timing shift / Font embed / Batch rename) match the GUI; the CLI additionally exposes `chain` (multi-step pipeline in one invocation, only the terminal step writes to disk) and `refresh-fonts` (persistent font cache) — both CLI-only for now.
+`ssahdrify-cli` is the command-line (CLI) version of the GUI, built from the same source. The four core features (HDR convert / Timing shift / Font embed / Batch rename) match the GUI; the CLI additionally exposes `chain` (multi-step pipeline in one invocation, only the terminal step writes to disk) and `refresh-fonts` (build / refresh the CLI font cache).
 
 ### 快速示例 | Quick Examples
 
@@ -189,7 +189,7 @@ ssahdrify-cli chain          --help
 | 选项 / Option         | 说明 / Description                                                                                                                                                                                                                                  |
 | --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `--lang <en\|zh>`     | 输出语言；不指定时按系统区域设置自动检测（zh\* → zh，否则 en）/ Output language; auto-detected from OS locale when omitted (zh\* → zh, otherwise en)                                                                                                |
-| `--json`              | 输出机器可读 JSON 报告 / Emit a machine-readable JSON report                                                                                                                                                                                        |
+| `--json`              | 为支持的子命令输出机器可读 JSON 报告；详见下方 JSON 模式 / Emit machine-readable JSON for supported subcommands; see JSON Mode below                                                                                                              |
 | `--verbose`           | 显示更多进度细节 / Show more progress detail                                                                                                                                                                                                        |
 | `--quiet`             | 抑制常规进度输出 / Suppress normal progress output                                                                                                                                                                                                  |
 | `--dry-run`           | 预演计划工作但不写文件 / Preview planned work without writing files                                                                                                                                                                                 |
@@ -201,9 +201,9 @@ ssahdrify-cli chain          --help
 
 > **JSON 模式 | JSON Mode**
 >
-> `--json` 输出固定 schema 报告，按文件给出 status (`written` / `planned` / `skipped` / `failed`)、output path、encoding、warnings 等字段；stderr 仍可携带人类可读诊断。pipeline 集成场景建议固定使用此模式。
+> `--json` 目前适用于 `hdr` / `shift` / `embed` / `rename`。它输出固定 schema 报告，按文件给出 status (`written` / `planned` / `skipped` / `failed`)、output path、encoding、warnings 等字段；stderr 仍可携带人类可读诊断。`chain` v1 会明确提示不支持 JSON 并改用纯文本报告；`refresh-fonts` 使用 stderr 状态输出。
 >
-> `--json` emits a fixed-schema report listing per-file status (`written` / `planned` / `skipped` / `failed`), output path, encoding, warnings, etc.; stderr still carries human-readable diagnostics. For pipeline integration, prefer this mode.
+> `--json` currently applies to `hdr` / `shift` / `embed` / `rename`. It emits a fixed-schema report listing per-file status (`written` / `planned` / `skipped` / `failed`), output path, encoding, warnings, etc.; stderr still carries human-readable diagnostics. `chain` v1 explicitly reports that JSON output is not supported and falls back to plain text; `refresh-fonts` uses stderr status output.
 >
 > **终端再插值的安全提示 | Terminal-interpolation safety note**
 >
@@ -213,9 +213,9 @@ ssahdrify-cli chain          --help
 
 ### 字体缓存 | Font Cache
 
-`embed` 子命令每次启动都需要扫描 `--font-dir` 里的所有字体文件来构建查表（通常几秒到几十秒，5000+ 字体级别可达分钟级）。**持久化字体缓存**让你只扫描一次：第一次跑 `refresh-fonts` 把元数据写到磁盘上的 SQLite 文件，之后所有 `embed` 调用都自动用这份缓存做查表，跳过扫描。fan-sub 团队按集打包时尤其有用。
+`embed` 子命令每次启动都需要扫描 `--font-dir` 里的所有字体文件来构建查表（通常几秒到几十秒，5000+ 字体级别可达分钟级）。**持久化字体缓存**让你只扫描一次：第一次跑 `refresh-fonts` 把元数据写到磁盘上的 SQLite 文件，之后的 `embed` 调用会在缓存有效时复用它做查表，跳过扫描。fan-sub 团队按集打包时尤其有用。
 
-The `embed` subcommand normally rescans every `--font-dir` on every invocation to build its lookup table (seconds to tens of seconds; minutes for 5000+ font collections). The **persistent font cache** lets you scan once: a first `refresh-fonts` run writes metadata to a SQLite file on disk, and all subsequent `embed` calls reuse it. Especially useful for fan-sub teams encoding episodes in batches.
+The `embed` subcommand normally rescans every `--font-dir` on every invocation to build its lookup table (seconds to tens of seconds; minutes for 5000+ font collections). The **persistent font cache** lets you scan once: a first `refresh-fonts` run writes metadata to a SQLite file on disk, and later `embed` calls reuse it when the cache is still valid. Especially useful for fan-sub teams encoding episodes in batches.
 
 #### 工作流 | Workflow
 
@@ -241,17 +241,17 @@ ssahdrify-cli refresh-fonts --font-dir "C:/Fonts/Anime" --font-dir "C:/Fonts/Lat
 
 默认按操作系统选择（与 GUI 缓存独立，避免锁竞争）：
 
-- Windows: `%APPDATA%/ssaHdrify/cli_font_cache.sqlite3`
-- macOS: `$HOME/Library/Application Support/ssaHdrify/cli_font_cache.sqlite3`
-- Linux: `${XDG_DATA_HOME:-$HOME/.local/share}/ssaHdrify/cli_font_cache.sqlite3`
+- Windows: `%APPDATA%/ssahdrify/cli_font_cache.sqlite3`
+- macOS: `$HOME/Library/Application Support/ssahdrify/cli_font_cache.sqlite3`
+- Linux: `${XDG_DATA_HOME:-$HOME/.local/share}/ssahdrify/cli_font_cache.sqlite3`
 
 `--cache-file <PATH>` 可覆盖。
 
 OS-specific defaults (separate from the GUI cache to avoid lock contention):
 
-- Windows: `%APPDATA%/ssaHdrify/cli_font_cache.sqlite3`
-- macOS: `$HOME/Library/Application Support/ssaHdrify/cli_font_cache.sqlite3`
-- Linux: `${XDG_DATA_HOME:-$HOME/.local/share}/ssaHdrify/cli_font_cache.sqlite3`
+- Windows: `%APPDATA%/ssahdrify/cli_font_cache.sqlite3`
+- macOS: `$HOME/Library/Application Support/ssahdrify/cli_font_cache.sqlite3`
+- Linux: `${XDG_DATA_HOME:-$HOME/.local/share}/ssahdrify/cli_font_cache.sqlite3`
 
 Override with `--cache-file <PATH>`.
 
@@ -341,12 +341,26 @@ npm run tauri dev
 ### 构建 | Production Build
 
 ```bash
+# GUI portable executable
 npm run tauri build
+
+# CLI portable executable
+npm run build:cli
+
+# Build both GUI and CLI
+npm run build:all
 ```
 
-便携式 exe 产出于 `src-tauri/target/release/ssahdrify.exe`，可直接运行——无需安装步骤。
+便携式 exe 产出于 `src-tauri/target/release/`，可直接运行——无需安装步骤。`tauri.conf.json` 目前设置了 `bundle.active: false`，因此默认生成便携式二进制文件而不是安装包。
 
-The portable exe is produced at `src-tauri/target/release/ssahdrify.exe` — ready to run directly, no install step required.
+Portable executables are produced under `src-tauri/target/release/` and are ready to run directly, with no install step required. `tauri.conf.json` currently sets `bundle.active: false`, so the default output is portable binaries rather than installers.
+
+Expected release build outputs:
+
+```text
+src-tauri/target/release/ssahdrify.exe
+src-tauri/target/release/ssahdrify-cli.exe
+```
 
 ### 测试 | Testing
 
@@ -375,17 +389,17 @@ cargo test --manifest-path src-tauri/Cargo.toml   # Rust 后端测试 / Rust bac
                │                                       │
 ┌──────────────┴───────────────┐ ┌─────────────────────┴───────────────────────┐
 │  GUI binary                  │ │  CLI binary                                 │
-│  ssahdrify.exe  ~10 MB       │ │  ssahdrify-cli.exe  ~37-58 MB               │
+│  ssahdrify.exe               │ │  ssahdrify-cli.exe                         │
 │                              │ │                                             │
 │  Tauri 2 + React +           │ │  clap (argv parsing)                        │
-│  Tailwind frontend           │ │  deno_core / V8 (embedded engine.js)        │
-│  - 4 tabs                    │ │  - 4 subcommands                            │
-│  - i18n (zh/en),             │ │  - --json mode for pipelines                │
+│  Tailwind frontend           │ │  deno_core / V8 (embedded JS bundle)        │
+│  - 4 tabs                    │ │  - 6 subcommands                            │
+│  - i18n (zh/en),             │ │  - JSON reports for hdr/shift/embed/rename  │
 │    dark/light/auto theme     │ │  - env_logger (stderr warnings)             │
 │  - FontSourceModal UI        │ │  - sys-locale (--lang auto)                 │
 └──────────────┬───────────────┘ └─────────────────────┬───────────────────────┘
                │                                       │
-           Tauri IPC                              deno_core ops
+           Tauri IPC                       execute_script + JSON
                │                                       │
                └────────────────────┬──────────────────┘
                                     │
@@ -395,7 +409,7 @@ cargo test --manifest-path src-tauri/Cargo.toml   # Rust 后端测试 / Rust bac
 │  - fontcull / fontcull-skrifa (subsetting + name-table reader)               │
 │  - chardetng + encoding_rs (encoding detection + conversion)                 │
 │  - serde / serde_json (serialization)                                        │
-│  - rusqlite (user font index)                                                │
+│  - rusqlite (font cache + user font index)                                   │
 └──────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -445,28 +459,35 @@ original TypeScript written for this project.
 
 ### 第三方依赖 | Third-Party Dependencies
 
-所有依赖均使用与 GPL-3.0 兼容的许可证。
+下表列出主要直接依赖与随应用分发的资产；完整传递依赖以 `package-lock.json` 和 `src-tauri/Cargo.lock` 为准。
 
-All dependencies use licenses compatible with GPL-3.0.
+The tables below list the main direct dependencies and bundled assets; the full transitive dependency set is recorded in `package-lock.json` and `src-tauri/Cargo.lock`.
 
 #### 运行时依赖（随应用分发）| Runtime (shipped with the application)
 
 | 组件 / Component                                          | 许可证 / License  | 用途 / Usage                                                                                                   |
 | --------------------------------------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------- |
-| [Tauri](https://tauri.app/)                               | MIT OR Apache-2.0 | 桌面应用框架 / Desktop app framework                                                                           |
-| [React](https://react.dev/)                               | MIT               | UI 框架 / UI framework                                                                                         |
+| [Tauri](https://tauri.app/)                               | Apache-2.0 OR MIT | 桌面应用框架 / Desktop app framework                                                                           |
+| [Tauri plugins](https://v2.tauri.app/plugin/)             | Apache-2.0 OR MIT | 对话框、文件访问和日志插件 / Dialog, filesystem, and logging plugins                                           |
+| [React](https://react.dev/) / React DOM                   | MIT               | UI 框架 / UI framework                                                                                         |
+| [React Window](https://github.com/bvaughn/react-window)   | MIT               | 大列表虚拟滚动 / Virtualized large lists                                                                       |
 | [Color.js](https://colorjs.io/)                           | MIT               | HDR 色彩空间转换 (PQ/HLG) / HDR color space conversion                                                         |
 | [ass-compiler](https://github.com/weizhenye/ass-compiler) | MIT               | ASS 字幕解析（字体收集）/ ASS subtitle parsing for font collection                                             |
+| [js-base64](https://github.com/dankogai/js-base64)        | BSD-3-Clause      | 前端与 CLI chain 字体载荷 base64 解码 / Base64 decoding for frontend and CLI chain font payloads               |
 | [font-kit](https://github.com/servo/font-kit)             | MIT OR Apache-2.0 | 跨平台系统字体发现 (Rust) / Cross-platform system font discovery                                               |
-| [fontcull](https://github.com/bearcove/fontcull)          | MIT               | 字体子集化（含 fontcull-klippa、fontcull-skrifa）/ Font subsetting (includes fontcull-klippa, fontcull-skrifa) |
+| [fontcull](https://github.com/bearcove/fontcull)          | MIT / MIT OR Apache-2.0 | 字体子集化（含 fontcull-klippa、fontcull-skrifa）/ Font subsetting (includes fontcull-klippa, fontcull-skrifa) |
 | [chardetng](https://github.com/hsivonen/chardetng)        | MIT OR Apache-2.0 | 编码检测 (Firefox 引擎) / Encoding detection (Firefox's engine)                                                |
-| [encoding_rs](https://github.com/hsivonen/encoding_rs)    | MIT OR Apache-2.0 | 编码转换 / Encoding conversion                                                                                 |
-| [serde](https://serde.rs/)                                | MIT OR Apache-2.0 | Rust 序列化 / Rust serialization                                                                               |
+| [encoding_rs](https://github.com/hsivonen/encoding_rs)    | (Apache-2.0 OR MIT) AND BSD-3-Clause | 编码转换 / Encoding conversion                                                                 |
+| [rusqlite](https://github.com/rusqlite/rusqlite)          | MIT               | 字体缓存和本地字体索引 / Font cache and local font index                                                       |
+| [serde](https://serde.rs/) / serde_json                   | MIT OR Apache-2.0 | Rust 序列化 / Rust serialization                                                                               |
 | [deno_core](https://github.com/denoland/deno)             | MIT               | 嵌入式 V8 JS 运行时（CLI）/ Embedded V8 JS runtime (CLI)                                                       |
 | [V8](https://v8.dev/)                                     | BSD-3-Clause      | JavaScript 引擎（经 deno_core 嵌入，CLI）/ JavaScript engine via deno_core (CLI)                               |
 | [clap](https://github.com/clap-rs/clap)                   | MIT OR Apache-2.0 | CLI 参数解析（CLI）/ CLI argument parsing (CLI)                                                                |
 | [env_logger](https://github.com/rust-cli/env_logger)      | MIT OR Apache-2.0 | CLI 日志后端 stderr（CLI）/ CLI logging backend on stderr (CLI)                                                |
 | [sys-locale](https://github.com/1Password/sys-locale)     | MIT OR Apache-2.0 | OS 区域设置检测（驱动 `--lang` 自动检测，CLI）/ OS locale detection driving `--lang` auto (CLI)                |
+| [base64](https://github.com/marshallpierce/rust-base64)   | MIT OR Apache-2.0 | Rust 侧字体载荷 base64 编码 / Base64 encoding for Rust-side font payloads                                      |
+| [unicode-normalization](https://github.com/unicode-rs/unicode-normalization) | MIT OR Apache-2.0 | Unicode 路径 / 输出键规范化 / Unicode path and output-key normalization                         |
+| [rfd](https://github.com/PolyMeilex/rfd)                  | MIT               | 启动失败时的原生错误对话框 / Native error dialog for startup failures                                          |
 
 #### 捆绑字体（随应用分发）| Bundled Fonts (shipped with the application)
 
@@ -486,7 +507,9 @@ All dependencies use licenses compatible with GPL-3.0.
 | [Tailwind CSS](https://tailwindcss.com/)      | MIT              | CSS 工具框架 / CSS utility framework                              |
 | [TypeScript](https://www.typescriptlang.org/) | Apache-2.0       | 类型检查 / Type checking                                          |
 | [Vite](https://vite.dev/)                     | MIT              | 构建工具 / Build tool                                             |
+| [Tauri CLI](https://tauri.app/)               | MIT OR Apache-2.0 | Tauri 构建入口 / Tauri build entry point                          |
 | [ESLint](https://eslint.org/)                 | MIT              | 代码检查 / Linting                                                |
+| [Stylelint](https://stylelint.io/)            | MIT              | CSS 代码检查 / CSS linting                                        |
 | [Prettier](https://prettier.io/)              | MIT              | 代码格式化 / Code formatter                                       |
 | [Vitest](https://vitest.dev/)                 | MIT              | 单元测试 / Unit testing                                           |
 | [esbuild](https://esbuild.github.io/)         | MIT              | engine.js 打包（CLI 嵌入用）/ Bundles engine.js for CLI embedding |

--- a/README.md
+++ b/README.md
@@ -63,12 +63,12 @@ macOS / Linux users, see "Build from Source" below.
 
 ## 功能 | Features
 
-| 标签页 / Tab                            | 功能 / Description                                                                                                                                                                                                                                                                                                     |
-| --------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **HDR 色彩转换 / HDR Color Conversion** | 将字幕颜色转换为匹配 BT.2100 PQ 或 HLG 的 HDR 色彩值 / Convert subtitle colors to HDR-ready BT.2100 PQ or HLG values                                                                                                                                                                                                   |
-| **时间轴偏移 / Timing Shift**           | 批量调整字幕时间戳；可从指定时间点之后开始偏移，并实时预览效果 / Batch-adjust subtitle timestamps; optionally start after a chosen timestamp, with live preview                                                                                                                                                         |
-| **字体嵌入 / Font Embedding**           | 自动检测字幕引用的字体，在系统字体库或本地字体源中匹配，并把子集化后的字体嵌入 ASS 文件 / Detect fonts referenced by the subtitle, match them from system or local font sources, and embed subset fonts into the ASS file                                                                                              |
-| **批量重命名 / Batch Rename**           | 自动匹配视频和字幕，并按视频文件名重命名字幕；如果同一视频匹配到多个字幕候选，可手动选择并调整配对 / Automatically match videos with subtitles and rename subtitles to match the video filename; when multiple subtitle candidates match the same video, choose and adjust the pairing manually                         |
+| 标签页 / Tab                            | 功能 / Description                                                                                                                                                                                                                                                                              |
+| --------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **HDR 色彩转换 / HDR Color Conversion** | 将字幕颜色转换为匹配 BT.2100 PQ 或 HLG 的 HDR 色彩值 / Convert subtitle colors to HDR-ready BT.2100 PQ or HLG values                                                                                                                                                                            |
+| **时间轴偏移 / Timing Shift**           | 批量调整字幕时间戳；可从指定时间点之后开始偏移，并实时预览效果 / Batch-adjust subtitle timestamps; optionally start after a chosen timestamp, with live preview                                                                                                                                 |
+| **字体嵌入 / Font Embedding**           | 自动检测字幕引用的字体，在系统字体库或本地字体源中匹配，并把子集化后的字体嵌入 ASS 文件 / Detect fonts referenced by the subtitle, match them from system or local font sources, and embed subset fonts into the ASS file                                                                       |
+| **批量重命名 / Batch Rename**           | 自动匹配视频和字幕，并按视频文件名重命名字幕；如果同一视频匹配到多个字幕候选，可手动选择并调整配对 / Automatically match videos with subtitles and rename subtitles to match the video filename; when multiple subtitle candidates match the same video, choose and adjust the pairing manually |
 
 > [!TIP]
 > **完整支持中文路径** — 包含中文、日文或其他非 ASCII 字符的文件路径都可以正常处理。Tauri 和 Rust 底层使用 Unicode API，不受传统 ANSI 编码限制。
@@ -89,9 +89,9 @@ macOS / Linux users, see "Build from Source" below.
 
 > **参数说明 | Parameter Guide**
 >
-> | 参数 / Parameter  | 默认值 / Default | 说明 / Description                                                                                                                        |
-> | ----------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-> | EOTF curve        | PQ               | PQ (ST 2084) 用于 HDR10/杜比视界；HLG 用于广播 HDR / PQ for HDR10/Dolby Vision; HLG for broadcast HDR                                                  |
+> | 参数 / Parameter  | 默认值 / Default | 说明 / Description                                                                                                                                                       |
+> | ----------------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+> | EOTF curve        | PQ               | PQ (ST 2084) 用于 HDR10/杜比视界；HLG 用于广播 HDR / PQ for HDR10/Dolby Vision; HLG for broadcast HDR                                                                    |
 > | Target brightness | 203 nits         | SDR 字幕峰值亮度（BT.2408 标准值）。如果字幕太亮就调低，太暗就调高 / Peak SDR subtitle brightness (BT.2408 reference value). Lower it if too bright; raise it if too dim |
 
 ### 时间轴偏移 / Timing Shift
@@ -186,17 +186,17 @@ ssahdrify-cli chain          --help
 
 ### 全局选项 | Global Options
 
-| 选项 / Option         | 说明 / Description                                                                                                                                                                                                                                  |
-| --------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--lang <en\|zh>`     | 输出语言；不指定时按系统区域设置自动检测（zh\* → zh，否则 en）/ Output language; auto-detected from OS locale when omitted (zh\* → zh, otherwise en)                                                                                                |
-| `--json`              | 为支持的子命令输出机器可读 JSON 报告；详见下方 JSON 模式 / Emit machine-readable JSON for supported subcommands; see JSON Mode below                                                                                                              |
-| `--verbose`           | 显示更详细的进度 / Show more detailed progress                                                                                                                                                                                                      |
-| `--quiet`             | 隐藏常规进度输出 / Suppress normal progress output                                                                                                                                                                                                  |
-| `--dry-run`           | 预览计划执行的操作，不写入文件 / Preview planned work without writing files                                                                                                                                                                         |
-| `--overwrite`         | 允许覆盖已存在的输出文件 / Replace existing output files instead of skipping                                                                                                                                                                        |
-| `--output-dir <DIR>`  | 将输出重定向到指定目录 / Redirect output to a specific directory                                                                                                                                                                                    |
-| `--no-cache`          | 跳过本次运行的字体缓存；缓存文件本身保持不变 / Skip the font cache for this run; leave the cache file untouched                                                                                                                                     |
-| `--cache-file <PATH>` | 使用指定缓存文件路径，覆盖默认路径 / Use a specific cache file path instead of the OS default (see Cache Location below)                                                                                                                           |
+| 选项 / Option         | 说明 / Description                                                                                                                                                                                                                                           |
+| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `--lang <en\|zh>`     | 输出语言；不指定时按系统区域设置自动检测（zh\* → zh，否则 en）/ Output language; auto-detected from OS locale when omitted (zh\* → zh, otherwise en)                                                                                                         |
+| `--json`              | 为支持的子命令输出机器可读 JSON 报告；详见下方 JSON 模式 / Emit machine-readable JSON for supported subcommands; see JSON Mode below                                                                                                                         |
+| `--verbose`           | 显示更详细的进度 / Show more detailed progress                                                                                                                                                                                                               |
+| `--quiet`             | 隐藏常规进度输出 / Suppress normal progress output                                                                                                                                                                                                           |
+| `--dry-run`           | 预览计划执行的操作，不写入文件 / Preview planned work without writing files                                                                                                                                                                                  |
+| `--overwrite`         | 允许覆盖已存在的输出文件 / Replace existing output files instead of skipping                                                                                                                                                                                 |
+| `--output-dir <DIR>`  | 将输出重定向到指定目录 / Redirect output to a specific directory                                                                                                                                                                                             |
+| `--no-cache`          | 跳过本次运行的字体缓存；缓存文件本身保持不变 / Skip the font cache for this run; leave the cache file untouched                                                                                                                                              |
+| `--cache-file <PATH>` | 使用指定缓存文件路径，覆盖默认路径 / Use a specific cache file path instead of the OS default (see Cache Location below)                                                                                                                                     |
 | `--fail-fast`         | 任一文件失败即停止处理后续输入；已成功写出的文件会保留，失败文件的目标位置可能留下部分写入产物 / Abort the batch on the first failed file; previously-succeeded outputs are kept, but the failed input may leave a partial-write artifact at its destination |
 
 > **JSON 模式 | JSON Mode**
@@ -465,29 +465,29 @@ The tables below list the main direct dependencies and bundled assets; the full 
 
 #### 运行时依赖（随应用分发）| Runtime (shipped with the application)
 
-| 组件 / Component                                          | 许可证 / License  | 用途 / Usage                                                                                                   |
-| --------------------------------------------------------- | ----------------- | -------------------------------------------------------------------------------------------------------------- |
-| [Tauri](https://tauri.app/)                               | Apache-2.0 OR MIT | 桌面应用框架 / Desktop app framework                                                                           |
-| [Tauri plugins](https://v2.tauri.app/plugin/)             | Apache-2.0 OR MIT | 对话框、文件访问和日志插件 / Dialog, filesystem, and logging plugins                                           |
-| [React](https://react.dev/) / React DOM                   | MIT               | UI 框架 / UI framework                                                                                         |
-| [React Window](https://github.com/bvaughn/react-window)   | MIT               | 大列表虚拟滚动 / Virtualized large lists                                                                       |
-| [Color.js](https://colorjs.io/)                           | MIT               | HDR 色彩空间转换 (PQ/HLG) / HDR color space conversion                                                         |
-| [ass-compiler](https://github.com/weizhenye/ass-compiler) | MIT               | ASS 字幕解析（字体收集）/ ASS subtitle parsing for font collection                                             |
-| [js-base64](https://github.com/dankogai/js-base64)        | BSD-3-Clause      | 前端与 CLI chain 字体载荷 base64 解码 / Base64 decoding for frontend and CLI chain font payloads               |
-| [font-kit](https://github.com/servo/font-kit)             | MIT OR Apache-2.0 | 跨平台系统字体发现 (Rust) / Cross-platform system font discovery                                               |
-| [fontcull](https://github.com/bearcove/fontcull)          | MIT / MIT OR Apache-2.0 | 字体子集化（含 fontcull-klippa、fontcull-skrifa）/ Font subsetting (includes fontcull-klippa, fontcull-skrifa) |
-| [chardetng](https://github.com/hsivonen/chardetng)        | MIT OR Apache-2.0 | 编码检测 (Firefox 引擎) / Encoding detection (Firefox's engine)                                                |
-| [encoding_rs](https://github.com/hsivonen/encoding_rs)    | (Apache-2.0 OR MIT) AND BSD-3-Clause | 编码转换 / Encoding conversion                                                                 |
-| [rusqlite](https://github.com/rusqlite/rusqlite)          | MIT               | 字体缓存和本地字体索引 / Font cache and local font index                                                       |
-| [serde](https://serde.rs/) / serde_json                   | MIT OR Apache-2.0 | Rust 序列化 / Rust serialization                                                                               |
-| [deno_core](https://github.com/denoland/deno)             | MIT               | 嵌入式 V8 JS 运行时（CLI）/ Embedded V8 JS runtime (CLI)                                                       |
-| [V8](https://v8.dev/)                                     | BSD-3-Clause      | JavaScript 引擎（经 deno_core 嵌入，CLI）/ JavaScript engine via deno_core (CLI)                               |
-| [clap](https://github.com/clap-rs/clap)                   | MIT OR Apache-2.0 | CLI 参数解析（CLI）/ CLI argument parsing (CLI)                                                                |
-| [env_logger](https://github.com/rust-cli/env_logger)      | MIT OR Apache-2.0 | CLI 日志后端 stderr（CLI）/ CLI logging backend on stderr (CLI)                                                |
-| [sys-locale](https://github.com/1Password/sys-locale)     | MIT OR Apache-2.0 | OS 区域设置检测（驱动 `--lang` 自动检测，CLI）/ OS locale detection driving `--lang` auto (CLI)                |
-| [base64](https://github.com/marshallpierce/rust-base64)   | MIT OR Apache-2.0 | Rust 侧字体载荷 base64 编码 / Base64 encoding for Rust-side font payloads                                      |
-| [unicode-normalization](https://github.com/unicode-rs/unicode-normalization) | MIT OR Apache-2.0 | Unicode 路径 / 输出键规范化 / Unicode path and output-key normalization                         |
-| [rfd](https://github.com/PolyMeilex/rfd)                  | MIT               | 启动失败时的原生错误对话框 / Native error dialog for startup failures                                          |
+| 组件 / Component                                                             | 许可证 / License                     | 用途 / Usage                                                                                                   |
+| ---------------------------------------------------------------------------- | ------------------------------------ | -------------------------------------------------------------------------------------------------------------- |
+| [Tauri](https://tauri.app/)                                                  | Apache-2.0 OR MIT                    | 桌面应用框架 / Desktop app framework                                                                           |
+| [Tauri plugins](https://v2.tauri.app/plugin/)                                | Apache-2.0 OR MIT                    | 对话框、文件访问和日志插件 / Dialog, filesystem, and logging plugins                                           |
+| [React](https://react.dev/) / React DOM                                      | MIT                                  | UI 框架 / UI framework                                                                                         |
+| [React Window](https://github.com/bvaughn/react-window)                      | MIT                                  | 大列表虚拟滚动 / Virtualized large lists                                                                       |
+| [Color.js](https://colorjs.io/)                                              | MIT                                  | HDR 色彩空间转换 (PQ/HLG) / HDR color space conversion                                                         |
+| [ass-compiler](https://github.com/weizhenye/ass-compiler)                    | MIT                                  | ASS 字幕解析（字体收集）/ ASS subtitle parsing for font collection                                             |
+| [js-base64](https://github.com/dankogai/js-base64)                           | BSD-3-Clause                         | 前端与 CLI chain 字体载荷 base64 解码 / Base64 decoding for frontend and CLI chain font payloads               |
+| [font-kit](https://github.com/servo/font-kit)                                | MIT OR Apache-2.0                    | 跨平台系统字体发现 (Rust) / Cross-platform system font discovery                                               |
+| [fontcull](https://github.com/bearcove/fontcull)                             | MIT / MIT OR Apache-2.0              | 字体子集化（含 fontcull-klippa、fontcull-skrifa）/ Font subsetting (includes fontcull-klippa, fontcull-skrifa) |
+| [chardetng](https://github.com/hsivonen/chardetng)                           | MIT OR Apache-2.0                    | 编码检测 (Firefox 引擎) / Encoding detection (Firefox's engine)                                                |
+| [encoding_rs](https://github.com/hsivonen/encoding_rs)                       | (Apache-2.0 OR MIT) AND BSD-3-Clause | 编码转换 / Encoding conversion                                                                                 |
+| [rusqlite](https://github.com/rusqlite/rusqlite)                             | MIT                                  | 字体缓存和本地字体索引 / Font cache and local font index                                                       |
+| [serde](https://serde.rs/) / serde_json                                      | MIT OR Apache-2.0                    | Rust 序列化 / Rust serialization                                                                               |
+| [deno_core](https://github.com/denoland/deno)                                | MIT                                  | 嵌入式 V8 JS 运行时（CLI）/ Embedded V8 JS runtime (CLI)                                                       |
+| [V8](https://v8.dev/)                                                        | BSD-3-Clause                         | JavaScript 引擎（经 deno_core 嵌入，CLI）/ JavaScript engine via deno_core (CLI)                               |
+| [clap](https://github.com/clap-rs/clap)                                      | MIT OR Apache-2.0                    | CLI 参数解析（CLI）/ CLI argument parsing (CLI)                                                                |
+| [env_logger](https://github.com/rust-cli/env_logger)                         | MIT OR Apache-2.0                    | CLI 日志后端 stderr（CLI）/ CLI logging backend on stderr (CLI)                                                |
+| [sys-locale](https://github.com/1Password/sys-locale)                        | MIT OR Apache-2.0                    | OS 区域设置检测（驱动 `--lang` 自动检测，CLI）/ OS locale detection driving `--lang` auto (CLI)                |
+| [base64](https://github.com/marshallpierce/rust-base64)                      | MIT OR Apache-2.0                    | Rust 侧字体载荷 base64 编码 / Base64 encoding for Rust-side font payloads                                      |
+| [unicode-normalization](https://github.com/unicode-rs/unicode-normalization) | MIT OR Apache-2.0                    | Unicode 路径 / 输出键规范化 / Unicode path and output-key normalization                                        |
+| [rfd](https://github.com/PolyMeilex/rfd)                                     | MIT                                  | 启动失败时的原生错误对话框 / Native error dialog for startup failures                                          |
 
 #### 捆绑字体（随应用分发）| Bundled Fonts (shipped with the application)
 
@@ -502,14 +502,14 @@ The tables below list the main direct dependencies and bundled assets; the full 
 
 #### 构建时依赖（不随应用分发）| Build-time only (not shipped)
 
-| 组件 / Component                              | 许可证 / License | 用途 / Usage                                                      |
-| --------------------------------------------- | ---------------- | ----------------------------------------------------------------- |
-| [Tailwind CSS](https://tailwindcss.com/)      | MIT              | CSS 工具框架 / CSS utility framework                              |
-| [TypeScript](https://www.typescriptlang.org/) | Apache-2.0       | 类型检查 / Type checking                                          |
-| [Vite](https://vite.dev/)                     | MIT              | 构建工具 / Build tool                                             |
-| [Tauri CLI](https://tauri.app/)               | MIT OR Apache-2.0 | Tauri 构建入口 / Tauri build entry point                          |
-| [ESLint](https://eslint.org/)                 | MIT              | 代码检查 / Linting                                                |
-| [Stylelint](https://stylelint.io/)            | MIT              | CSS 代码检查 / CSS linting                                        |
-| [Prettier](https://prettier.io/)              | MIT              | 代码格式化 / Code formatter                                       |
-| [Vitest](https://vitest.dev/)                 | MIT              | 单元测试 / Unit testing                                           |
-| [esbuild](https://esbuild.github.io/)         | MIT              | 为 CLI 嵌入打包 engine.js / Bundles engine.js for CLI embedding |
+| 组件 / Component                              | 许可证 / License  | 用途 / Usage                                                    |
+| --------------------------------------------- | ----------------- | --------------------------------------------------------------- |
+| [Tailwind CSS](https://tailwindcss.com/)      | MIT               | CSS 工具框架 / CSS utility framework                            |
+| [TypeScript](https://www.typescriptlang.org/) | Apache-2.0        | 类型检查 / Type checking                                        |
+| [Vite](https://vite.dev/)                     | MIT               | 构建工具 / Build tool                                           |
+| [Tauri CLI](https://tauri.app/)               | MIT OR Apache-2.0 | Tauri 构建入口 / Tauri build entry point                        |
+| [ESLint](https://eslint.org/)                 | MIT               | 代码检查 / Linting                                              |
+| [Stylelint](https://stylelint.io/)            | MIT               | CSS 代码检查 / CSS linting                                      |
+| [Prettier](https://prettier.io/)              | MIT               | 代码格式化 / Code formatter                                     |
+| [Vitest](https://vitest.dev/)                 | MIT               | 单元测试 / Unit testing                                         |
+| [esbuild](https://esbuild.github.io/)         | MIT               | 为 CLI 嵌入打包 engine.js / Bundles engine.js for CLI embedding |

--- a/scripts/build-engine.mjs
+++ b/scripts/build-engine.mjs
@@ -50,6 +50,7 @@ await build({
   outfile: resolve(projectRoot, "dist-engine/engine.js"),
   define: {
     __APP_VERSION__: JSON.stringify(APP_VERSION),
+    "import.meta.env.DEV": "false",
   },
 });
 

--- a/src-tauri/src/bin/cli/chain.rs
+++ b/src-tauri/src/bin/cli/chain.rs
@@ -19,7 +19,7 @@
 //! See `docs/architecture/ssahdrify_cli_design.md` § "v1.4.1 stable
 //! 后续用户反馈" feature #4 for the locked design decisions.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use clap::Parser;
 
@@ -257,8 +257,9 @@ pub fn parse_chain_argv(
         ));
     }
 
-    let warnings = collect_suspicious_orderings(&steps);
     let output_template = user_output_template.unwrap_or_else(|| derive_stacked_default(&steps));
+    validate_chain_output_template(&output_template)?;
+    let warnings = collect_suspicious_orderings(&steps);
 
     Ok(ChainPlan {
         steps,
@@ -376,6 +377,7 @@ fn parse_one_step(segment: &[String], is_terminal: bool) -> Result<ParsedStep, S
             let mut wrapper = HdrStepWrapper::try_parse_from(&tokens)
                 .map_err(|e| format_step_parse_error("hdr", &e))?;
             if !is_terminal {
+                reject_nonterminal_files("hdr", &wrapper.inner.files)?;
                 wrapper.inner.files.clear();
             }
             Ok(ParsedStep::Hdr(wrapper.inner))
@@ -384,6 +386,7 @@ fn parse_one_step(segment: &[String], is_terminal: bool) -> Result<ParsedStep, S
             let mut wrapper = ShiftStepWrapper::try_parse_from(&tokens)
                 .map_err(|e| format_step_parse_error("shift", &e))?;
             if !is_terminal {
+                reject_nonterminal_files("shift", &wrapper.inner.files)?;
                 wrapper.inner.files.clear();
             }
             Ok(ParsedStep::Shift(wrapper.inner))
@@ -392,6 +395,7 @@ fn parse_one_step(segment: &[String], is_terminal: bool) -> Result<ParsedStep, S
             let mut wrapper = EmbedStepWrapper::try_parse_from(&tokens)
                 .map_err(|e| format_step_parse_error("embed", &e))?;
             if !is_terminal {
+                reject_nonterminal_files("embed", &wrapper.inner.files)?;
                 wrapper.inner.files.clear();
             }
             Ok(ParsedStep::Embed(wrapper.inner))
@@ -401,6 +405,18 @@ fn parse_one_step(segment: &[String], is_terminal: bool) -> Result<ParsedStep, S
             "unknown chain step '{other}' (expected: hdr, shift, embed)"
         )),
     }
+}
+
+fn reject_nonterminal_files(kind: &str, files: &[PathBuf]) -> Result<(), String> {
+    let only_placeholder =
+        files.len() == 1 && files[0].as_path() == Path::new(CHAIN_NONTERMINAL_PLACEHOLDER);
+    if only_placeholder {
+        return Ok(());
+    }
+    Err(format!(
+        "step '{kind}': input files are only allowed on the terminal chain step; \
+         move file paths after the final step"
+    ))
 }
 
 fn take_step_files(step: &mut ParsedStep) -> Vec<PathBuf> {
@@ -415,6 +431,49 @@ fn segment_has_output_template_token(segment: &[String]) -> bool {
     segment
         .iter()
         .any(|tok| tok == "--output-template" || tok.starts_with("--output-template="))
+}
+
+fn validate_chain_output_template(template: &str) -> Result<(), String> {
+    let bytes = template.as_bytes();
+    let mut i = 0usize;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'{' => {
+                let name_start = i + 1;
+                if name_start >= bytes.len()
+                    || !(bytes[name_start].is_ascii_alphabetic() || bytes[name_start] == b'_')
+                {
+                    return Err(chain_template_token_error());
+                }
+                let mut j = name_start + 1;
+                while j < bytes.len()
+                    && (j - name_start) < 32
+                    && (bytes[j].is_ascii_alphanumeric() || bytes[j] == b'_')
+                {
+                    j += 1;
+                }
+                if j >= bytes.len() || bytes[j] != b'}' {
+                    return Err(chain_template_token_error());
+                }
+                let name = &template[name_start..j];
+                if name != "name" && name != "ext" {
+                    return Err(format!(
+                        "chain output template references unknown token '{{{name}}}'; \
+                         chain-level templates support {{name}} and {{ext}} only"
+                    ));
+                }
+                i = j + 1;
+            }
+            b'}' => return Err(chain_template_token_error()),
+            _ => i += 1,
+        }
+    }
+    Ok(())
+}
+
+fn chain_template_token_error() -> String {
+    "chain output template supports only {name} and {ext}; remove unsupported brace syntax"
+        .to_string()
 }
 
 fn first_token_or<'a>(segment: &'a [String], fallback: &'a str) -> &'a str {
@@ -604,6 +663,13 @@ mod tests {
     }
 
     #[test]
+    fn parse_nonterminal_hdr_step_rejects_user_file() {
+        let segment = argv_of(&["hdr", "--eotf", "pq", "early.ass"]);
+        let err = parse_one_step(&segment, false).unwrap_err();
+        assert!(err.contains("terminal chain step"), "got: {err}");
+    }
+
+    #[test]
     fn parse_terminal_shift_step_with_multiple_files() {
         let segment = argv_of(&["shift", "--offset", "+2s", "a.ass", "b.ass", "c.ass"]);
         let step = parse_one_step(&segment, true).unwrap();
@@ -656,6 +722,20 @@ mod tests {
         assert!(!segment_has_output_template_token(&segment));
     }
 
+    #[test]
+    fn validates_chain_output_template_tokens() {
+        validate_chain_output_template("{name}.processed{ext}").unwrap();
+        let err = validate_chain_output_template("{name}.{format}.ass").unwrap_err();
+        assert!(err.contains("unknown token '{format}'"), "got: {err}");
+    }
+
+    #[test]
+    fn rejects_malformed_chain_output_template_braces() {
+        let err = validate_chain_output_template("{name}.{toolong_token_name_over_32_chars}.ass")
+            .unwrap_err();
+        assert!(err.contains("{name} and {ext}"), "got: {err}");
+    }
+
     // ── parse_chain_argv (full pipeline) ──────────────────────
 
     #[test]
@@ -702,6 +782,30 @@ mod tests {
         let err = parse_chain_argv(&argv, None).unwrap_err();
         assert!(err.contains("--output-template"), "got: {err}");
         assert!(err.contains("chain-level flag"), "got: {err}");
+    }
+
+    #[test]
+    fn full_parse_rejects_nonterminal_input_files() {
+        let argv = argv_of(&[
+            "hdr",
+            "--eotf",
+            "pq",
+            "early.ass",
+            "+",
+            "shift",
+            "--offset",
+            "+2s",
+            "cat.ass",
+        ]);
+        let err = parse_chain_argv(&argv, None).unwrap_err();
+        assert!(err.contains("terminal chain step"), "got: {err}");
+    }
+
+    #[test]
+    fn full_parse_rejects_unknown_chain_template_tokens() {
+        let argv = argv_of(&["shift", "--offset", "+2s", "cat.ass"]);
+        let err = parse_chain_argv(&argv, Some("{name}.{format}.ass".into())).unwrap_err();
+        assert!(err.contains("unknown token '{format}'"), "got: {err}");
     }
 
     #[test]

--- a/src-tauri/src/bin/cli/main.rs
+++ b/src-tauri/src/bin/cli/main.rs
@@ -111,9 +111,10 @@ struct GlobalOptions {
     /// always named `cli_font_cache.sqlite3`. Useful for testing or
     /// non-default layouts. 覆盖字体缓存文件路径。
     ///
-    /// Same `global = true` rationale as `no_cache` above
-    /// : one declaration, cross-subcommand visible,
-    /// ignored where unread.
+    /// Same `global = true` rationale as `no_cache` above: one
+    /// declaration, cross-subcommand visible. Commands that read the
+    /// cache validate the path before opening it; chain reports that
+    /// the flag has no effect because chain v1 never uses the cache.
     #[arg(long, global = true, value_name = "PATH")]
     cache_file: Option<PathBuf>,
 
@@ -672,34 +673,6 @@ fn init_logger() {
 fn run() -> Result<ExitCode, String> {
     let Cli { globals, command } = Cli::parse();
 
-    // validate `--cache-file` through the IPC
-    // validator before any consumer (`run_refresh_fonts`,
-    // `prepare_embed_cache`) opens / stat's the file. The cache file
-    // is user-supplied argv and explicitly P1b per the design doc —
-    // without validation, a value like `\\.\PhysicalDrive0` (DOS
-    // device) or `C:\dir\..\elsewhere\cache.sqlite3` (traversal)
-    // would reach SQLite open. The stderr drift report also
-    // interpolates this path; rejecting BiDi / line-break chars at
-    // the entry point closes the smuggling vector symmetrically with
-    // every other IPC path.
-    //
-    // refuse non-UTF-8 paths via `to_str()`
-    // rather than passing `to_string_lossy()` through the validator.
-    // A path with non-UTF-8 / WTF-16-surrogate bytes would otherwise
-    // lossy-substitute into U+FFFD for the validate call, then
-    // `FontCache::open_or_create` (downstream) opened the PathBuf
-    // with the ORIGINAL byte sequence — different bytes than what
-    // validate_ipc_path checked. Refusing upfront keeps the
-    // validated string and the opened path byte-identical.
-    if let Some(ref cache_file) = globals.cache_file {
-        let cache_str = cache_file.to_str().ok_or_else(|| {
-            "--cache-file: path contains non-UTF-8 bytes; refuse upfront so the IPC \
-             validator and the subsequent SQLite open agree on the same byte sequence"
-                .to_string()
-        })?;
-        app_lib::util::validate_ipc_path(cache_str, "--cache-file")?;
-    }
-
     match command {
         Command::Hdr(args) => run_hdr(&globals, args),
         Command::Shift(args) => run_shift(&globals, args),
@@ -708,6 +681,18 @@ fn run() -> Result<ExitCode, String> {
         Command::Chain(args) => run_chain(&globals, args),
         Command::RefreshFonts(args) => run_refresh_fonts(&globals, args),
     }
+}
+
+fn validate_cache_file_arg(globals: &GlobalOptions) -> Result<(), String> {
+    if let Some(ref cache_file) = globals.cache_file {
+        let cache_str = cache_file.to_str().ok_or_else(|| {
+            "--cache-file: path contains non-UTF-8 bytes; refuse upfront so the IPC \
+             validator and the subsequent SQLite open agree on the same byte sequence"
+                .to_string()
+        })?;
+        app_lib::util::validate_ipc_path(cache_str, "--cache-file")?;
+    }
+    Ok(())
 }
 
 fn run_refresh_fonts(globals: &GlobalOptions, args: RefreshFontsArgs) -> Result<ExitCode, String> {
@@ -720,6 +705,8 @@ fn run_refresh_fonts(globals: &GlobalOptions, args: RefreshFontsArgs) -> Result<
              different subcommand."
             .to_string());
     }
+
+    validate_cache_file_arg(globals)?;
 
     // validate each --font-dir argv early —
     // fail-fast before opening the cache or starting any scan. The
@@ -1013,6 +1000,16 @@ fn run_chain(globals: &GlobalOptions, args: ChainArgs) -> Result<ExitCode, Strin
             )
         );
     }
+    if globals.cache_file.is_some() && !globals.quiet {
+        eprintln!(
+            "{}",
+            localize(
+                globals,
+                "ℹ --cache-file has no effect in chain mode; chain v1 doesn't use the persistent cache.".to_string(),
+                "ℹ chain 模式下 --cache-file 不生效；chain v1 不读取持久缓存。".to_string(),
+            )
+        );
+    }
 
     // chain v1 doesn't implement the --json output shape
     // that hdr / shift / embed / rename support; reporting loop below
@@ -1284,12 +1281,11 @@ fn emit_chain_warnings(globals: &GlobalOptions, warnings: &[String]) {
 /// differently.
 ///
 /// Token shape `[a-z_][a-z0-9_]{0,31}` mirrors the TS regex
-/// (32-char identifier cap). Returns `None` when a
-/// token's name is not present in `vars` — this matches the TS
-/// strict-throw behavior at the prediction layer: the caller
-/// (`predict_chain_output_path`) defers to V8 + TS for the
-/// authoritative `unknown token` error, avoiding a permissive
-/// silent-empty prediction that diverges from TS resolution.
+/// (32-char identifier cap). Returns `None` when a token's name is not
+/// present in `vars`. Current chain parsing rejects unsupported
+/// chain-level template tokens before V8 starts; this helper stays
+/// fail-closed in case a future caller bypasses that validator or adds
+/// a token without updating this prediction layer.
 ///
 /// Case asymmetry note : this lexer is lowercase-only
 /// (matches the TS substituteTemplate lexer). The TS chain validator
@@ -1424,11 +1420,10 @@ fn predict_chain_output_path(
         .and_then(|e| e.to_str())
         .map(|e| format!(".{e}"))
         .unwrap_or_default();
-    // `substitute_template` returns None for unknown tokens. `?`
-    // propagates: predict returns None → caller falls
-    // back to V8 + TS, which throws the authoritative `unknown token`
-    // error. Matches the "defer to V8 on divergence" pattern used
-    // elsewhere in this function.
+    // Unsupported tokens are rejected at chain-parse time before this
+    // function runs. If vars ever drift from that validator, returning
+    // None here keeps the cheap-first predictor fail-closed instead of
+    // silently producing a different output path.
     let output_name = substitute_template(output_template, &[("name", stem), ("ext", &ext)])?;
     // Reject shapes TS-side `assertSafeOutputFilename` would reject:
     // path separators (chain output is a single filename in input's
@@ -1935,19 +1930,12 @@ fn emit_chain_dry_run(plan: &chain::ChainPlan, globals: &GlobalOptions) {
     // silently print both rows pointing at the same output, hiding the
     // future failure from the user.
     //
-    // Fidelity caveat: this mirrors the real-run dedup key ONLY when
-    // `predict_chain_output_path` produces a key that
-    // matches what V8's `resolveChainOutputPath` will return. Today
-    // chain templates only support {name} and {ext} and both
-    // predictors agree byte-for-byte, so the mirror is complete. If a
-    // future chain template feature adds a token the Rust predictor
-    // doesn't model, prediction returns None for that input → dry-run
-    // shows no `→ outpath` line and the dedup set never sees the key.
-    // The real run has a post-V8 reconcile step
-    // (`process_one_chain_input` line ~1357) that dry-run can't
-    // replay without invoking V8. So the preview is "faithful for
-    // currently-supported templates"; when prediction abstains, the
-    // user should expect possible divergence at write time.
+    // Fidelity caveat: chain parsing currently limits templates to
+    // {name} and {ext}, and this predictor mirrors those tokens byte
+    // for byte. If a future template feature adds a token, that work
+    // must update both the parser and this predictor; otherwise dry-run
+    // would omit the `→ outpath` line and miss duplicate-output
+    // detection for that input.
     let mut seen_outputs: HashSet<String> = HashSet::new();
     for input in &plan.input_files {
         let input_disp = sanitize_for_display(&input.display().to_string());
@@ -2559,6 +2547,7 @@ fn run_embed(globals: &GlobalOptions, args: EmbedArgs) -> Result<ExitCode, Strin
         }
         None
     } else {
+        validate_cache_file_arg(globals)?;
         prepare_embed_cache(globals, &args)
     };
 
@@ -5133,10 +5122,9 @@ mod tests {
 
     #[test]
     fn substitute_template_unknown_token_returns_none() {
-        // unknown token (vars has name + ext, template
-        // uses {lang}) returns None so the caller defers to V8 + TS for
-        // the authoritative `unknown token` error. Pre-fix this returned
-        // Some("Show.ass") via silent-empty substitution.
+        // Unknown token (vars has name + ext, template uses {lang})
+        // returns None. Chain parsing now rejects this before runtime,
+        // but the helper still fails closed if called directly.
         let got = substitute_template("{name}.{lang}{ext}", &[("name", "Show"), ("ext", ".ass")]);
         assert!(got.is_none());
     }

--- a/src-tauri/src/font_cache.rs
+++ b/src-tauri/src/font_cache.rs
@@ -143,6 +143,29 @@ fn platform_data_dir() -> Result<PathBuf, String> {
     }
 }
 
+fn cache_sidecar_path(cache_path: &Path, suffix: &str) -> PathBuf {
+    let mut path = cache_path.as_os_str().to_os_string();
+    path.push(suffix);
+    PathBuf::from(path)
+}
+
+fn reject_cache_reparse_paths(cache_path: &Path) -> Result<(), CacheError> {
+    for path in std::iter::once(cache_path.to_path_buf()).chain(
+        ["-journal", "-wal", "-shm"]
+            .into_iter()
+            .map(|suffix| cache_sidecar_path(cache_path, suffix)),
+    ) {
+        if crate::util::is_reparse_point(&path) {
+            return Err(CacheError::Io(format!(
+                "refusing to open cache at a reparse point (symlink / junction): {}. \
+                 Inspect and remove the link manually before relaunching.",
+                path.display()
+            )));
+        }
+    }
+    Ok(())
+}
+
 /// Schema version. Bumped when any table layout changes; mismatch on
 /// open returns `CacheError::SchemaVersionMismatch` so the caller
 /// can rebuild (CLI: drift-equivalent fallback to no-cache; GUI:
@@ -418,26 +441,7 @@ impl FontCache {
             }
         }
 
-        // Refuse a reparse point at the cache file path.
-        // `Connection::open` follows symlinks, so a planted symlink
-        // (dangling or not) would otherwise be followed and SQLite
-        // would create / open a database at the attacker's chosen
-        // target. An earlier fix to `migrate_legacy_gui_cache` made
-        // dangling-symlink handling worse: previously the migration's
-        // `fs::rename` would have replaced the symlink itself with
-        // the legacy cache; now `symlink_metadata().is_ok()` treats
-        // the dangling symlink as "occupied" and skips migration,
-        // leaving the symlink for `open_or_create` to follow. Closing
-        // the gap here means ALL callers (migrate + direct startup +
-        // future) are defended at the SQLite open boundary, not just
-        // the migration helper.
-        if crate::util::is_reparse_point(cache_path) {
-            return Err(CacheError::Io(format!(
-                "refusing to open cache at a reparse point (symlink / junction): {}. \
-                 Inspect and remove the link manually before relaunching.",
-                cache_path.display()
-            )));
-        }
+        reject_cache_reparse_paths(cache_path)?;
 
         // Residual TOCTOU window between the `is_reparse_point`
         // check above and the `Connection::open` below — an attacker
@@ -805,6 +809,10 @@ impl FontCache {
         let row: Result<(String, i32), _> = self.conn.query_row(
             "SELECT k.font_path, k.face_index \
              FROM cached_family_keys k \
+             INNER JOIN cached_fonts f \
+               ON f.font_path = k.font_path AND f.face_index = k.face_index \
+             INNER JOIN cached_folders d \
+               ON d.folder_path = f.folder_path \
              WHERE k.family_name_key = ?1 AND k.bold = ?2 AND k.italic = ?3 \
              ORDER BY k.font_path, k.face_index \
              LIMIT 1",
@@ -1040,6 +1048,23 @@ mod tests {
             )
             .expect("query schema_version");
         assert_eq!(version, SCHEMA_VERSION.to_string());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn open_refuses_reparse_sidecar_paths() {
+        use std::os::unix::fs::symlink;
+
+        let (_guard, path) = temp_cache_path();
+        let target = path.with_extension("wal-target");
+        fs::write(&target, b"not sqlite").unwrap();
+        symlink(&target, cache_sidecar_path(&path, "-wal")).unwrap();
+
+        let err = FontCache::open_or_create(&path).unwrap_err();
+        assert!(
+            err.to_string().contains("reparse point"),
+            "expected sidecar reparse refusal, got {err}"
+        );
     }
 
     #[test]
@@ -1542,6 +1567,44 @@ mod tests {
             .lookup_family("Helvetica", false, false)
             .expect("lookup ok");
         assert!(result.is_none(), "expected None, got {result:?}");
+    }
+
+    #[test]
+    fn lookup_family_ignores_orphan_family_key_rows() {
+        let (_guard, path) = temp_cache_path();
+        let cache = FontCache::open_or_create(&path).expect("open");
+        cache
+            .conn
+            .pragma_update(None, "foreign_keys", "OFF")
+            .unwrap();
+        cache
+            .conn
+            .execute(
+                "INSERT INTO cached_family_keys(\
+                    font_path, face_index, family_name, family_name_key, bold, italic\
+                 ) VALUES(?1, ?2, ?3, ?4, ?5, ?6)",
+                params![
+                    "/orphan/arial.ttf",
+                    0,
+                    "Arial",
+                    family_lookup_key("Arial"),
+                    0,
+                    0,
+                ],
+            )
+            .unwrap();
+        cache
+            .conn
+            .pragma_update(None, "foreign_keys", "ON")
+            .unwrap();
+
+        let result = cache
+            .lookup_family("Arial", false, false)
+            .expect("lookup ok");
+        assert!(
+            result.is_none(),
+            "orphan family key row must not bypass cached_fonts/cached_folders anchoring"
+        );
     }
 
     #[test]

--- a/src-tauri/src/font_cache_commands.rs
+++ b/src-tauri/src/font_cache_commands.rs
@@ -1003,6 +1003,38 @@ pub fn clear_font_cache() -> Result<(), String> {
         .clone()
         .ok_or_else(|| "Cache path not initialized; setup did not run".to_string())?;
 
+    // Build the main-file + sidecar set and reject reparse points
+    // BEFORE dropping the live cache handle. If a planted sidecar is
+    // found, clear must fail without making the current in-memory
+    // cache unavailable or clearing the provenance set.
+    let paths: Vec<PathBuf> = ["", "-journal", "-wal", "-shm"]
+        .iter()
+        .map(|suffix| {
+            let mut p = path.clone().into_os_string();
+            p.push(suffix);
+            PathBuf::from(p)
+        })
+        .collect();
+    let reparse_skipped: Vec<String> = paths
+        .iter()
+        .filter(|p| crate::util::is_reparse_point(p))
+        .map(|p| {
+            log::warn!(
+                "clear_font_cache: refusing to remove reparse-point {}; aborting clear.",
+                p.display()
+            );
+            p.display().to_string()
+        })
+        .collect();
+    if !reparse_skipped.is_empty() {
+        return Err(format!(
+            "Refusing to clear font cache: the following path(s) are reparse points \
+             (symlinks / junctions) and were left in place to avoid following the link. \
+             Inspect and remove manually: {}",
+            reparse_skipped.join(", ")
+        ));
+    }
+
     // Two-lock pattern: the slot lock is taken, released, then
     // re-taken — bracketed by the CacheMutationGuard
     // above. The interleaved drop is intentional so the SQLite file
@@ -1072,7 +1104,10 @@ pub fn clear_font_cache() -> Result<(), String> {
     // set as init_user_font_db so a partially-cleared state from an
     // earlier crash gets fully wiped here.
     //
-    // Two-phase pre-scan + remove for atomic semantics. An earlier
+    // Two-phase pre-scan + remove for atomic semantics. The pre-scan
+    // above runs before the live handle/provenance are dropped; this
+    // loop is Phase 2 and only runs once every path is known clean.
+    // An earlier
     // version of the loop detected reparse and continued — but ALSO
     // continued removing any subsequent non-reparse sidecars, leaving
     // partial state (e.g., [main, JOURNAL-reparse, wal, shm] → main +
@@ -1113,33 +1148,6 @@ pub fn clear_font_cache() -> Result<(), String> {
     // there is no user-content tributary. The threat is purely the
     // P1a actor model (process with filesystem write access to the
     // defender's AppData parent), not a content-tainted input.
-    let paths: Vec<PathBuf> = ["", "-journal", "-wal", "-shm"]
-        .iter()
-        .map(|suffix| {
-            let mut p = path.clone().into_os_string();
-            p.push(suffix);
-            PathBuf::from(p)
-        })
-        .collect();
-    let reparse_skipped: Vec<String> = paths
-        .iter()
-        .filter(|p| crate::util::is_reparse_point(p))
-        .map(|p| {
-            log::warn!(
-                "clear_font_cache: refusing to remove reparse-point {}; aborting clear.",
-                p.display()
-            );
-            p.display().to_string()
-        })
-        .collect();
-    if !reparse_skipped.is_empty() {
-        return Err(format!(
-            "Refusing to clear font cache: the following path(s) are reparse points \
-             (symlinks / junctions) and were left in place to avoid following the link. \
-             Inspect and remove manually: {}",
-            reparse_skipped.join(", ")
-        ));
-    }
     for p in &paths {
         match std::fs::remove_file(p) {
             Ok(()) => {}
@@ -1765,6 +1773,42 @@ mod tests {
         fs::write(&main, b"x").unwrap();
         migrate_legacy_gui_cache(&dir.0, &dir.0);
         assert!(main.exists(), "self-rename must not destroy the file");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn clear_font_cache_reparse_error_preserves_live_handle() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TempCacheDir::new("clear_reparse_preserve");
+        let cache_path = dir.0.join(GUI_CACHE_FILE_NAME);
+        let cache = FontCache::open_or_create(&cache_path).expect("open cache");
+        let target = dir.0.join("wal-target");
+        fs::write(&target, b"not sqlite").unwrap();
+        let wal = {
+            let mut p = cache_path.clone().into_os_string();
+            p.push("-wal");
+            PathBuf::from(p)
+        };
+        symlink(&target, &wal).unwrap();
+
+        {
+            let mut path_slot = GUI_FONT_CACHE_PATH.lock().unwrap();
+            *path_slot = Some(cache_path.clone());
+            let mut cache_slot = GUI_FONT_CACHE.lock().unwrap();
+            *cache_slot = Some(cache);
+        }
+
+        let err = clear_font_cache().unwrap_err();
+        assert!(err.contains("reparse points"), "got: {err}");
+        assert!(
+            GUI_FONT_CACHE.lock().unwrap().is_some(),
+            "failed clear must leave the old cache handle available"
+        );
+
+        *GUI_FONT_CACHE.lock().unwrap() = None;
+        *GUI_FONT_CACHE_PATH.lock().unwrap() = None;
+        crate::fonts::clear_cache_provenance();
     }
 
     // ── finalize_drift generation check ──

--- a/src-tauri/src/fonts.rs
+++ b/src-tauri/src/fonts.rs
@@ -2734,11 +2734,13 @@ pub fn clear_cache_provenance() {
 ///   change rejected them as untrusted, breaking the documented
 ///   behavior.
 ///
-/// - Per project P1a (single-user desktop, AppData-local SQLite, no
-///   hostile-local-process model), trusting cache rows opened by THIS
-///   process is the right tradeoff for the project's actual threat
-///   surface. If the project later ships a server / multi-user mode,
-///   revisit per the design doc's "Revisit triggers" section.
+/// - Per the personal-desktop threat model, a cache file can be stale,
+///   corrupt, or same-user modified. Trust is therefore limited to rows
+///   returned by `lookup_family` in THIS process, after path and
+///   face-index validation. This is basic fail-safe protection, not a
+///   high-assurance defense against a process that can race every
+///   filesystem operation. Revisit if the project later ships a server
+///   or multi-user mode.
 ///
 /// Routes to `ALLOWED_CACHE_FONT_PATHS` — kept apart from the system-
 /// font set so the system-fonts-dir defense still applies to
@@ -3112,9 +3114,10 @@ pub fn subset_font(
     // set, ALLOWED_CACHE_FONT_PATHS). Nothing accepts a path that
     // merely appears in the SQLite file but was not actually looked up
     // this run. An earlier gate rejected all cache rows, which broke
-    // the design-locked CLI Situation B and GUI lookup tier 2. P1a
-    // accepts the in-process trust under the project's single-user-
-    // desktop threat model.
+    // the design-locked CLI Situation B and GUI lookup tier 2. The
+    // personal-desktop threat model accepts this in-process trust only
+    // after lookup-time path / face-index validation; it is not a
+    // server-grade hostile-process boundary.
     let canonical_string = normalize_canonical_path(&canonical.to_string_lossy());
     let registered_key = (canonical_string.clone(), font_index);
     // (readability): name each tier flag for what

--- a/src-tauri/src/safe_io.rs
+++ b/src-tauri/src/safe_io.rs
@@ -56,7 +56,7 @@ use crate::encoding::ALLOWED_TEXT_EXTENSIONS;
 use crate::util::{is_reparse_point, validate_ipc_path};
 use std::fs;
 use std::io::Write;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tauri_plugin_fs::FsExt;
 
 fn check_subtitle_extension(path: &Path, label: &str) -> Result<(), String> {
@@ -93,6 +93,61 @@ fn check_scope_allows(
         ));
     }
     Ok(())
+}
+
+fn scope_resolved_path(path: &Path, label: &str) -> Result<PathBuf, String> {
+    let absolute = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|e| format!("Failed to resolve current directory for {label}: {e}"))?
+            .join(path)
+    };
+
+    let mut existing = absolute.as_path();
+    let mut missing = Vec::new();
+    loop {
+        match fs::symlink_metadata(existing) {
+            Ok(_) => break,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                let file_name = existing.file_name().ok_or_else(|| {
+                    format!(
+                        "Cannot resolve {label} path for filesystem scope policy: {}",
+                        path.display()
+                    )
+                })?;
+                missing.push(file_name.to_os_string());
+                existing = existing.parent().ok_or_else(|| {
+                    format!(
+                        "Cannot resolve {label} path for filesystem scope policy: {}",
+                        path.display()
+                    )
+                })?;
+            }
+            Err(e) => {
+                return Err(format!(
+                    "Failed to stat {label} path for filesystem scope policy: {e}"
+                ));
+            }
+        }
+    }
+
+    let mut resolved = existing
+        .canonicalize()
+        .map_err(|e| format!("Failed to resolve {label} path for filesystem scope policy: {e}"))?;
+    for component in missing.iter().rev() {
+        resolved.push(component);
+    }
+    Ok(resolved)
+}
+
+fn check_scope_allows_resolved(
+    is_allowed: &impl Fn(&Path) -> bool,
+    path: &Path,
+    label: &str,
+) -> Result<(), String> {
+    let resolved = scope_resolved_path(path, label)?;
+    check_scope_allows(is_allowed, &resolved, label)
 }
 
 fn ensure_parent_dir(path: &Path) -> Result<(), String> {
@@ -332,6 +387,7 @@ pub fn safe_write_text_file_inner(
     let path_ref = Path::new(path);
     check_subtitle_extension(path_ref, "Output")?;
     check_scope_allows(&is_allowed, path_ref, "Output")?;
+    check_scope_allows_resolved(&is_allowed, path_ref, "Output")?;
     ensure_parent_dir(path_ref)?;
     clear_existing_destination(path_ref, overwrite)?;
     create_new_and_write_bytes(path_ref, content.as_bytes())
@@ -351,6 +407,8 @@ pub fn safe_copy_file_inner(
     check_subtitle_extension(dst_ref, "Destination")?;
     check_scope_allows(&is_allowed, src_ref, "Source")?;
     check_scope_allows(&is_allowed, dst_ref, "Destination")?;
+    check_scope_allows_resolved(&is_allowed, src_ref, "Source")?;
+    check_scope_allows_resolved(&is_allowed, dst_ref, "Destination")?;
     reject_reparse_source(src_ref, "copy")?;
     reject_same_canonical_path(src_ref, dst_ref)?;
     ensure_parent_dir(dst_ref)?;
@@ -398,6 +456,8 @@ pub fn safe_rename_file_inner(
     check_subtitle_extension(dst_ref, "Destination")?;
     check_scope_allows(&is_allowed, src_ref, "Source")?;
     check_scope_allows(&is_allowed, dst_ref, "Destination")?;
+    check_scope_allows_resolved(&is_allowed, src_ref, "Source")?;
+    check_scope_allows_resolved(&is_allowed, dst_ref, "Destination")?;
     reject_reparse_source(src_ref, "rename")?;
     reject_same_canonical_path(src_ref, dst_ref)?;
     ensure_parent_dir(dst_ref)?;
@@ -573,6 +633,20 @@ mod tests {
     }
 
     #[test]
+    fn write_rechecks_scope_after_canonicalizing_existing_parent() {
+        let dir = temp_dir("write_scope_canonical_parent");
+        let raw_path = dir.join(".").join("out.ass");
+        let resolved_path = dir.canonicalize().unwrap().join("out.ass");
+
+        let err = safe_write_text_file_inner(&raw_path.to_string_lossy(), "x", false, move |p| {
+            p != resolved_path
+        })
+        .unwrap_err();
+        assert!(err.contains("denied by"), "got: {err}");
+        assert!(!dir.join("out.ass").exists());
+    }
+
+    #[test]
     fn copy_preserves_source_and_creates_destination() {
         let dir = temp_dir("copy_basic");
         let src = dir.join("src.ass");
@@ -611,6 +685,25 @@ mod tests {
     }
 
     #[test]
+    fn copy_rechecks_destination_scope_after_canonicalizing_existing_parent() {
+        let dir = temp_dir("copy_scope_canonical_parent");
+        let src = dir.join("src.ass");
+        let raw_dst = dir.join(".").join("dst.ass");
+        let resolved_dst = dir.canonicalize().unwrap().join("dst.ass");
+        fs::write(&src, b"payload").unwrap();
+
+        let err = safe_copy_file_inner(
+            &src.to_string_lossy(),
+            &raw_dst.to_string_lossy(),
+            false,
+            move |p| p != resolved_dst,
+        )
+        .unwrap_err();
+        assert!(err.contains("denied by"), "got: {err}");
+        assert!(!dir.join("dst.ass").exists());
+    }
+
+    #[test]
     fn rename_moves_source_to_destination() {
         let dir = temp_dir("rename_basic");
         let src = dir.join("src.ass");
@@ -625,6 +718,26 @@ mod tests {
         .unwrap();
         assert!(!src.exists());
         assert_eq!(fs::read(&dst).unwrap(), b"payload");
+    }
+
+    #[test]
+    fn rename_rechecks_destination_scope_after_canonicalizing_existing_parent() {
+        let dir = temp_dir("rename_scope_canonical_parent");
+        let src = dir.join("src.ass");
+        let raw_dst = dir.join(".").join("dst.ass");
+        let resolved_dst = dir.canonicalize().unwrap().join("dst.ass");
+        fs::write(&src, b"payload").unwrap();
+
+        let err = safe_rename_file_inner(
+            &src.to_string_lossy(),
+            &raw_dst.to_string_lossy(),
+            false,
+            move |p| p != resolved_dst,
+        )
+        .unwrap_err();
+        assert!(err.contains("denied by"), "got: {err}");
+        assert!(src.exists());
+        assert!(!dir.join("dst.ass").exists());
     }
 
     // Symlink tests are POSIX-only because Windows symlink creation

--- a/src-tauri/tests/test_chain.rs
+++ b/src-tauri/tests/test_chain.rs
@@ -612,3 +612,98 @@ fn chain_rejects_in_step_output_template() {
         "stderr should explain chain-level requirement: {stderr}"
     );
 }
+
+#[test]
+fn chain_cache_file_reports_no_effect() {
+    if let Some(reason) = engine_bundle_missing() {
+        panic!("engine bundle missing — run `npm run build:engine` first ({reason})");
+    }
+
+    let dir = temp_dir("cache_file_no_effect");
+    let input = write_fixture(&dir, "cat.ass");
+    let cache_file = dir.join("custom-cache.sqlite3");
+
+    let output = Command::new(cli_path())
+        .arg("--cache-file")
+        .arg(&cache_file)
+        .args(["chain", "shift", "--offset", "+2s"])
+        .arg(&input)
+        .output()
+        .expect("failed to run chain");
+
+    assert!(
+        output.status.success(),
+        "chain should succeed; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--cache-file")
+            && (stderr.contains("no effect") || stderr.contains("不生效")),
+        "expected --cache-file no-effect notice: {stderr}"
+    );
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn chain_rejects_nonterminal_input_files() {
+    let dir = temp_dir("nonterminal_input");
+    let early = write_fixture(&dir, "early.ass");
+    let terminal = write_fixture(&dir, "terminal.ass");
+
+    let output = Command::new(cli_path())
+        .args(["chain", "hdr", "--eotf", "pq"])
+        .arg(&early)
+        .args(["+", "shift", "--offset", "+2s"])
+        .arg(&terminal)
+        .output()
+        .expect("failed to spawn");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "expected exit code 2; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("terminal chain step"),
+        "stderr should explain terminal-step-only inputs: {stderr}"
+    );
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn chain_rejects_unknown_template_before_engine() {
+    let dir = temp_dir("unknown_template");
+    let input = write_fixture(&dir, "cat.ass");
+
+    let output = Command::new(cli_path())
+        .args([
+            "chain",
+            "--output-template",
+            "{name}.{format}.ass",
+            "shift",
+            "--offset",
+            "+2s",
+        ])
+        .arg(&input)
+        .output()
+        .expect("failed to spawn");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "expected exit code 2; stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("unknown token '{format}'"),
+        "stderr should report the unsupported token before engine work: {stderr}"
+    );
+
+    let _ = fs::remove_dir_all(dir);
+}

--- a/src/cli-engine-entry.test.ts
+++ b/src/cli-engine-entry.test.ts
@@ -112,6 +112,35 @@ describe("font embed engine helpers", () => {
     expect(plan.fonts[0]!.codepoints).toEqual([72, 101, 108, 111]);
   });
 
+  it("rejects malformed ASS before font collection", () => {
+    const noScriptInfo = `[V4+ Styles]
+Format: Name, Fontname, Fontsize, Bold, Italic
+Style: Default,Arial,20,0,0
+
+[Events]
+Format: Layer, Start, End, Style, Text
+Dialogue: 0,0:00:00.00,0:00:01.00,Default,Hello
+`;
+
+    expect(() =>
+      planFontEmbed({
+        inputPath: "C:\\subs\\malformed.ass",
+        content: noScriptInfo,
+      })
+    ).toThrow(/\[Script Info\]/);
+  });
+
+  it("rejects line-heavy ASS before font collection", () => {
+    const lineHeavyAss = `[Script Info]\n${"x\n".repeat(501_100)}`;
+
+    expect(() =>
+      planFontEmbed({
+        inputPath: "C:\\subs\\line-heavy.ass",
+        content: lineHeavyAss,
+      })
+    ).toThrow(/File too large: >501024 lines/);
+  });
+
   it("applies uuencoded font entries before the events section", () => {
     const result = applyFontEmbed({
       content: SIMPLE_ASS,

--- a/src/cli-engine-entry.ts
+++ b/src/cli-engine-entry.ts
@@ -299,6 +299,7 @@ export function planRename(request: RenamePlanRequest): RenamePlanResult {
 }
 
 export function planFontEmbed(request: FontEmbedPlanRequest): FontEmbedPlanResult {
+  assertAssShape(request.content);
   const usages = collectFontsWithParser(request.content, parseAss);
 
   return {

--- a/src/features/font-embed/font-collector.test.ts
+++ b/src/features/font-embed/font-collector.test.ts
@@ -769,3 +769,23 @@ describe("font-collector R_TAG overlong-cap boundary (200000 / 200001)", () => {
     ).toBe(true);
   });
 });
+
+describe("font-collector per-variant codepoint cap boundary", () => {
+  function makeUniqueGlyphRun(count: number): string {
+    return Array.from({ length: count }, (_, i) => String.fromCodePoint(0x10000 + i)).join("");
+  }
+
+  it("allows duplicate glyphs after the per-variant cap is exactly full", async () => {
+    await ensureLoaded();
+    const atCap = makeUniqueGlyphRun(65536);
+    const usage = collectFonts(makeASS(`${atCap}${String.fromCodePoint(0x10000)}`));
+    const arial = usage.find((u) => u.key.family === "Arial");
+    expect(arial?.codepoints.size).toBe(65536);
+  });
+
+  it("rejects a new glyph just beyond the per-variant cap", async () => {
+    await ensureLoaded();
+    const overCap = makeUniqueGlyphRun(65537);
+    expect(() => collectFonts(makeASS(overCap))).toThrow(/Too many codepoints for one font/);
+  });
+});

--- a/src/features/font-embed/font-collector.ts
+++ b/src/features/font-embed/font-collector.ts
@@ -277,22 +277,6 @@ export function collectFontsWithParser(assContent: string, parser: AssParseFunct
       }
     }
     for (const char of text) {
-      if (usage.codepoints.size >= MAX_CODEPOINTS_PER_VARIANT) {
-        // throw on per-variant cap for parity
-        // with MAX_FONT_VARIANTS (above) and MAX_TOTAL_CODEPOINTS
-        // (below). Pre-R10 this branch silently `break`ed,
-        // truncating the variant's glyph set without surfacing the
-        // limit — under adversarial input (a crafted ASS that
-        // sprays a million unique codepoints into one font) the
-        // user would receive a subsetted font missing characters
-        // they could see in the source. Aligning to throw makes
-        // the cap-hit a hard failure (visible error message) that
-        // the user can act on by splitting the input or excluding
-        // the offending file.
-        throw new Error(
-          `Too many codepoints for one font variant: ${usage.codepoints.size}+ (max ${MAX_CODEPOINTS_PER_VARIANT})`
-        );
-      }
       const cp = char.codePointAt(0);
       // Skip control chars (incl. U+007F DEL), ASCII space, and invalid
       // codepoints. Space is dropped here because the Rust subset always
@@ -303,17 +287,25 @@ export function collectFontsWithParser(assContent: string, parser: AssParseFunct
       // for them harmlessly, so the leak (1 extra codepoint per C1 char
       // in MAX_CODEPOINTS_PER_VARIANT accounting) is bounded and benign
       // .
-      if (cp !== undefined && cp > 32 && cp !== 0x7f && cp <= 0x10ffff) {
-        const before = usage.codepoints.size;
-        usage.codepoints.add(cp);
-        if (usage.codepoints.size !== before) {
-          totalCodepoints++;
-          if (totalCodepoints > MAX_TOTAL_CODEPOINTS) {
-            throw new Error(
-              `Too many codepoints across fonts: ${totalCodepoints} (max ${MAX_TOTAL_CODEPOINTS})`
-            );
-          }
-        }
+      if (cp === undefined || cp <= 32 || cp === 0x7f || cp > 0x10ffff) {
+        continue;
+      }
+      if (usage.codepoints.has(cp)) {
+        continue;
+      }
+      if (usage.codepoints.size >= MAX_CODEPOINTS_PER_VARIANT) {
+        // Throw only for a NEW glyph beyond the cap. Duplicates and
+        // skipped characters remain harmless at the boundary.
+        throw new Error(
+          `Too many codepoints for one font variant: ${usage.codepoints.size}+ (max ${MAX_CODEPOINTS_PER_VARIANT})`
+        );
+      }
+      usage.codepoints.add(cp);
+      totalCodepoints++;
+      if (totalCodepoints > MAX_TOTAL_CODEPOINTS) {
+        throw new Error(
+          `Too many codepoints across fonts: ${totalCodepoints} (max ${MAX_TOTAL_CODEPOINTS})`
+        );
       }
     }
   }

--- a/src/features/font-embed/font-embedder.test.ts
+++ b/src/features/font-embed/font-embedder.test.ts
@@ -433,6 +433,25 @@ describe("analyzeFonts — useRustUserFonts production path", () => {
     expect(arial?.source).toBe("system");
     expect(arial?.filePath).toBe("C:/Windows/Fonts/arialbd.ttf");
   });
+
+  it("falls through to system fonts when persistent cache lookup rejects", async () => {
+    resolveUserFontMock.mockResolvedValue(null);
+    lookupFontFamilyMock.mockRejectedValue(new Error("corrupt cache"));
+    findSystemFontMock.mockImplementation(async (family: string, bold: boolean) => {
+      if (family === "FZLanTingHei" && !bold) return { path: "C:/Windows/Fonts/FZ.ttf", index: 0 };
+      if (family === "Arial" && bold) return { path: "C:/Windows/Fonts/arialbd.ttf", index: 0 };
+      throw new Error("Font not found");
+    });
+
+    const { infos } = await analyzeFonts(MINIMAL_ASS, null, undefined, true);
+    const fz = infos.find((i) => i.key.family === "FZLanTingHei");
+    const arial = infos.find((i) => i.key.family === "Arial" && i.key.bold);
+
+    expect(fz?.source).toBe("system");
+    expect(fz?.filePath).toBe("C:/Windows/Fonts/FZ.ttf");
+    expect(arial?.source).toBe("system");
+    expect(arial?.filePath).toBe("C:/Windows/Fonts/arialbd.ttf");
+  });
 });
 
 describe("userFontKey", () => {

--- a/src/features/font-embed/font-embedder.ts
+++ b/src/features/font-embed/font-embedder.ts
@@ -217,7 +217,13 @@ export async function analyzeFonts(
     // same per-font IPC N times (mirrors systemFontCache below).
     let cacheResult = cacheLookupCache?.get(key);
     if (cacheResult === undefined) {
-      cacheResult = await lookupFontFamily(usage.key.family, usage.key.bold, usage.key.italic);
+      try {
+        cacheResult = await lookupFontFamily(usage.key.family, usage.key.bold, usage.key.italic);
+      } catch (error) {
+        if (isDev)
+          console.debug(`[ssaHdrify] persistent cache lookup failed; falling through`, error);
+        cacheResult = null;
+      }
       cacheLookupCache?.set(key, cacheResult);
     }
     if (cacheResult) {


### PR DESCRIPTION
## Summary

- Updates the public README for the current GUI and CLI behavior.
- Lands release-prep review fixes for CLI chain validation, safe output I/O, font cache handling, font embedding edge cases, and CLI engine bundling.
- Keeps the project on the existing `1.5.0-preview.1` manifest version; the next preview release version can be bumped separately before tagging.

## Verification

Already run on this branch before PR creation:

- `npm run build:engine`
- `npm run test:run`
- `npm run lint`
- `cargo test --manifest-path src-tauri/Cargo.toml`
- `git diff --check`
- `npm audit --omit=dev --json`

## Release note

This PR prepares the branch for a new preview release, but does not create release binaries, tags, or GitHub releases by itself.