### PR TITLE
修复字幕完整性并强化文件与运行时安全

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,8 +131,8 @@ jobs:
       - name: Build the embedded TypeScript engine
         run: npm run build:engine
 
-      - name: Install the current stable Rust toolchain
-        run: rustup toolchain install stable --profile minimal --component rustfmt --component clippy --no-self-update
+      - name: Install the pinned Rust toolchain
+        run: rustup toolchain install --profile minimal --component rustfmt --component clippy --no-self-update
 
       - name: Check Rust formatting
         run: cargo fmt --manifest-path src-tauri/Cargo.toml --check
@@ -142,6 +142,9 @@ jobs:
 
       - name: Run the locked Rust test suite
         run: cargo test --manifest-path src-tauri/Cargo.toml --locked
+
+      - name: Smoke-test the Tauri build entry point
+        run: npm run tauri build -- --debug --no-bundle --ci
 
   rust-msrv:
     name: Rust 1.91 compatibility (Windows)

--- a/.gitignore
+++ b/.gitignore
@@ -24,5 +24,6 @@ dist-ssr
 *.sln
 *.sw?
 
-# Built release artifacts (renamed portable exe staged for gh release create)
-SSA HDRify_v*_x64.exe
+# Built release artifacts (renamed portable exes staged for gh release create)
+/ssahdrify_v*_x64.exe
+/ssahdrify-cli_v*_x64.exe

--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ macOS / Linux users, see "Build from Source" below.
 
 ## 功能 | Features
 
-| 标签页 / Tab                            | 功能 / Description                                                                                                                                                                                                                                                                                                                                                                                                                      |
-| --------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **HDR 色彩转换 / HDR Color Conversion** | 将字幕颜色转换为适配 BT.2100 PQ 或 HLG 的 HDR 色彩值 / Convert subtitle colors into HDR values suitable for BT.2100 PQ or HLG                                                                                                                                                                                                                                                                                                           |
-| **时间轴偏移 / Timing Shift**           | 批量调整字幕时间戳；可从指定时间点之后开始偏移，并实时预览效果 / Batch-adjust subtitle timestamps; optionally start after a chosen timestamp, with live preview                                                                                                                                                                                                                                                                         |
-| **字体嵌入 / Font Embedding**           | 自动检测字幕引用的字体，在系统字体库或本地字体源中匹配，并把子集化后的字体嵌入 ASS 文件 / Detect fonts referenced by the subtitle, match them from system or local font sources, and embed subset fonts into the ASS file                                                                                                                                                                                                               |
-| **批量重命名 / Batch Rename**           | 自动匹配视频和字幕，并按视频文件名重命名字幕；当同一视频匹配到多个候选字幕时，可手动选择并调整配对，也可以启用多字幕模式，为每个视频保留多个语言的外挂字幕。 / Automatically match videos and subtitles, then rename subtitles after the video filename; when one video has multiple subtitle candidates, manually choose and adjust pairings, or enable multi-subtitle mode to keep multiple language sidecar subtitles for each video |
-| **样式编辑 / Style Edit**               | 批量预览并修改 ASS/SSA `Style:` 行的字体族和字号。两项操作可独立启用，也可以只替换指定的原字体；行内 `\fn` / `\fs` 标签保持不变。 / Preview and batch-edit font family and size in ASS/SSA `Style:` rows. Enable either operation independently, optionally filter one source family, and leave inline `\fn` / `\fs` tags untouched.                                                                                                    |
+| 标签页 / Tab                            | 功能 / Description                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **HDR 色彩转换 / HDR Color Conversion** | 将字幕颜色转换为适配 BT.2100 PQ 或 HLG 的 HDR 色彩值 / Convert subtitle colors into HDR values suitable for BT.2100 PQ or HLG                                                                                                                                                                                                                                                                                                               |
+| **时间轴偏移 / Timing Shift**           | 批量调整字幕时间戳；可从指定时间点之后开始偏移，并实时预览效果 / Batch-adjust subtitle timestamps; optionally start after a chosen timestamp, with live preview                                                                                                                                                                                                                                                                             |
+| **字体嵌入 / Font Embedding**           | 自动检测字幕引用的字体，在系统字体库或本地字体源中匹配，并把子集化后的字体嵌入 ASS 文件 / Detect fonts referenced by the subtitle, match them from system or local font sources, and embed subset fonts into the ASS file                                                                                                                                                                                                                   |
+| **批量重命名 / Batch Rename**           | 自动匹配视频和字幕，并按视频文件名重命名字幕；当同一视频匹配到多个候选字幕时，可手动选择并调整配对，也可以启用多字幕模式，为每个视频保留多种语言的外挂字幕文件。 / Automatically match videos and subtitles, then rename subtitles after the video filename; when one video has multiple subtitle candidates, manually choose and adjust pairings, or enable multi-subtitle mode to keep multiple language sidecar subtitles for each video |
+| **样式编辑 / Style Edit**               | 批量预览并修改 ASS/SSA `Style:` 行的字体族和字号。两项操作可独立启用，也可以只替换指定的原字体；行内 `\fn` / `\fs` 标签保持不变。 / Preview and batch-edit font family and size in ASS/SSA `Style:` rows. Enable either operation independently, optionally filter one source family, and leave inline `\fn` / `\fs` tags untouched.                                                                                                        |
 
 > [!TIP]
 > **完整支持中文路径** — 包含中文、日文或其他非 ASCII 字符的文件路径都可以正常处理。Tauri 和 Rust 底层使用 Unicode API，不受传统 ANSI 编码限制。
@@ -91,18 +91,18 @@ macOS / Linux users, see "Build from Source" below.
 
 Format support is not identical across workflows. The table below describes current behavior. `HDR Color Conversion` first converts `.srt`, `.sub`, and `.vtt` to ASS before processing.
 
-| 功能 / Workflow                     | `.ass` / `.ssa`                            | `.srt`                                     | `.sub`                                     | `.vtt`                                                                                              | `.sup`                                                       |
-| ----------------------------------- | ------------------------------------------ | ------------------------------------------ | ------------------------------------------ | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------ |
-| HDR 色彩转换 / HDR Color Conversion | 原生处理 / native                          | 转换为 ASS / convert to ASS                | 转换为 ASS / convert to ASS                | 基本文本 cue 转换为 ASS / basic text cues convert to ASS                                            | 不支持 / no                                                  |
-| 时间轴偏移 / Timing Shift           | 保持格式 / preserve format                 | 保持格式 / preserve format                 | 保持格式 / preserve format                 | 重建基础 cue；不保留全部 WebVTT 元数据 / rebuilds basic cues; does not preserve all WebVTT metadata | 不支持 / no                                                  |
-| 字体嵌入 / Font Embedding           | 支持 / yes                                 | 不支持 / no                                | 不支持 / no                                | 不支持 / no                                                                                         | 不支持 / no                                                  |
-| 样式编辑 / Style Edit               | 支持 / yes                                 | 不支持 / no                                | 不支持 / no                                | 不支持 / no                                                                                         | 不支持 / no                                                  |
-| `diagnose-fonts`                    | 支持 / yes                                 | 不支持 / no                                | 不支持 / no                                | 不支持 / no                                                                                         | 不支持 / no                                                  |
-| 批量重命名 / Batch Rename           | 配对、复制或重命名 / pair, copy, or rename | 配对、复制或重命名 / pair, copy, or rename | 配对、复制或重命名 / pair, copy, or rename | 配对、复制或重命名 / pair, copy, or rename                                                          | 作为不解析的侧车文件配对、复制或重命名 / opaque sidecar only |
-| `chain`                             | 取决于步骤 / depends on steps              | 取决于步骤 / depends on steps              | 取决于步骤 / depends on steps              | 仅支持本身接受 `.vtt` 的步骤 / only where the chosen step accepts `.vtt`                            | 不支持 / no                                                  |
+| 功能 / Workflow                     | `.ass` / `.ssa`                            | `.srt`                                     | `.sub`                                     | `.vtt`                                                                                              | `.sup`                                                                 |
+| ----------------------------------- | ------------------------------------------ | ------------------------------------------ | ------------------------------------------ | --------------------------------------------------------------------------------------------------- | ---------------------------------------------------------------------- |
+| HDR 色彩转换 / HDR Color Conversion | 原生处理 / native                          | 转换为 ASS / convert to ASS                | 转换为 ASS / convert to ASS                | 基本文本 cue 转换为 ASS / basic text cues convert to ASS                                            | 不支持 / no                                                            |
+| 时间轴偏移 / Timing Shift           | 保持格式 / preserve format                 | 保持格式 / preserve format                 | 保持格式 / preserve format                 | 重建基础 cue；不保留全部 WebVTT 元数据 / rebuilds basic cues; does not preserve all WebVTT metadata | 不支持 / no                                                            |
+| 字体嵌入 / Font Embedding           | 支持 / yes                                 | 不支持 / no                                | 不支持 / no                                | 不支持 / no                                                                                         | 不支持 / no                                                            |
+| 样式编辑 / Style Edit               | 支持 / yes                                 | 不支持 / no                                | 不支持 / no                                | 不支持 / no                                                                                         | 不支持 / no                                                            |
+| `diagnose-fonts`                    | 支持 / yes                                 | 不支持 / no                                | 不支持 / no                                | 不支持 / no                                                                                         | 不支持 / no                                                            |
+| 批量重命名 / Batch Rename           | 配对、复制或重命名 / pair, copy, or rename | 配对、复制或重命名 / pair, copy, or rename | 配对、复制或重命名 / pair, copy, or rename | 配对、复制或重命名 / pair, copy, or rename                                                          | 作为外挂字幕文件配对、复制或重命名（不解析内容） / opaque sidecar only |
+| `chain`                             | 取决于步骤 / depends on steps              | 取决于步骤 / depends on steps              | 取决于步骤 / depends on steps              | 仅支持本身接受 `.vtt` 的步骤 / only where the chosen step accepts `.vtt`                            | 不支持 / no                                                            |
 
 > [!NOTE]
-> 这里的 `.sub` 指 MicroDVD 文本字幕。Blu-ray PGS `.sup` 和 VobSub `.sub/.idx` 属于图像字幕，不适用于 HDR 文本颜色转换、时间轴偏移、ASS 字体嵌入或 `diagnose-fonts`。`.sup` 只会在「批量重命名」中作为不解析内容的侧车文件进行配对、复制或重命名。如需把图像字幕变成文本字幕，请先使用专门的字幕转换/OCR 工具。
+> 这里的 `.sub` 指 MicroDVD 文本字幕。Blu-ray PGS `.sup` 和 VobSub `.sub/.idx` 属于图像字幕，不适用于 HDR 文本颜色转换、时间轴偏移、ASS 字体嵌入或 `diagnose-fonts`。`.sup` 只会在「批量重命名」中作为外挂字幕文件进行配对、复制或重命名，不会解析其中的内容。如需把图像字幕变成文本字幕，请先使用专门的字幕转换/OCR 工具。
 >
 > Here `.sub` means MicroDVD text subtitles. Blu-ray PGS `.sup` and VobSub `.sub/.idx` are image subtitle formats, so HDR text color conversion, Timing Shift, ASS font embedding, and `diagnose-fonts` do not apply. `.sup` is only paired, copied, or renamed as an opaque sidecar in Batch Rename. To turn image subtitles into text subtitles, use a dedicated subtitle conversion/OCR tool first.
 
@@ -145,7 +145,7 @@ Format support is not identical across workflows. The table below describes curr
 
 Fonts commonly used in fan-sub typesetting are often not installed system-wide. Open **Font Sources**: **Add Folder** scans only the selected folder, while **Add Font Library** scans the selected root and all of its subfolders. These fonts can be matched without installing them into the OS.
 
-支持大型字体文件夹和多层字体库；发现文件与解析字体时都会显示进度，也可以随时取消。选择约 5000 个字体文件或总量约 5 GiB 以上的来源前，程序会先弹出确认对话框。扫描和缓存写入都有安全上限；超大、扫描中变化、无法完整读取或被取消的来源可能提前停止，或仅用于本次会话而不写入持久化缓存，并会在界面/日志中提示。递归扫描不会跟随符号链接、junction（目录联接）或其他 reparse point（重解析点）。
+支持大型字体文件夹和多层字体库；发现文件与解析字体时都会显示进度，也可以随时取消。扫描包含约 5000 个字体文件或内容总量约 5 GiB 以上的来源前，程序会先弹出确认对话框。扫描和缓存写入都有安全上限；超大、扫描中变化、无法完整读取或被取消的来源可能提前停止，或仅用于本次会话而不写入持久化缓存，并会在界面/日志中提示。递归扫描不会跟随符号链接、junction（目录联接）或其他 reparse point（重解析点）。
 
 Large font folders and nested libraries are supported; discovery and parsing show progress and can be cancelled. Before scanning a source with about 5000 font files or about 5 GiB of content, the app asks for confirmation. Scanning and cache writes are bounded by safety ceilings; unusually large, changing, unreadable, or cancelled sources may stop early or remain available only for the current session instead of being written to the persistent cache, with a visible UI/log message. Recursive scans do not follow symbolic links, junctions, or other reparse points.
 
@@ -166,7 +166,7 @@ Large font folders and nested libraries are supported; discovery and parsing sho
 3. 在预览表中逐行确认旧值和新值；默认勾选所有会发生变化的行，也可以取消任意行 / Review old and new values row by row; every effective change is checked by default, and any row can be cleared
 4. 点击「写入」。输出固定为源文件旁的 `.styled.ass` / `.styled.ssa` 新文件；如果目标已存在，本次不会覆盖它 / Click **Write**. Output is always a new sibling `.styled.ass` / `.styled.ssa` file; an existing target is never overwritten
 
-编辑器只修改样式表中的 `Fontname` 和 `Fontsize` 字段，并按文件自己的 `Format:` 列顺序解析。它不会全局替换对话或注释文字，也不会更改行内 `\fn` / `\fs` 覆盖标签。输出保留源文件的受支持文本编码、BOM（字节顺序标记）和换行符；如果源文件在预览后发生变化，安全写入会拒绝使用过期计划。
+编辑器只修改样式表中的 `Fontname` 和 `Fontsize` 字段，并按文件自己的 `Format:` 列顺序解析。它不会全局替换对话或注释文字，也不会更改行内 `\fn` / `\fs` 覆盖标签。输出保留源文件的受支持文本编码、BOM（字节顺序标记）和换行符；如果源文件在预览后发生变化，安全写入会拒绝继续执行这个已过期的写入计划。
 
 The editor changes only `Fontname` and `Fontsize` fields in the style table and follows each file's own `Format:` column order. It does not globally replace dialogue or comment text, and it leaves inline `\fn` / `\fs` override tags untouched. Output preserves the source's supported text encoding, byte-order mark (BOM), and line endings; if a source changes after preview, the safe writer rejects the stale plan.
 
@@ -233,11 +233,11 @@ ssahdrify-cli chain hdr --eotf pq + shift --offset +500ms input.ass
 # 批量重命名：默认复制到视频所在目录 / Batch rename (default: copy sub next to video)
 ssahdrify-cli rename "<series-folder>"
 
-# 多外挂字幕：保留语言后缀，避免 sc/tc 同扩展字幕互相覆盖 / Multiple sidecar subtitles: keep language suffixes
+# 多个外挂字幕文件：保留语言后缀，避免 sc/tc 同扩展字幕互相覆盖 / Multiple sidecar subtitles: keep language suffixes
 ssahdrify-cli rename "<series-folder>" --langs all --dry-run
 ```
 
-`rename --langs auto` 保持和 GUI 一致的默认行为：每个视频只选一个字幕，输出文件名精确匹配视频 stem（如 `Video.ass`）。`rename --langs all` 或显式列表（如 `--langs sc,jp`）可以为同一个视频规划多个字幕，并写成带语言后缀的文件名（如 `Video.sc.ass`、`Video.jp.srt`）；没有语言标记的字幕仍使用精确视频名（如 `Video.ass`）。如果多行会写到同一个目标路径，CLI 会在写入前阻止这些冲突行。
+`rename --langs auto` 保持和 GUI 一致的默认行为：每个视频只选一个字幕，输出文件名精确匹配视频 stem（如 `Video.ass`）。`rename --langs all` 或显式列表（如 `--langs sc,jp`）可以为同一个视频规划多个字幕，并写成带语言后缀的文件名（如 `Video.sc.ass`、`Video.jp.srt`）；没有语言标记的字幕仍使用精确视频名（如 `Video.ass`）。如果多行会写入同一个目标路径，CLI 会在写入前拦截这些存在冲突的条目。
 
 `rename --langs auto` keeps the same default behavior as the GUI: one subtitle per video, with the output filename matching the video stem exactly (`Video.ass`). `rename --langs all` or an explicit list such as `--langs sc,jp` can plan multiple subtitles for the same video and write them with language suffixes such as `Video.sc.ass` and `Video.jp.srt`; untagged subtitles still use the exact video name (`Video.ass`). If multiple rows would write to the same target path, the CLI blocks those conflicting rows before writing.
 
@@ -268,18 +268,18 @@ ssahdrify-cli chain          --help
 
 ### 全局选项 | Global Options
 
-| 选项 / Option         | 说明 / Description                                                                                                                                                                                                                                           |
-| --------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `--lang <en\|zh>`     | 输出语言；不指定时按系统区域设置自动检测（zh\* → zh，否则 en）/ Output language; auto-detected from OS locale when omitted (zh\* → zh, otherwise en)                                                                                                         |
-| `--json`              | 为支持的子命令输出机器可读 JSON 报告；详见下方 JSON 模式 / Emit machine-readable JSON for supported subcommands; see JSON Mode below                                                                                                                         |
-| `--verbose`           | 显示更详细的进度 / Show more detailed progress                                                                                                                                                                                                               |
-| `--quiet`             | 隐藏常规进度输出 / Suppress normal progress output                                                                                                                                                                                                           |
-| `--dry-run`           | 预览计划执行的操作，不写入文件 / Preview planned work without writing files                                                                                                                                                                                  |
-| `--overwrite`         | 允许覆盖已存在的输出文件 / Replace existing output files instead of skipping                                                                                                                                                                                 |
-| `--output-dir <DIR>`  | 将输出重定向到指定目录 / Redirect output to a specific directory                                                                                                                                                                                             |
-| `--no-cache`          | 跳过本次运行的字体缓存；缓存文件本身保持不变 / Skip the font cache for this run; leave the cache file untouched                                                                                                                                              |
-| `--cache-file <PATH>` | 使用指定缓存文件路径，覆盖默认路径 / Use a specific cache file path instead of the OS default (see Cache Location below)                                                                                                                                     |
-| `--fail-fast`         | 任一文件失败即停止处理后续输入；已成功写出的文件会保留，失败文件的目标位置可能留下部分写入产物 / Abort the batch on the first failed file; previously-succeeded outputs are kept, but the failed input may leave a partial-write artifact at its destination |
+| 选项 / Option         | 说明 / Description                                                                                                                                                                                                                                               |
+| --------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--lang <en\|zh>`     | 输出语言；不指定时按系统区域设置自动检测（zh\* → zh，否则 en）/ Output language; auto-detected from OS locale when omitted (zh\* → zh, otherwise en)                                                                                                             |
+| `--json`              | 为支持的子命令输出机器可读 JSON 报告；详见下方 JSON 模式 / Emit machine-readable JSON for supported subcommands; see JSON Mode below                                                                                                                             |
+| `--verbose`           | 显示更详细的进度 / Show more detailed progress                                                                                                                                                                                                                   |
+| `--quiet`             | 隐藏常规进度输出 / Suppress normal progress output                                                                                                                                                                                                               |
+| `--dry-run`           | 预览计划执行的操作，不写入文件 / Preview planned work without writing files                                                                                                                                                                                      |
+| `--overwrite`         | 允许覆盖已存在的输出文件 / Replace existing output files instead of skipping                                                                                                                                                                                     |
+| `--output-dir <DIR>`  | 将输出重定向到指定目录 / Redirect output to a specific directory                                                                                                                                                                                                 |
+| `--no-cache`          | 跳过本次运行的字体缓存；缓存文件本身保持不变 / Skip the font cache for this run; leave the cache file untouched                                                                                                                                                  |
+| `--cache-file <PATH>` | 使用指定缓存文件路径，覆盖默认路径 / Use a specific cache file path instead of the OS default (see Cache Location below)                                                                                                                                         |
+| `--fail-fast`         | 任一文件失败即停止处理后续输入；已成功写出的文件会保留，失败输入的目标位置可能残留未完整写入的文件 / Abort the batch on the first failed file; previously-succeeded outputs are kept, but the failed input may leave a partial-write artifact at its destination |
 
 > **JSON 模式 | JSON Mode**
 >
@@ -332,7 +332,7 @@ ssahdrify-cli diagnose-fonts --subset-check --font-dir "<font-folder>" input.ass
 ssahdrify-cli embed --font-dir "<font-folder>" --on-missing fail --fail-fast --diagnose input.ass
 ```
 
-`embed` 默认仍使用 `--on-missing warn`：能嵌入的字体会继续嵌入，缺失或子集化失败的字体会变成 warning。此时输出文件可能已经写出，但 summary 会明确显示 `written with warnings / incomplete`，避免把部分成功误读成“全部字体都成功”。
+`embed` 默认仍使用 `--on-missing warn`：能嵌入的字体会继续嵌入，缺失或子集化失败的字体会变成 warning。此时输出文件可能已经写出，但 summary 会明确显示 `written with warnings / incomplete`，避免把部分成功误读成「全部字体都成功」。
 
 `embed` still defaults to `--on-missing warn`: fonts that can be embedded continue to be embedded, while missing fonts or subset failures become warnings. In that case the output file may already be written, but the summary explicitly says `written with warnings / incomplete` so partial success is not mistaken for “all fonts succeeded.”
 
@@ -396,8 +396,8 @@ At startup, `embed` validates each cached source's directory inventory and candi
 - 单个缓存来源最多安全写入 **32,768 个 font faces**。超过上限、用户取消、遇到读取不完整或扫描期间来源变化时，结果不会作为完整缓存发布；GUI 已成功读取的部分字体可以仅在当前会话继续使用，并会明确提示。
 - 单个字体文件的扫描/子集化读取上限为 **64 MiB**；超过会被拒绝并报告错误。
 - 递归扫描不会跟随符号链接、Windows junction 或其他 reparse point（重解析点），从而避免越过所选字体库根目录或形成目录循环。
-- GUI 和 CLI 各自使用独立缓存文件，避免 SQLite 锁竞争；同一个可执行文件同时只会读写一个缓存文件（默认路径或 `--cache-file` 覆盖路径）。`chain` v1 暂不读取缓存（其中的 embed 步始终使用显式 `--font-dir`、`--recursive-font-dir` 或系统字体）。
-- 跨版本不会自动迁移缓存结构。本次递归来源支持采用 cache schema v6；旧缓存会进入明确的一次性重建流程。CLI 会提示删除旧缓存文件并重新运行 `refresh-fonts`，GUI 会在确认后重建，不会静默改写。
+- GUI 和 CLI 各自使用独立缓存文件，避免 SQLite 锁竞争；同一个可执行文件同一时间只会打开一个缓存文件（默认路径或 `--cache-file` 覆盖路径）。`chain` v1 暂不读取缓存（其中的 embed 步始终使用显式 `--font-dir`、`--recursive-font-dir` 或系统字体）。
+- 跨版本不会自动迁移缓存结构。递归来源支持目前使用 cache schema v6；旧缓存会进入明确的一次性重建流程。CLI 会提示删除旧缓存文件并重新运行 `refresh-fonts`，GUI 会在确认后重建，不会静默改写。
 
 - `--font-dir` and GUI **Add Folder** always scan one level; only `--recursive-font-dir` and **Add Font Library** recurse. The same root can be tracked independently in both scopes.
 - The font cache tracks at most 256 sources. A recursive scan is also bounded to 4096 real directories, 64 levels, 50,000 candidate font files, 128 GiB of candidate-file data, and 200,000 directory entries.
@@ -451,7 +451,7 @@ PQ 模式已验证与 Python 原版（colour-science）逐像素一致。HLG 模
 
 PQ mode is verified pixel-exact against the Python version (colour-science). HLG mode uses a manually implemented BT.2100 inverse OOTF + OETF (bypassing Color.js's rec2100hlg space) and also matches the Python version exactly.
 
-由于字幕混合链路和 HDR 显示环境很复杂（HDMI 元数据协商、显示器色调映射等），实际效果主要保证“红还是红、蓝还是蓝”的基础观感，不适合严格校色场景。
+由于字幕混合链路和 HDR 显示环境很复杂（HDMI 元数据协商、显示器色调映射等），实际效果主要保证「红还是红、蓝还是蓝」的基础观感，不适合严格校色场景。
 
 Due to the complexity of subtitle blending pipelines and HDR display environments (HDMI metadata negotiation, display tone mapping, etc.), the result is mainly intended to preserve the basic impression that “red stays red and blue stays blue.” It is not meant for strict color-accuracy or color-grading workflows.
 
@@ -519,7 +519,7 @@ cargo test --manifest-path src-tauri/Cargo.toml   # Rust 后端测试 / Rust bac
 >
 > Release builds use native TypeScript 7 for type-checking. ESLint and `typescript-eslint` continue to use TypeScript 6's programmatic API through the official `@typescript/typescript6` compatibility package, and CI checks both toolchains. Use the `npm run typecheck:*` scripts above instead of relying on bare `tsc` / `npx tsc` resolution order.
 >
-> `Dependency Watch` 是只读的每周检查：它监视直接 npm 和 Cargo 依赖、TypeScript 别名工具链，以及锁定到完整提交哈希的 GitHub Actions。发现普通更新时，它只让工作流运行显示红色并写入汇总；不会创建分支或拉取请求。依赖安全漏洞由 GitHub Dependabot Alerts 单独监视。
+> `Dependency Watch` 是只读的每周检查：它监视直接 npm 和 Cargo 依赖、TypeScript 别名工具链，以及锁定到完整提交哈希的 GitHub Actions。发现普通更新时，它只会将工作流运行标红并写入汇总；不会创建分支或拉取请求。依赖安全漏洞由 GitHub Dependabot Alerts 单独监视。
 >
 > `Dependency Watch` is a read-only weekly check for direct npm and Cargo dependencies, the aliased TypeScript toolchain, and GitHub Actions pinned to full commit hashes. When an ordinary update exists, it only marks the workflow run red and writes a summary; it cannot create a branch or pull request. GitHub Dependabot Alerts separately monitor dependency security vulnerabilities.
 
@@ -592,7 +592,7 @@ This project is a Tauri desktop rewrite of [ssaHdrify](https://github.com/gky99/
 The original project was created by ying (2021) and later maintained by gky99 (2024-2025).
 It is also licensed under GPL-3.0.
 
-HDR 色彩转换算法由 TypeScript（基于 [Color.js](https://colorjs.io/)）重新实现，方案参考了 Python 原版（使用 [colour-science](https://www.colour-science.org/)）。没有逐字复制代码；实现本身是新的，但按许可证语境仍按衍生作品处理。
+HDR 色彩转换算法由 TypeScript（基于 [Color.js](https://colorjs.io/)）重新实现，方案参考了 Python 原版（使用 [colour-science](https://www.colour-science.org/)）。没有逐字复制代码；实现本身是新的，但出于许可证考量，本项目仍按衍生作品处理。
 
 The HDR color conversion algorithm was reimplemented in TypeScript (using
 [Color.js](https://colorjs.io/)) based on the approach in the Python version
@@ -602,7 +602,7 @@ derivative work for license purposes.
 
 ### 算法归属 | Algorithm Attribution
 
-`src/features/font-embed/font-collector.ts` 中的字体收集算法受 [Aegisub](https://github.com/Aegisub/Aegisub) 的 FontCollector 设计（BSD-3-Clause）启发。未复制 Aegisub 代码，实现为本项目原创 TypeScript。
+`src/features/font-embed/font-collector.ts` 中的字体收集算法受 [Aegisub](https://github.com/Aegisub/Aegisub) 的 FontCollector 设计（BSD-3-Clause）启发。未复制 Aegisub 代码；TypeScript 实现由本项目独立编写。
 
 The font collection algorithm in `src/features/font-embed/font-collector.ts`
 is inspired by [Aegisub](https://github.com/Aegisub/Aegisub)'s FontCollector
@@ -653,7 +653,7 @@ The tables below list the main direct dependencies and bundled assets. For the f
 >
 > OFL-1.1 allows these fonts to be bundled, embedded, and redistributed alongside any software, including GPL-3.0 projects. The fonts and their derivatives must remain licensed under OFL, must not be sold on their own, and modified versions must not use Reserved Font Names declared by their respective licenses. The bundled Smiley Sans license declares `Smiley` and `得意黑`; the bundled Inter license declares none.
 
-桌面版可从页脚的 **许可证** 打开离线声明，阅读项目 GPL 正文、两款捆绑字体的完整 OFL 文本，以及 Feather Icons 的 MIT 声明。
+在桌面版中，点击页脚的「许可证」即可离线阅读项目 GPL 正文、两款捆绑字体的完整 OFL 文本，以及 Feather Icons 的 MIT 声明。
 
 In the desktop app, choose **Licenses** in the footer to read offline copies of the project GPL, both bundled fonts' complete OFL texts, and the Feather Icons MIT notice.
 

--- a/README.md
+++ b/README.md
@@ -233,9 +233,16 @@ ssahdrify-cli chain hdr --eotf pq + shift --offset +500ms input.ass
 # 批量重命名：默认复制到视频所在目录 / Batch rename (default: copy sub next to video)
 ssahdrify-cli rename "<series-folder>"
 
+# 批量重命名：复制到自定义目录 / Batch rename: copy to a chosen directory
+ssahdrify-cli rename --mode copy-to-chosen --output-dir "<output-folder>" "<series-folder>"
+
 # 多个外挂字幕文件：保留语言后缀，避免 sc/tc 同扩展字幕互相覆盖 / Multiple sidecar subtitles: keep language suffixes
 ssahdrify-cli rename "<series-folder>" --langs all --dry-run
 ```
+
+`rename --mode` 控制文件操作。默认的 `copy-to-video` 会把字幕复制到匹配视频所在的目录；`rename` 会在字幕原目录中直接重命名源文件；`copy-to-chosen` 会把字幕复制到 `--output-dir` 指定的目录。`copy-to-chosen` 必须同时传入 `--output-dir`，另外两种模式则不接受该参数。
+
+`rename --mode` controls the file operation. The default `copy-to-video` copies each subtitle beside its matched video; `rename` renames the source subtitle in its existing directory; and `copy-to-chosen` copies it to the directory supplied through `--output-dir`. `--output-dir` is required with `copy-to-chosen` and is rejected with the other two modes.
 
 `rename --langs auto` 保持和 GUI 一致的默认行为：每个视频只选一个字幕，输出文件名精确匹配视频 stem（如 `Video.ass`）。`rename --langs all` 或显式列表（如 `--langs sc,jp`）可以为同一个视频规划多个字幕，并写成带语言后缀的文件名（如 `Video.sc.ass`、`Video.jp.srt`）；没有语言标记的字幕仍使用精确视频名（如 `Video.ass`）。如果多行会写入同一个目标路径，CLI 会在写入前拦截这些存在冲突的条目。
 
@@ -303,9 +310,9 @@ ssahdrify-cli chain          --help
 
 `hdr` / `shift` / `embed` / `rename` support `--diagnose[=summary|full]`. `--diagnose` and `--diagnose=summary` are equivalent and attach compact diagnostics after the command finishes; `--diagnose=full` lists per-file details, and `embed` also lists font-resolution tiers (font sources passed for this run, persistent cache, system fonts) plus cache status. `chain` and `refresh-fonts` do not support `--diagnose`; passing it returns an error instead of being silently ignored.
 
-`diagnose-fonts` 是独立的详细诊断命令，默认输出 verbose 报告，而且只读：不写输出字幕、不刷新或修改字体缓存。它接受字幕输入和字体解析选项：`--font-dir`、`--font-file`、`--no-system-fonts`、`--no-cache`、`--cache-file`、`--lang`、`--json`。需要确认字体文件是否真的能被子集化时，可显式加入 `--subset-check`；该检查只在内存中运行，不写出字幕。
+`diagnose-fonts` 是独立的详细诊断命令，默认输出 verbose 报告，而且只读：不写输出字幕、不刷新或修改字体缓存。它接受字幕输入和字体解析选项：`--font-dir`、`--recursive-font-dir`、`--font-file`、`--no-system-fonts`、`--no-cache`、`--cache-file`、`--lang`、`--json`。需要确认字体文件是否真的能被子集化时，可显式加入 `--subset-check`；该检查只在内存中运行，不写出字幕。
 
-`diagnose-fonts` is the standalone detailed diagnostic command. It is verbose by default and read-only: it does not write output subtitles and does not refresh or modify the font cache. It accepts subtitle inputs plus font-resolution options: `--font-dir`, `--font-file`, `--no-system-fonts`, `--no-cache`, `--cache-file`, `--lang`, and `--json`. Add `--subset-check` explicitly when you need to confirm whether resolved font files can actually be subset; the check runs in memory and does not write subtitles.
+`diagnose-fonts` is the standalone detailed diagnostic command. It is verbose by default and read-only: it does not write output subtitles and does not refresh or modify the font cache. It accepts subtitle inputs plus font-resolution options: `--font-dir`, `--recursive-font-dir`, `--font-file`, `--no-system-fonts`, `--no-cache`, `--cache-file`, `--lang`, and `--json`. Add `--subset-check` explicitly when you need to confirm whether resolved font files can actually be subset; the check runs in memory and does not write subtitles.
 
 `diagnose-fonts` 和带 `--diagnose` 的 `embed` 还会输出 package-level Font QA 状态：`complete`、`incomplete` 或 `blocked`。`complete` 表示已检查文件里的字体引用全部解析成功；`incomplete` 表示有缺失字体、警告或被跳过的可选子集化检查；`blocked` 表示文件诊断失败、字体解析错误，或 `--subset-check` 明确失败。
 
@@ -463,7 +470,7 @@ Due to the complexity of subtitle blending pipelines and HDR display environment
 
 - [Node.js](https://nodejs.org/) (v22.13 minimum, v24 LTS recommended, or v26 Current)
 - npm 11.19.0（由 `packageManager` 声明并由 CI 强制 / declared by `packageManager` and enforced in CI）
-- [Rust 工具链 / Rust toolchain](https://rustup.rs/) (1.91 minimum; latest stable recommended)
+- [Rust 工具链 / Rust toolchain](https://rustup.rs/)（最低 1.91；rustup 会自动安装仓库锁定且经过测试的稳定工具链 / 1.91 minimum; rustup automatically installs the repository-pinned tested stable toolchain）
 - Windows: WebView2 (Windows 10/11 已预装 / pre-installed on Windows 10/11)
 - macOS / Linux: 参考 / see [Tauri prerequisites](https://v2.tauri.app/start/prerequisites/)
 
@@ -620,7 +627,7 @@ The tables below list the main direct dependencies and bundled assets. For the f
 | 组件 / Component                                                             | 许可证 / License                               | 用途 / Usage                                                                                                   |
 | ---------------------------------------------------------------------------- | ---------------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
 | [Tauri](https://tauri.app/)                                                  | Apache-2.0 OR MIT                              | 桌面应用框架 / Desktop app framework                                                                           |
-| [Tauri plugins](https://v2.tauri.app/plugin/)                                | Apache-2.0 OR MIT                              | 对话框、文件访问和日志插件 / Dialog, filesystem, and logging plugins                                           |
+| [Tauri plugins](https://v2.tauri.app/plugin/)                                | Apache-2.0 OR MIT                              | 对话框、文件访问、日志和单实例启动保护 / Dialog, filesystem, logging, and single-instance startup protection   |
 | [React](https://react.dev/) / React DOM                                      | MIT                                            | UI 框架 / UI framework                                                                                         |
 | [React Window](https://github.com/bvaughn/react-window)                      | MIT                                            | 大列表虚拟滚动 / Virtualized large lists                                                                       |
 | [Color.js](https://colorjs.io/)                                              | MIT                                            | HDR 色彩空间转换 (PQ/HLG) / HDR color space conversion                                                         |

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -13,11 +13,11 @@ export default defineConfig([
   globalIgnores(["dist", "dist-engine", "src-tauri"]),
   // scripts/*.mjs runs at build time and ships engine bytes into the
   // CLI binary via include_str!; the umbrella `**/*.{ts,tsx}` pattern
-  // excluded it from lint coverage. Add a Node-globals block so the
-  // build-engine helper + the shared app-version resolver get
-  // unused-var / unreachable / typo signal.
+  // excluded it and this config file from lint coverage. Add a
+  // Node-globals block so the config, build-engine helper, and shared
+  // app-version resolver get unused-var / unreachable / typo signal.
   {
-    files: ["scripts/**/*.{mjs,js}"],
+    files: ["eslint.config.js", "scripts/**/*.{mjs,js}"],
     extends: [js.configs.recommended],
     languageOptions: {
       ecmaVersion: 2023,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "ssahdrify-tauri",
       "version": "1.7.0-preview.1",
+      "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tauri-apps/api": "^2.11.1",
         "@tauri-apps/plugin-dialog": "^2.7.2",

--- a/package.json
+++ b/package.json
@@ -2,13 +2,15 @@
   "name": "ssahdrify-tauri",
   "private": true,
   "version": "1.7.0-preview.1",
+  "license": "GPL-3.0-or-later",
   "packageManager": "npm@11.19.0",
   "type": "module",
   "engines": {
     "node": "^22.13.0 || ^24.0.0 || ^26.0.0"
   },
   "allowScripts": {
-    "esbuild@0.28.2": true
+    "esbuild@0.28.2": true,
+    "fsevents@2.3.3": true
   },
   "//": "Build script taxonomy: `build` = GUI frontend release prerequisite (native TypeScript 7 release typecheck + vite build, invoked by `tauri build` through beforeBuildCommand); TypeScript 6 remains the API-compatibility toolchain for ESLint/typescript-eslint and a transition check in `typecheck:all`. Use the explicit npm scripts instead of bare `tsc` / `npx tsc`. `build:gui` = vite build only (skip typecheck, faster local rebuild); `build:engine` = esbuild → dist-engine/engine.js (the CLI binary's V8 bundle, embedded via include_str!); `build:cli` = TypeScript 7 release typecheck + build:engine + cargo --release --bin ssahdrify-cli; `build:all` = native Tauri GUI build (which invokes `build`) + build:cli (CLI). Lint umbrella (`lint`) runs JS+CSS+Rust; `lint:fix` autofixes what it can.",
   "scripts": {

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "stable"
+channel = "1.97.1"
 profile = "minimal"
 components = ["clippy", "rustfmt"]

--- a/scripts/build-engine.mjs
+++ b/scripts/build-engine.mjs
@@ -33,6 +33,7 @@ import { resolveAppVersion } from "./lib/app-version.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const projectRoot = resolve(__dirname, "..");
+const ENGINE_BUNDLE_COMPLETION_MARKER = "/* ssahdrify-engine-bundle-complete */";
 
 const APP_VERSION = resolveAppVersion(projectRoot);
 
@@ -46,6 +47,9 @@ await build({
   platform: "neutral",
   mainFields: ["module", "main"],
   outfile: resolve(projectRoot, "dist-engine/engine.js"),
+  footer: {
+    js: ENGINE_BUNDLE_COMPLETION_MARKER,
+  },
   define: {
     __APP_VERSION__: JSON.stringify(APP_VERSION),
     "import.meta.env.DEV": "false",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -127,6 +127,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix 1.1.4",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix 1.1.4",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix 1.1.4",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -311,6 +442,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
 ]
 
 [[package]]
@@ -652,6 +796,15 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
+]
+
+[[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1184,7 +1337,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1216,7 +1369,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab8ecd87370524b461f8557c119c405552c396ed91fc0a8eec68679eab26f94a"
 dependencies = [
- "libloading 0.7.4",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -1356,6 +1509,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1412,7 +1592,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1422,6 +1602,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "event-listener"
+version = "5.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a23add41df1562121a9393cb065eab5146a1242410f23a644851e90cfd669d2"
+dependencies = [
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -1715,6 +1915,19 @@ name = "futures-io"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -2108,6 +2321,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -2750,6 +2969,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2941,7 +3166,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 1.3.1",
+ "proc-macro-crate 2.0.2",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3171,6 +3396,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "outref"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3200,6 +3435,12 @@ dependencies = [
  "libc",
  "system-deps",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -3335,6 +3576,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3377,6 +3629,20 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3445,6 +3711,15 @@ checksum = "b00f26d3400549137f92511a46ac1cd8ce37cb5598a96d382381458b992a5d24"
 dependencies = [
  "toml_datetime 0.6.3",
  "toml_edit 0.20.2",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -3729,8 +4004,21 @@ dependencies = [
  "bitflags 2.13.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags 2.13.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.12.1",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4193,6 +4481,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-log",
+ "tauri-plugin-single-instance",
  "tokio",
  "unicode-normalization",
 ]
@@ -4647,6 +4936,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-single-instance"
+version = "2.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3214becf9ef5783c0ae99a3bb25adf5353a7a16ebf53e74b909e29205735c6c"
+dependencies = [
+ "serde",
+ "serde_json",
+ "tauri",
+ "thiserror 2.0.19",
+ "tokio",
+ "tracing",
+ "windows-sys 0.60.2",
+ "zbus",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4744,6 +5049,19 @@ dependencies = [
  "dunce",
  "embed-resource",
  "toml 1.1.4+spec-1.1.0",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix 1.1.4",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5034,6 +5352,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.1.3+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5100,7 +5430,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -5151,6 +5493,17 @@ name = "typenum"
 version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unic-char-property"
@@ -5567,7 +5920,7 @@ checksum = "b4ee928febd44d98f2f459a4a79bd4d928591333a494a10a868418ac1b39cf1f"
 dependencies = [
  "either",
  "home",
- "rustix",
+ "rustix 0.38.44",
  "winsafe",
 ]
 
@@ -5593,7 +5946,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6016,6 +6369,9 @@ name = "winnow"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winreg"
@@ -6173,6 +6529,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5db4be7c075cb421e4b7ee645541604239bd243ba7c357511f4ff3a74b555907"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix 1.1.4",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.4",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2990635d09ade6df1868f72f8cac69a876a90981e8bd3c40b1be413f8dc88f40"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8bf88b4a3ff53e883001e0e0115b297a9d53c31b9c1edd2bfdd853e3428624e"
+dependencies = [
+ "serde",
+ "winnow 1.0.4",
+ "zvariant",
+]
+
+[[package]]
+name = "zcheapstr"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1afec51604565183aeb5c54c20aeab286120d4e4460f7f76e3e8bb8c0d99473"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "zerofrom"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6245,4 +6671,45 @@ dependencies = [
  "potential_utf",
  "resb",
  "serde",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e28c25bd8bb8da5a1f3e7065d0c156b9ee9a7973adf78b0e35eaefdf3b1b5c"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 1.0.4",
+ "zcheapstr",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d496a145685283b67e232bd9e47377f6b60ad9d51e3601b23867f77c42477f96"
+dependencies = [
+ "proc-macro-crate 3.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 3.0.3",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6b84ebb462416c27cdb97f2e7f5f0ccc844da1fe2ecc7121e1b690b41318bf42"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 3.0.3",
+ "winnow 1.0.4",
 ]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -77,16 +77,10 @@ fontcull-write-fonts = "0.44"
 unicode-normalization = "0.1"
 sys-locale = "0.3"
 env_logger = "0.11"
-# Used by the chain feature's pre-resolved subset payload to encode
-# Vec<u8> as base64 instead of the JSON `[byte, byte, ...]` form. The
-# JSON-array form expands ~4-5× per byte (decimal text + comma + space)
-# and pressures V8's heap on the per-font MAX_FONT_DATA_SIZE budget
-# (64 MB, defined in src/fonts.rs); base64 is ~1.33× and decoded in
-# TS via the local byte decoder. A previous comment
-# of CUMULATIVE_FALLBACK_BYTES was a phantom citation; that symbol
-# was removed along with the fontcull-parse-fail fallback
-# path. The justification is still load-bearing: MAX_FONT_DATA_SIZE
-# guards subset_font's data return on the Ok path.)
+# Used by CLI wire formats that carry pre-resolved subset payloads and by
+# the GUI's Apple fallback. JSON `[byte, byte, ...]` expands ~4-5× per byte;
+# base64 is ~1.33×. Windows/Linux GUI IPC uses Tauri's raw `ipc::Response`,
+# while Tauri 2.11's macOS/iOS eval path would serialize raw bytes as JSON.
 base64 = { version = "0.23", default-features = false, features = ["std"] }
 # Direct dep on rfd matches the transitive version pulled in by
 # tauri-plugin-dialog. Used at app setup to surface init failures via a

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -95,6 +95,9 @@ base64 = { version = "0.23", default-features = false, features = ["std"] }
 # on Linux/BSD.
 rfd = { version = "0.16", default-features = false }
 
+[target.'cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))'.dependencies]
+tauri-plugin-single-instance = "2.4.3"
+
 [dev-dependencies]
 glob = "0.3.3"
 

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -4,6 +4,9 @@ fn main() {
 }
 
 fn copy_cli_engine_bundle() {
+    const ENGINE_BUNDLE_GLOBAL_TOKEN: &str = "ssaHdrifyCliEngine";
+    const ENGINE_BUNDLE_COMPLETION_MARKER: &str = "/* ssahdrify-engine-bundle-complete */";
+
     let manifest_dir = std::path::PathBuf::from(
         std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set by Cargo"),
     );
@@ -21,17 +24,28 @@ fn copy_cli_engine_bundle() {
     // build still succeeds, but a non-NotFound error gets a
     // cargo:warning so the developer notices the underlying cause.
     let source = match std::fs::read_to_string(&source_path) {
-        Ok(content) if content.is_empty() => {
-            // A 0-byte engine.js is the
-            // signature of a partial-write from a still-running
-            // `npm run build:engine`, or a manually-truncated bundle
-            // from a botched edit. Previously we'd embed the empty
-            // string and let V8 fail at runtime with an inscrutable
+        Ok(content) if content.trim().is_empty() => {
+            // An empty or whitespace-only engine.js indicates a partial
+            // write from a still-running `npm run build:engine`, or other
+            // unexpected build output. Previously we'd embed that content
+            // and let V8 fail at runtime with an inscrutable
             // "ssaHdrifyCliEngine is undefined" — the cargo:warning
             // surfaces the underlying cause at build time. Fall
             // through to the stub so the build still succeeds.
             println!(
-                "cargo:warning=CLI engine bundle at {} is 0 bytes (partial write or truncation?); falling back to stub",
+                "cargo:warning=CLI engine bundle at {} is empty or whitespace-only (partial or unexpected build output?); falling back to stub",
+                source_path.display()
+            );
+            missing_engine_stub()
+        }
+        Ok(content)
+            if !content.contains(ENGINE_BUNDLE_GLOBAL_TOKEN)
+                || !content
+                    .trim_end()
+                    .ends_with(ENGINE_BUNDLE_COMPLETION_MARKER) =>
+        {
+            println!(
+                "cargo:warning=CLI engine bundle at {} failed its global-token/completion-marker sanity check (partial or unexpected build output?); falling back to stub",
                 source_path.display()
             );
             missing_engine_stub()

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "Default permissions for the desktop window. fs:scope is allow=** + deny-list for sensitive locations (credentials, browser profiles, shell history, jump lists, app's own session DB); plugin-fs command ACL scope stays defined here for policy parity, and Rust-side safe_io / encoding commands build an app-owned tauri::fs::Scope from this same JSON via fs_policy.rs. Frontend overwrite preflight and file reads/writes/copy/rename route through Rust commands with extension, reparse-point, and scope checks; no direct plugin-fs file command grant is exposed to the WebView. Deny-list order: $HOME → $DATA → $LOCALDATA → $APPDATA/$APPLOCALDATA → app-private. Deny-list integrity is pinned by tests/test_capabilities.rs.",
+  "description": "Default permissions for the desktop window. fs:scope is allow=** + deny-list for sensitive locations (credentials, browser profiles, shell history, jump lists, app's own session DB); plugin-fs command ACL scope stays defined here for policy parity, and Rust-side safe_io / encoding / dropzone commands build an app-owned tauri::fs::Scope from this same JSON via fs_policy.rs. Frontend overwrite preflight, file reads/writes/copy/rename, and dropped-path expansion route through Rust commands with extension, reparse-point, and scope checks; no direct plugin-fs file command grant is exposed to the WebView. Deny-list order: $HOME → $DATA → $LOCALDATA → $APPDATA/$APPLOCALDATA → app-private. Deny-list integrity is pinned by tests/test_capabilities.rs.",
   "windows": ["main"],
   "permissions": [
     "core:default",

--- a/src-tauri/src/bin/cli/engine.rs
+++ b/src-tauri/src/bin/cli/engine.rs
@@ -226,11 +226,11 @@ pub struct FontEmbedApplyResult {
 /// `output_path` is where, `notes` is the per-step diagnostic
 /// summary surfaced in the Rust shell's per-file report.
 ///
-/// `skipped_count` is the aggregate count of captions whose text
-/// exceeded MAX_CAPTION_TEXT_LEN (64 KB) across every step that
-/// parses subtitle content. The shell routes this through
-/// `emit_oversized_skipped_warning` (stderr + FileReport.warnings)
-/// to mirror the standalone HDR / Shift CLI paths. Previously the
+/// `skipped_count` is the largest per-step count of source captions whose
+/// text exceeded MAX_CAPTION_TEXT_LEN (64 KB). The maximum avoids counting
+/// a preserved cue again in each later shift step. The shell routes it through
+/// the oversized-caption warning path (stderr + FileReport.warnings) to mirror
+/// the standalone HDR / Shift CLI paths. Previously the
 /// chain side relied on a string-suffix-in-note shape the Rust
 /// shell never parsed; the typed field closes that gap.
 #[derive(Debug, Deserialize)]

--- a/src-tauri/src/bin/cli/engine.rs
+++ b/src-tauri/src/bin/cli/engine.rs
@@ -73,6 +73,8 @@ pub struct ShiftConversionRequest {
     pub input_path: String,
     pub content: String,
     pub offset_ms: i64,
+    // Keep absent optionals absent on the JS wire. The TS boundary also
+    // normalizes nullish values defensively for direct/future callers.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub threshold_ms: Option<i64>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -580,7 +582,29 @@ impl CliEngine {
 
 #[cfg(test)]
 mod tests {
-    use super::{FontEmbedApplyRequest, FontSubsetPayload};
+    use super::{FontEmbedApplyRequest, FontSubsetPayload, ShiftConversionRequest};
+
+    #[test]
+    fn shift_request_omits_both_absent_optionals_from_json_wire_shape() {
+        let request = ShiftConversionRequest {
+            input_path: r"C:\subs\episode.ass".to_string(),
+            content: "[Script Info]\n".to_string(),
+            offset_ms: 1000,
+            threshold_ms: None,
+            timing_map_rules: None,
+            output_template: "{name}.shifted{ext}".to_string(),
+        };
+
+        let json = serde_json::to_value(request).expect("request should serialize");
+        assert!(
+            json.get("thresholdMs").is_none(),
+            "None threshold must be omitted rather than serialized as null"
+        );
+        assert!(
+            json.get("timingMapRules").is_none(),
+            "None timing map must be omitted rather than serialized as null"
+        );
+    }
 
     #[test]
     fn font_subset_payload_serializes_bytes_as_base64() {

--- a/src-tauri/src/bin/cli/main.rs
+++ b/src-tauri/src/bin/cli/main.rs
@@ -5317,7 +5317,8 @@ fn group_resolved_fonts_by_face(
 ///
 /// CLI lens: `subset_font` is an in-process Rust call from this
 /// binary, not an IPC boundary. The "IPC cap" framing only applies
-/// on the GUI / Tauri path where `subset_font_b64` wraps it.
+/// on the GUI / Tauri path where `subset_font_bytes` uses raw bytes on
+/// Windows/Linux and a base64 fallback on Apple targets.
 ///
 /// Cross-language drift defense: `dedup_cap_matches_ipc_cap` in
 /// `mod tests` pins the equality with

--- a/src-tauri/src/bin/cli/main.rs
+++ b/src-tauri/src/bin/cli/main.rs
@@ -1,7 +1,7 @@
 use std::collections::HashSet;
 use std::fs;
 use std::io::ErrorKind;
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::process::ExitCode;
 use std::sync::OnceLock;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -1179,7 +1179,11 @@ fn init_logger() {
 }
 
 fn run() -> Result<ExitCode, String> {
-    let Cli { globals, command } = Cli::parse();
+    let Cli {
+        mut globals,
+        command,
+    } = Cli::parse();
+    normalize_global_paths(&mut globals)?;
 
     match command {
         Command::Hdr(args) => run_hdr(&globals, args.args, args.diagnose.mode()),
@@ -1190,6 +1194,20 @@ fn run() -> Result<ExitCode, String> {
         Command::Chain(args) => run_chain(&globals, args),
         Command::RefreshFonts(args) => run_refresh_fonts(&globals, args),
     }
+}
+
+fn normalize_global_paths(globals: &mut GlobalOptions) -> Result<(), String> {
+    globals.output_dir = globals
+        .output_dir
+        .as_deref()
+        .map(absolute_path)
+        .transpose()?;
+    globals.cache_file = globals
+        .cache_file
+        .as_deref()
+        .map(absolute_path)
+        .transpose()?;
+    Ok(())
 }
 
 fn validate_cache_file_arg(globals: &GlobalOptions) -> Result<(), String> {
@@ -1253,17 +1271,18 @@ fn run_refresh_fonts(globals: &GlobalOptions, args: RefreshFontsArgs) -> Result<
     // fail-fast before opening the cache or starting any scan. The
     // downstream scan_directory_collecting now validates too (defense
     // in depth), but the early check produces a cleaner per-arg
-    // error message at the right level. `--cache-file` (also argv untrusted-input)
-    // is already validated at the top of run() before any subcommand.
+    // error message at the right level. `--cache-file` (also argv
+    // untrusted-input) was normalized before dispatch and is validated above.
     for (dir, _scope, flag_name) in refresh_font_directory_sources(&args) {
         // Refuse non-UTF-8 paths upfront via `to_str()` rather than
         // routing `to_string_lossy()` through the validator. With
         // lossy substitution, WTF-16-surrogate / non-UTF-8 bytes
-        // become U+FFFD for the validate call while downstream scan
-        // / cache writes consume the ORIGINAL PathBuf — different
-        // bytes than what validate_ipc_path checked. Sibling pattern
-        // to the `--cache-file` refusal at the top of run().
-        let dir_str = dir.to_str().ok_or_else(|| {
+        // become U+FFFD for the validate call while downstream scan /
+        // cache writes consume the lossless normalized PathBuf — different
+        // bytes than what validate_ipc_path checked. Sibling pattern to the
+        // `--cache-file` refusal above.
+        let normalized_dir = absolute_path(dir)?;
+        let dir_str = normalized_dir.to_str().ok_or_else(|| {
             format!(
                 "{flag_name}: path contains non-UTF-8 bytes; refuse upfront so the IPC \
                  validator and the subsequent scan / cache write agree on the same \
@@ -2015,10 +2034,6 @@ impl ChainOutcomeBuilder {
         }
     }
 
-    fn replace_warnings(&mut self, new: Vec<String>) {
-        self.warnings = new;
-    }
-
     fn extend_warnings<I: IntoIterator<Item = String>>(&mut self, iter: I) {
         self.warnings.extend(iter);
     }
@@ -2402,7 +2417,7 @@ fn process_one_chain_input(
     // returns share the prediction:
     //   1. Duplicate-output-in-batch — if a prior input in this run
     //      produced the same predicted output, fail before any I/O
-    //      or V8 work. Mirrors `dedup_and_exists_check` in the
+    //      or V8 work. Mirrors `reserve_output` in the
     //      per-feature dispatchers.
     //   2. Already-exists — if --overwrite is off and the predicted
     //      path exists, skip before V8.
@@ -2495,6 +2510,9 @@ fn process_one_chain_input(
             return builder.into_failed(err);
         }
     };
+    if let Some(warning) = format_inferred_encoding_warning(globals, &read_result) {
+        builder.extend_warnings([warning]);
+    }
 
     // Build the JSON payload matching the TS-side ChainRunRequest.
     // `to_runtime_payload` is now infallible —
@@ -2528,13 +2546,11 @@ fn process_one_chain_input(
             // the whole story.
             Err((err, partial_warnings)) => {
                 evict_predicted(seen_outputs);
-                // Replace into builder so the failed-shape funnel still
-                // owns the partial warnings collected pre-Err.
-                builder.replace_warnings(partial_warnings);
+                builder.extend_warnings(partial_warnings);
                 return builder.into_failed(err);
             }
         };
-        builder.replace_warnings(embed_warnings);
+        builder.extend_warnings(embed_warnings);
         // Cumulative cap on the aggregate raw font-subset bytes
         // BEFORE the base64 +
         // serde_json marshal below. Per-font cap (MAX_FONT_DATA_SIZE,
@@ -2581,7 +2597,7 @@ fn process_one_chain_input(
         }
     };
 
-    // Surface chain's aggregated skipped-caption count through the
+    // Surface chain's deduplicated skipped-caption count through the
     // same path the standalone HDR / Shift CLIs use — stderr "⚠ ..."
     // line + append to FileReport.warnings (for --json output). An
     // older shape rode along inside an opaque chain note string that
@@ -2589,8 +2605,12 @@ fn process_one_chain_input(
     // stderr-routing and the json wire. Embed pre-resolution warnings
     // (collected above) sit in the same vec; both get surfaced via
     // the Written outcome.
-    if let Some(msgs) = format_oversized_skipped_warning(globals, result.skipped_count, &input_str)
-    {
+    if let Some(msgs) = format_oversized_caption_warning(
+        globals,
+        result.skipped_count,
+        &input_str,
+        OversizedCaptionHandling::FormatDependent,
+    ) {
         builder.extend_warnings(msgs);
     }
 
@@ -2865,7 +2885,7 @@ fn process_hdr_file(
     };
     let output = display_path(&output_path);
 
-    if let Some(early) = dedup_and_exists_check(
+    let mut reservation = match reserve_output(
         globals,
         &input_path,
         &output_path,
@@ -2873,14 +2893,16 @@ fn process_hdr_file(
         None,
         seen_outputs,
     ) {
-        return early;
-    }
+        Ok(reservation) => reservation,
+        Err(early) => return *early,
+    };
 
     if globals.dry_run {
         // Dry-run gates BEFORE the read so cheap-first lives up to its
         // name on `--dry-run` invocations: no I/O, no V8 work, just the
         // resolved path. encoding is None because we haven't read —
         // matches the cheap-first contract (Embed already does this).
+        reservation.keep();
         return planned_report(&input_path, Some(output), None);
     }
 
@@ -2888,6 +2910,11 @@ fn process_hdr_file(
         Ok(result) => result,
         Err(error) => return failed_report(&input_path, Some(output), None, error),
     };
+    let mut warnings = None;
+    append_warning(
+        &mut warnings,
+        format_inferred_encoding_warning(globals, &read_result),
+    );
 
     let request = engine::HdrConversionRequest {
         input_path: input.clone(),
@@ -2900,11 +2927,21 @@ fn process_hdr_file(
     let conversion = match engine.convert_hdr(&request) {
         Ok(result) => result,
         Err(error) => {
-            return failed_report(&input_path, Some(output), Some(read_result.encoding), error);
+            let mut report =
+                failed_report(&input_path, Some(output), Some(read_result.encoding), error);
+            report.warnings = warnings;
+            return report;
         }
     };
 
-    let warnings = format_oversized_skipped_warning(globals, conversion.skipped_count, &input);
+    if let Some(messages) = format_oversized_caption_warning(
+        globals,
+        conversion.skipped_count,
+        &input,
+        OversizedCaptionHandling::Dropped,
+    ) {
+        warnings.get_or_insert_with(Vec::new).extend(messages);
+    }
 
     // (sibling): attach warnings to the
     // failed_report on write_output failure so the oversized-caption
@@ -2922,6 +2959,8 @@ fn process_hdr_file(
         return report;
     }
 
+    reservation.keep();
+
     FileReport {
         input,
         output: Some(output),
@@ -2932,26 +2971,21 @@ fn process_hdr_file(
     }
 }
 
-/// stderr-surface the count of skipped oversized captions
-/// (>64 KB text) so CLI / chain users get the same signal the GUI shows
-/// via msg_oversized_skipped. Returns the warning string for inclusion
-/// in `FileReport.warnings` (used by --json output) so machine readers
-/// see it too. English-only per the existing convention for
-/// unconditional warnings (verbose-gated paths use `emit_verbose` /
-/// `localize` for bilingual output).
-/// Pure format helper: builds the oversized-caption warning message
-/// and returns it; does NOT `eprintln!`. Callers attach the returned
-/// `Vec<String>` to `FileReport.warnings`; the actual stderr emission
-/// happens at the existing print loops — `emit_file_report` for
-/// standalone HDR / Shift / Embed, and the `ChainFileOutcome::Written`
-/// arm for chain. A combined eprintln+return helper would cause double
-/// emission AND bypass `--quiet` at the helper's eprintln (the print
-/// loops are `!globals.quiet`-gated; a helper wouldn't be). The
-/// `format_*` name reinforces the contract.
-fn format_oversized_skipped_warning(
+#[derive(Clone, Copy)]
+enum OversizedCaptionHandling {
+    Dropped,
+    Preserved,
+    FormatDependent,
+}
+
+/// Build a bilingual oversized-caption warning for human and JSON output.
+/// The caller supplies what happened because structure-preserving ASS/VTT
+/// shifts retain the original cue while rebuilding operations omit it.
+fn format_oversized_caption_warning(
     globals: &GlobalOptions,
     skipped_count: usize,
     input: &str,
+    handling: OversizedCaptionHandling,
 ) -> Option<Vec<String>> {
     if skipped_count == 0 {
         return None;
@@ -2961,14 +2995,65 @@ fn format_oversized_skipped_warning(
     // can't be corrupted by control / BiDi chars from a crafted
     // argv.
     let input_disp = sanitize_for_display(input);
-    Some(vec![localize(
-        globals,
-        format!(
-            "Dropped {skipped_count} oversized caption(s) from {input_disp}: \
-             text exceeded 64 KB per-caption cap"
+    let message = match handling {
+        OversizedCaptionHandling::Dropped => localize(
+            globals,
+            format!(
+                "Dropped {skipped_count} oversized caption(s) from {input_disp}: \
+                 text exceeded the 64 KB per-caption processing cap"
+            ),
+            format!(
+                "已丢弃 {skipped_count} 条超大字幕（来自 {input_disp}）：单条文本超过 64 KB 的处理上限"
+            ),
         ),
-        format!("已丢弃 {skipped_count} 条超大字幕（来自 {input_disp}）：单条文本超过 64 KB 上限"),
-    )])
+        OversizedCaptionHandling::Preserved => localize(
+            globals,
+            format!(
+                "Left {skipped_count} oversized caption(s) in {input_disp} unchanged: \
+                 text exceeded the 64 KB per-caption processing cap, so timing was not adjusted"
+            ),
+            format!(
+                "{input_disp} 中有 {skipped_count} 条超大字幕超过单条 64 KB 的处理上限，已保留原内容且未调整时间"
+            ),
+        ),
+        OversizedCaptionHandling::FormatDependent => localize(
+            globals,
+            format!(
+                "Skipped processing {skipped_count} oversized caption(s) in {input_disp}: \
+                 text exceeded the 64 KB per-caption cap; depending on the chain step and format, \
+                 original content was left unchanged or omitted"
+            ),
+            format!(
+                "{input_disp} 中有 {skipped_count} 条超大字幕超过单条 64 KB 的处理上限而未处理；根据链式步骤和格式，原内容会保留不变或被省略"
+            ),
+        ),
+    };
+    Some(vec![message])
+}
+
+fn format_inferred_encoding_warning(
+    globals: &GlobalOptions,
+    result: &app_lib::encoding::ReadTextResult,
+) -> Option<String> {
+    result.inferred_without_bom.then(|| {
+        localize(
+            globals,
+            format!(
+                "Detected BOM-less {} from its byte pattern. This is a best-effort inference; verify the output.",
+                result.encoding_id
+            ),
+            format!(
+                "已根据字节模式推测该文件使用无 BOM 的 {} 编码。此结果并非完全确定，请核对输出。",
+                result.encoding_id
+            ),
+        )
+    })
+}
+
+fn append_warning(warnings: &mut Option<Vec<String>>, warning: Option<String>) {
+    if let Some(warning) = warning {
+        warnings.get_or_insert_with(Vec::new).push(warning);
+    }
 }
 
 fn load_timing_map_rules(
@@ -3079,40 +3164,62 @@ fn process_shift_file(
     }
 }
 
-// Shared post-resolve check used by HDR, Shift (cheap + heavy), and
-// Embed dispatchers. Returns `Some(FileReport)` when the file should
-// short-circuit (duplicate output in the same batch, or pre-existing
-// output without --overwrite), `None` to proceed. Encoding is taken by
-// reference so the caller can pass `Some(&read.encoding)` (heavy-first,
-// after read) or `None` (cheap-first, before read). Returns `Option`
-// rather than `Result` because FileReport is large (>128 bytes); a
-// Result variant would trip clippy::result_large_err.
-fn dedup_and_exists_check(
+struct OutputReservation<'a> {
+    seen_outputs: &'a mut HashSet<String>,
+    key: String,
+    keep: bool,
+}
+
+impl OutputReservation<'_> {
+    fn keep(&mut self) {
+        self.keep = true;
+    }
+}
+
+impl Drop for OutputReservation<'_> {
+    fn drop(&mut self) {
+        if !self.keep {
+            self.seen_outputs.remove(&self.key);
+        }
+    }
+}
+
+// Reserve a standalone output until the caller either plans or writes it.
+// Any Skip or Failed return drops the guard and releases the key, so a later
+// input can retry the same path. Boxing the large error keeps Result clippy-
+// clean without obscuring the success-path lifetime.
+fn reserve_output<'a>(
     globals: &GlobalOptions,
     input_path: &Path,
     output_path: &Path,
     output: &str,
     encoding: Option<&str>,
-    seen_outputs: &mut HashSet<String>,
-) -> Option<FileReport> {
+    seen_outputs: &'a mut HashSet<String>,
+) -> Result<OutputReservation<'a>, Box<FileReport>> {
     let cloned_encoding = || encoding.map(|s| s.to_string());
-    if !seen_outputs.insert(normalize_output_key(output_path)) {
-        return Some(failed_report(
+    let key = normalize_output_key(output_path);
+    if !seen_outputs.insert(key.clone()) {
+        return Err(Box::new(failed_report(
             input_path,
             Some(output.to_string()),
             cloned_encoding(),
             "duplicate output path in planned batch".to_string(),
-        ));
+        )));
     }
+    let reservation = OutputReservation {
+        seen_outputs,
+        key,
+        keep: false,
+    };
     if output_path_exists(globals, output_path) && !globals.overwrite {
-        return Some(skipped_report(
+        return Err(Box::new(skipped_report(
             input_path,
             Some(output.to_string()),
             cloned_encoding(),
             "output exists; pass --overwrite to replace it".to_string(),
-        ));
+        )));
     }
-    None
+    Ok(reservation)
 }
 
 fn build_shift_request(
@@ -3161,7 +3268,7 @@ fn process_shift_file_cheap_first(
     };
     let output = display_path(&output_path);
 
-    if let Some(early) = dedup_and_exists_check(
+    let mut reservation = match reserve_output(
         globals,
         &input_path,
         &output_path,
@@ -3169,13 +3276,15 @@ fn process_shift_file_cheap_first(
         None,
         seen_outputs,
     ) {
-        return early;
-    }
+        Ok(reservation) => reservation,
+        Err(early) => return *early,
+    };
 
     if globals.dry_run {
         // Dry-run gates BEFORE the read so cheap-first lives up to its
         // name on `--dry-run` invocations. encoding is None because we
         // haven't read — matches the cheap-first contract.
+        reservation.keep();
         return planned_report(&input_path, Some(output), None);
     }
 
@@ -3183,6 +3292,11 @@ fn process_shift_file_cheap_first(
         Ok(result) => result,
         Err(error) => return failed_report(&input_path, Some(output), None, error),
     };
+    let mut warnings = None;
+    append_warning(
+        &mut warnings,
+        format_inferred_encoding_warning(globals, &read_result),
+    );
 
     let request = build_shift_request(
         input.clone(),
@@ -3194,7 +3308,10 @@ fn process_shift_file_cheap_first(
     let conversion = match engine.convert_shift(&request) {
         Ok(result) => result,
         Err(error) => {
-            return failed_report(&input_path, Some(output), Some(read_result.encoding), error);
+            let mut report =
+                failed_report(&input_path, Some(output), Some(read_result.encoding), error);
+            report.warnings = warnings;
+            return report;
         }
     };
 
@@ -3211,7 +3328,18 @@ fn process_shift_file_cheap_first(
         ),
     );
 
-    let warnings = format_oversized_skipped_warning(globals, conversion.skipped_count, &input);
+    if let Some(messages) = format_oversized_caption_warning(
+        globals,
+        conversion.skipped_count,
+        &input,
+        if matches!(conversion.format.as_str(), "ass" | "vtt") {
+            OversizedCaptionHandling::Preserved
+        } else {
+            OversizedCaptionHandling::Dropped
+        },
+    ) {
+        warnings.get_or_insert_with(Vec::new).extend(messages);
+    }
 
     // (sibling): attach warnings to the
     // failed_report on write_output failure so the oversized-caption
@@ -3229,6 +3357,8 @@ fn process_shift_file_cheap_first(
         report.warnings = warnings;
         return report;
     }
+
+    reservation.keep();
 
     FileReport {
         input,
@@ -3262,6 +3392,11 @@ fn process_shift_file_heavy_first(
         Ok(result) => result,
         Err(error) => return failed_report(&input_path, None, None, error),
     };
+    let mut warnings = None;
+    append_warning(
+        &mut warnings,
+        format_inferred_encoding_warning(globals, &read_result),
+    );
 
     let request = build_shift_request(
         input.clone(),
@@ -3273,7 +3408,9 @@ fn process_shift_file_heavy_first(
     let conversion = match engine.convert_shift(&request) {
         Ok(result) => result,
         Err(error) => {
-            return failed_report(&input_path, None, Some(read_result.encoding), error);
+            let mut report = failed_report(&input_path, None, Some(read_result.encoding), error);
+            report.warnings = warnings;
+            return report;
         }
     };
 
@@ -3287,7 +3424,18 @@ fn process_shift_file_heavy_first(
     // attaching `warnings` to every FileReport returned from this
     // function (early or final), the dry-run / dedup-skip paths would
     // silently lose the warning.
-    let warnings = format_oversized_skipped_warning(globals, conversion.skipped_count, &input);
+    if let Some(messages) = format_oversized_caption_warning(
+        globals,
+        conversion.skipped_count,
+        &input,
+        if matches!(conversion.format.as_str(), "ass" | "vtt") {
+            OversizedCaptionHandling::Preserved
+        } else {
+            OversizedCaptionHandling::Dropped
+        },
+    ) {
+        warnings.get_or_insert_with(Vec::new).extend(messages);
+    }
 
     let output_path = match relocate_output_path(&conversion.output_path, context.output_dir) {
         Ok(path) => path,
@@ -3299,7 +3447,7 @@ fn process_shift_file_heavy_first(
     };
     let output = display_path(&output_path);
 
-    if let Some(mut early) = dedup_and_exists_check(
+    let mut reservation = match reserve_output(
         globals,
         &input_path,
         &output_path,
@@ -3307,15 +3455,19 @@ fn process_shift_file_heavy_first(
         Some(&read_result.encoding),
         seen_outputs,
     ) {
-        early.warnings = warnings.clone();
-        return early;
-    }
+        Ok(reservation) => reservation,
+        Err(mut early) => {
+            early.warnings = warnings.clone();
+            return *early;
+        }
+    };
 
     // Dry-run gates BEFORE the verbose progress print: a
     // `--dry-run --verbose` invocation should NOT emit the "shift: N
     // captions, M shifted" line because no shift was actually
     // committed. Matches the cheap-first path's ordering.
     if globals.dry_run {
+        reservation.keep();
         let mut planned = planned_report(&input_path, Some(output), Some(read_result.encoding));
         planned.warnings = warnings;
         return planned;
@@ -3345,6 +3497,8 @@ fn process_shift_file_heavy_first(
         report.warnings = warnings;
         return report;
     }
+
+    reservation.keep();
 
     FileReport {
         input,
@@ -3607,6 +3761,7 @@ fn diagnose_font_file(ctx: &mut DiagnoseFontContext<'_>, file: &Path) -> EmbedFi
         Ok(result) => result,
         Err(error) => return (failed_report(&input_path, None, None, error), Vec::new()),
     };
+    let inferred_warning = format_inferred_encoding_warning(ctx.globals, &read_result);
 
     let plan_request = engine::FontDiagnosticsPlanRequest {
         content: read_result.text,
@@ -3614,10 +3769,9 @@ fn diagnose_font_file(ctx: &mut DiagnoseFontContext<'_>, file: &Path) -> EmbedFi
     let plan = match ctx.engine.plan_font_diagnostics(&plan_request) {
         Ok(result) => result,
         Err(error) => {
-            return (
-                failed_report(&input_path, None, Some(read_result.encoding), error),
-                Vec::new(),
-            );
+            let mut report = failed_report(&input_path, None, Some(read_result.encoding), error);
+            append_warning(&mut report.warnings, inferred_warning);
+            return (report, Vec::new());
         }
     };
 
@@ -3631,7 +3785,8 @@ fn diagnose_font_file(ctx: &mut DiagnoseFontContext<'_>, file: &Path) -> EmbedFi
     ) {
         Ok(outcome) => {
             let mut diagnostics = outcome.diagnostics;
-            let mut warnings = outcome.warnings;
+            let mut warnings: Vec<String> = inferred_warning.into_iter().collect();
+            warnings.extend(outcome.warnings);
             if ctx.subset_check {
                 warnings.extend(apply_subset_checks_to_diagnostics(
                     &outcome.resolved,
@@ -3656,10 +3811,12 @@ fn diagnose_font_file(ctx: &mut DiagnoseFontContext<'_>, file: &Path) -> EmbedFi
                 diagnostics,
             )
         }
-        Err(error) => (
-            failed_report(&input_path, None, Some(read_result.encoding), error.error),
-            error.diagnostics,
-        ),
+        Err(error) => {
+            let mut report =
+                failed_report(&input_path, None, Some(read_result.encoding), error.error);
+            append_warning(&mut report.warnings, inferred_warning);
+            (report, error.diagnostics)
+        }
     }
 }
 
@@ -4593,7 +4750,7 @@ fn process_embed_file(
     };
     let output = display_path(&output_path);
 
-    if let Some(early) = dedup_and_exists_check(
+    let mut reservation = match reserve_output(
         globals,
         &input_path,
         &output_path,
@@ -4601,14 +4758,16 @@ fn process_embed_file(
         None,
         seen_outputs,
     ) {
-        return (early, Vec::new());
-    }
+        Ok(reservation) => reservation,
+        Err(early) => return (*early, Vec::new()),
+    };
 
     if globals.dry_run {
         // Dry-run for embed reports the planned output path without
         // doing font discovery or content parsing — matches HDR/Shift
         // dry-run behavior and avoids the surprise of "dry-run scanned
         // 17k fonts then planned no actual write."
+        reservation.keep();
         return (planned_report(&input_path, Some(output), None), Vec::new());
     }
 
@@ -4621,6 +4780,9 @@ fn process_embed_file(
             )
         }
     };
+    let mut warnings: Vec<String> = format_inferred_encoding_warning(globals, &read_result)
+        .into_iter()
+        .collect();
 
     let plan_request = engine::FontEmbedPlanRequest {
         input_path: input.clone(),
@@ -4630,14 +4792,14 @@ fn process_embed_file(
     let plan = match engine.plan_font_embed(&plan_request) {
         Ok(result) => result,
         Err(error) => {
-            return (
-                failed_report(&input_path, Some(output), Some(read_result.encoding), error),
-                Vec::new(),
-            );
+            let mut report =
+                failed_report(&input_path, Some(output), Some(read_result.encoding), error);
+            if !warnings.is_empty() {
+                report.warnings = Some(warnings);
+            }
+            return (report, Vec::new());
         }
     };
-
-    let mut warnings: Vec<String> = Vec::new();
 
     let mut font_diagnostics = Vec::new();
     let resolved_fonts = match resolve_embed_fonts(
@@ -4655,15 +4817,16 @@ fn process_embed_file(
         }
         Err(mut error) => {
             font_diagnostics.append(&mut error.diagnostics);
-            return (
-                failed_report(
-                    &input_path,
-                    Some(output),
-                    Some(read_result.encoding),
-                    error.error,
-                ),
-                font_diagnostics,
+            let mut report = failed_report(
+                &input_path,
+                Some(output),
+                Some(read_result.encoding),
+                error.error,
             );
+            if !warnings.is_empty() {
+                report.warnings = Some(warnings);
+            }
+            return (report, font_diagnostics);
         }
     };
 
@@ -4776,6 +4939,8 @@ fn process_embed_file(
             font_diagnostics,
         );
     }
+
+    reservation.keep();
 
     (
         FileReport {
@@ -6479,21 +6644,62 @@ fn planned_report(
     }
 }
 
-// Trust model: --output-dir is user-controlled CLI argument. We
-// normalize it to absolute form here but DO NOT canonicalize (which
+// Trust model: CLI path arguments are user-controlled. We normalize
+// them to absolute form here but DO NOT canonicalize (which
 // would resolve symlinks). On Windows, fs::canonicalize returns the
 // `\\?\C:\...` extended-path form which surprises downstream tools;
 // on POSIX it would silently follow symlinks the user may have set
 // up intentionally. The trust boundary is "the user supplied this
 // path" — any symlinks they set up are theirs to manage.
 fn absolute_path(path: &Path) -> Result<PathBuf, String> {
-    if path.is_absolute() {
-        return Ok(path.to_path_buf());
+    if !path.is_absolute() && matches!(path.components().next(), Some(Component::Prefix(_))) {
+        return Err(format!(
+            "drive-relative paths are ambiguous; use an absolute path such as C:\\folder\\file or a normal relative path: {}",
+            sanitize_for_display(&path.display().to_string())
+        ));
     }
 
-    std::env::current_dir()
-        .map(|cwd| cwd.join(path))
-        .map_err(|err| format!("failed to resolve current directory: {err}"))
+    let joined = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        std::env::current_dir()
+            .map_err(|err| format!("failed to resolve current directory: {err}"))?
+            .join(path)
+    };
+
+    // CLI argv is explicitly user-controlled and may naturally contain
+    // `.` / `..`. Fold those components before the shared strict IPC path
+    // validator sees the path. This is lexical on purpose: output targets
+    // may not exist yet, and canonicalization would follow user-managed
+    // symlinks plus introduce Windows `\\?\` paths. GUI IPC remains strict
+    // and never calls this helper.
+    let mut normalized = PathBuf::new();
+    for component in joined.components() {
+        match component {
+            Component::Prefix(prefix) => normalized.push(prefix.as_os_str()),
+            Component::RootDir => normalized.push(component.as_os_str()),
+            Component::CurDir => {}
+            Component::ParentDir => {
+                if normalized.file_name().is_some() {
+                    normalized.pop();
+                } else if !normalized.has_root() {
+                    return Err(format!(
+                        "path escapes its filesystem root: {}",
+                        sanitize_for_display(&joined.display().to_string())
+                    ));
+                }
+            }
+            Component::Normal(segment) => normalized.push(segment),
+        }
+    }
+
+    if !normalized.is_absolute() {
+        return Err(format!(
+            "failed to resolve an absolute path from: {}",
+            sanitize_for_display(&joined.display().to_string())
+        ));
+    }
+    Ok(normalized)
 }
 
 // Cap on the relocated output path — Windows MAX_PATH minus one.
@@ -6691,7 +6897,7 @@ fn display_path(path: &Path) -> String {
     // make `evil\u{202e}.ass` silently resolve to a sibling
     // `evil.ass`, picking the wrong file at read / write time.
     // Display-time sanitization belongs at the print sites
-    // (`emit_file_report`, `format_oversized_skipped_warning`, etc.)
+    // (`emit_file_report`, `format_oversized_caption_warning`, etc.)
     // via `sanitize_for_display`.
     let raw = path.to_string_lossy().into_owned();
     if cfg!(windows) {
@@ -7005,7 +7211,7 @@ mod tests {
     #[cfg(unix)]
     use super::run_refresh_fonts;
     use super::{
-        apply_effective_embedded_font_names, apply_subset_checks_to_diagnostics,
+        absolute_path, apply_effective_embedded_font_names, apply_subset_checks_to_diagnostics,
         build_font_qa_summary, check_cache_drift, classify_locale, copy_file_output,
         create_cli_font_db_dir, diagnostic_next_actions, display_path,
         duplicate_rename_output_keys, engine, group_resolved_fonts_by_face, normalize_output_key,
@@ -7030,6 +7236,50 @@ mod tests {
     use clap::{CommandFactory, Parser};
     use std::fs;
     use std::path::{Path, PathBuf};
+
+    #[test]
+    fn absolute_path_folds_cli_dot_and_parent_components_without_touching_names() {
+        let cwd = std::env::current_dir().unwrap();
+        let normalized = absolute_path(Path::new("one/./two/../three/file..name.ass")).unwrap();
+
+        assert_eq!(
+            normalized,
+            cwd.join("one").join("three").join("file..name.ass")
+        );
+        assert!(normalized.is_absolute());
+        assert!(!normalized
+            .components()
+            .any(|component| matches!(component, std::path::Component::ParentDir)));
+    }
+
+    #[test]
+    fn absolute_path_clamps_parent_components_at_the_filesystem_root() {
+        let cwd = std::env::current_dir().unwrap();
+        let root = cwd.ancestors().last().unwrap();
+
+        assert_eq!(
+            absolute_path(&root.join("..").join("output.ass")).unwrap(),
+            root.join("output.ass")
+        );
+        assert_eq!(
+            absolute_path(&root.join("folder").join("..").join("..").join("output.ass")).unwrap(),
+            root.join("output.ass")
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn absolute_path_handles_rooted_windows_paths_and_rejects_drive_relative_paths() {
+        let cwd = std::env::current_dir().unwrap();
+        let root = cwd.ancestors().last().unwrap();
+
+        assert_eq!(
+            absolute_path(Path::new(r"\ssahdrify-test\file.ass")).unwrap(),
+            root.join("ssahdrify-test").join("file.ass")
+        );
+        let error = absolute_path(Path::new(r"C:ssahdrify-test\file.ass")).unwrap_err();
+        assert!(error.contains("drive-relative paths are ambiguous"));
+    }
 
     /// pin the cross-module constant equality. The CLI's
     /// dedup cap MUST equal the IPC cap inside fonts.rs — the dedup
@@ -8319,7 +8569,7 @@ mod tests {
     #[test]
     fn sanitize_for_display_strips_control_and_bidi() {
         // The display-time sanitizer companion to display_path. Used
-        // at `emit_file_report` and `format_oversized_skipped_warning`
+        // at `emit_file_report` and `format_oversized_caption_warning`
         // to laundering paths before stderr/println interpolation,
         // so a crafted argv filename can't corrupt the terminal.
         assert_eq!(

--- a/src-tauri/src/bin/cli/main.rs
+++ b/src-tauri/src/bin/cli/main.rs
@@ -5775,7 +5775,10 @@ fn expand_rename_inputs(globals: &GlobalOptions, paths: &[PathBuf]) -> Result<Ve
         .iter()
         .map(|path| absolute_path(path).map(|path| display_path(&path)))
         .collect();
-    let expanded = app_lib::dropzone::expand_dropped_paths(absolute_paths?)?;
+    // CLI argv paths are user-authored and have no Tauri AppHandle. Bypass
+    // only the GUI filesystem scope while retaining validation, reparse-point
+    // rejection, one-level walking, and both path-count caps.
+    let expanded = app_lib::dropzone::expand_dropped_paths_inner(absolute_paths?, |_| true)?;
 
     if expanded.files.is_empty() {
         return Err("no regular files found in rename input paths".to_string());
@@ -6824,8 +6827,9 @@ fn output_path_exists(globals: &GlobalOptions, path: &Path) -> bool {
 //   - `check_subtitle_extension` confines the destination to the
 //     subtitle-extension whitelist (defense-in-depth against argv
 //     typo redirecting to `.desktop` / `.lnk` persistence paths).
-//   - `clear_existing_destination` lstat's the destination before any
-//     remove_file (refuses reparse points there).
+//   - write / copy use `clear_existing_destination` before replacement;
+//     rename uses non-mutating destination inspection so an OS rename
+//     failure cannot erase the prior destination. Both reject reparse points.
 //   - copy / rename additionally enforce `reject_reparse_source` +
 //     `reject_same_canonical_path` (the case-only NTFS self-overwrite
 //     trap closed for the GUI) + the late re-check before
@@ -6839,10 +6843,10 @@ fn output_path_exists(globals: &GlobalOptions, path: &Path) -> bool {
 // owns all decisions internally. Higher-level callers still use
 // `output_path_exists` (preserved as a standalone CLI helper above)
 // for the cheap-first skip-when-exists check + `--quiet`-respecting
-// stderr WARN on stat failure. safe_io's `clear_existing_destination`
-// provides the second-layer fail-shut on the race between the higher-
-// level check and the write. Error wording at the safe_io boundary
-// bubbles through `failed_report` and is sanitized at the print
+// stderr WARN on stat failure. safe_io's destination inspection/removal
+// helpers provide the second-layer fail-shut on the race between the higher-
+// level check and the final filesystem operation. Error wording at the safe_io
+// boundary bubbles through `failed_report` and is sanitized at the print
 // boundary by `emit_file_report`'s `sanitize_for_display`.
 fn write_output(
     _globals: &GlobalOptions,

--- a/src-tauri/src/bin/cli/main.rs
+++ b/src-tauri/src/bin/cli/main.rs
@@ -1186,10 +1186,19 @@ fn run() -> Result<ExitCode, String> {
     normalize_global_paths(&mut globals)?;
 
     match command {
-        Command::Hdr(args) => run_hdr(&globals, args.args, args.diagnose.mode()),
-        Command::Shift(args) => run_shift(&globals, args.args, args.diagnose.mode()),
+        Command::Hdr(args) => {
+            emit_inert_cache_flags_notice(&globals, "hdr");
+            run_hdr(&globals, args.args, args.diagnose.mode())
+        }
+        Command::Shift(args) => {
+            emit_inert_cache_flags_notice(&globals, "shift");
+            run_shift(&globals, args.args, args.diagnose.mode())
+        }
         Command::Embed(args) => run_embed(&globals, args.args, args.diagnose.mode()),
-        Command::Rename(args) => run_rename(&globals, args.args, args.diagnose.mode()),
+        Command::Rename(args) => {
+            emit_inert_cache_flags_notice(&globals, "rename");
+            run_rename(&globals, args.args, args.diagnose.mode())
+        }
         Command::DiagnoseFonts(args) => run_diagnose_fonts(&globals, args),
         Command::Chain(args) => run_chain(&globals, args),
         Command::RefreshFonts(args) => run_refresh_fonts(&globals, args),
@@ -1208,6 +1217,35 @@ fn normalize_global_paths(globals: &mut GlobalOptions) -> Result<(), String> {
         .map(absolute_path)
         .transpose()?;
     Ok(())
+}
+
+fn emit_inert_cache_flags_notice(globals: &GlobalOptions, command: &str) {
+    if globals.quiet {
+        return;
+    }
+
+    let mut inert = Vec::new();
+    if globals.no_cache {
+        inert.push("--no-cache");
+    }
+    if globals.cache_file.is_some() {
+        inert.push("--cache-file");
+    }
+    if inert.is_empty() {
+        return;
+    }
+
+    let flags = inert.join(", ");
+    eprintln!(
+        "{}",
+        localize(
+            globals,
+            format!(
+                "ℹ {command} does not use the persistent font cache; these flags have no effect here: {flags}"
+            ),
+            format!("ℹ {command} 不使用持久字体缓存；以下参数在此无效：{flags}"),
+        )
+    );
 }
 
 fn validate_cache_file_arg(globals: &GlobalOptions) -> Result<(), String> {
@@ -2568,23 +2606,19 @@ fn process_one_chain_input(
                  or split the subtitle before embedding"
             ));
         }
-        // Encode subset bytes as base64 strings. The previous form
-        // (`{ "data": [byte, byte, ...] }`) expanded ~4-5× per byte
-        // when serde_json wrote bytes as decimal+comma JSON-in-JS-source,
-        // which compounded against the per-font MAX_FONT_DATA_SIZE
-        // budget (64 MB, defined in fonts.rs) into heavy V8 heap
-        // pressure on the worst-case path. Base64 is ~1.33× and
-        // decoded in TS via the local base64 byte decoder because bare
-        // deno_core has no Web API globals like atob().
-        let subsets_json: Vec<serde_json::Value> = subsets
-            .into_iter()
-            .map(|s| {
-                use base64::Engine as _;
-                let data_b64 = base64::engine::general_purpose::STANDARD.encode(&s.data);
-                serde_json::json!({ "fontName": s.font_name, "dataB64": data_b64 })
-            })
-            .collect();
-        payload["plan"]["steps"][idx]["params"]["subsets"] = serde_json::Value::Array(subsets_json);
+        // Serialize the canonical FontSubsetPayload wire type only after
+        // enforcing the raw-byte cap above. Its custom serializer owns the
+        // dataB64 representation, keeping standalone embed and chain from
+        // drifting into two hand-written payload shapes.
+        let subsets_json = match serde_json::to_value(&subsets) {
+            Ok(value) => value,
+            Err(error) => {
+                evict_predicted(seen_outputs);
+                return builder
+                    .into_failed(format!("failed to serialize chain embed subsets: {error}"));
+            }
+        };
+        payload["plan"]["steps"][idx]["params"]["subsets"] = subsets_json;
     }
 
     let request = engine::ChainRunRequest { payload };
@@ -7009,7 +7043,8 @@ fn emit_verbose(globals: &GlobalOptions, en: String, zh: String) {
 
 fn emit_verbose_err(globals: &GlobalOptions, en: String, zh: String) {
     if globals.verbose && !globals.json && !globals.quiet {
-        eprintln!("{}", localize(globals, en, zh));
+        let message = localize(globals, en, zh);
+        eprintln!("{}", sanitize_for_display(&message));
     }
 }
 

--- a/src-tauri/src/dropzone.rs
+++ b/src-tauri/src/dropzone.rs
@@ -80,28 +80,6 @@ where
     let mut rejected = 0usize;
     let total_inputs = paths.len();
     for (idx, raw) in paths.iter().enumerate() {
-        // Short-circuit at the TOP of the loop body once the result
-        // cap is hit. The cap check used to sit after the
-        // per-path stat + walk_one_level call, so the worst case
-        // (1000 input folders, first ~50 already filled `result` to
-        // MAX_RESULT_FILES = 5000) still paid stat + read_dir on
-        // every remaining input. The bottom-of-loop check at line
-        // ~128 below handles the case where the LAST iteration pushed
-        // the result to the cap (it uses `idx + 1 < total_inputs`
-        // because the work for this iteration is already done);
-        // this top-of-loop check is the cheap-first sibling for
-        // every SUBSEQUENT iteration — by construction `idx <
-        // total_inputs` holds for any iteration body that runs, so
-        // entering this branch means there's at least one more input
-        // we're skipping. The redundant `if idx < total_inputs`
-        // guard that wrapped `truncated = true` was dropped — it was
-        // always true by construction. `walk_one_level`
-        // itself has the same check at its inner loop top, so this
-        // is the third layer of the same budget.
-        if result.len() >= MAX_RESULT_FILES {
-            truncated = true;
-            break;
-        }
         // Skip silently rather than fail — native drag-drop shouldn't
         // produce empty / oversize / control-char paths, but the IPC
         // boundary trusts no caller, and dropping ONE bad path should

--- a/src-tauri/src/dropzone.rs
+++ b/src-tauri/src/dropzone.rs
@@ -7,11 +7,11 @@
 //! into video vs subtitle is the consumer's job; this command's contract
 //! is only "give me the regular files behind these dropped paths".
 //!
-//! Defense: skip hidden entries, symlinks, and reparse points so a
-//! mistakenly-dropped junction can't fan out into a protected directory
-//! (`.ssh`, OneDrive, etc.). The downstream readers (encoding.rs,
-//! fonts.rs) enforce their own extension/provenance allowlists, so even
-//! a path leak here can't be turned into an arbitrary read.
+//! Defense: apply the app-owned filesystem scope before touching each
+//! dropped path and before returning discovered children. Hidden entries,
+//! symlinks, and reparse points are also skipped so a mistakenly-dropped
+//! junction can't fan out into a protected directory (`.ssh`, OneDrive,
+//! etc.).
 
 use crate::util::{is_reparse_point, MAX_INPUT_PATHS};
 use serde::Serialize;
@@ -55,9 +55,16 @@ impl Default for ExpandedPaths {
     }
 }
 
-/// Expand dropped paths into a flat list of file paths.
-#[tauri::command]
-pub fn expand_dropped_paths(paths: Vec<String>) -> Result<ExpandedPaths, String> {
+/// Expand dropped paths into a flat list of file paths under an injected
+/// filesystem-scope policy. The GUI supplies its app-owned scope; the CLI
+/// supplies an allow-all predicate because argv paths are user-authored.
+pub fn expand_dropped_paths_inner<F>(
+    paths: Vec<String>,
+    is_allowed: F,
+) -> Result<ExpandedPaths, String>
+where
+    F: Fn(&Path) -> bool,
+{
     if paths.is_empty() {
         return Ok(ExpandedPaths::default());
     }
@@ -104,6 +111,15 @@ pub fn expand_dropped_paths(paths: Vec<String>) -> Result<ExpandedPaths, String>
             continue;
         }
         let p = Path::new(raw);
+        // Scope-gate before stat/read_dir so a compromised WebView cannot
+        // use this command to probe or enumerate a deny-listed path. Keep
+        // the warning path-free: the aggregate count below is sufficient,
+        // and denied child names must never become a disclosure channel.
+        if !is_allowed(p) {
+            log::warn!("dropzone: skipping path denied by filesystem scope");
+            rejected += 1;
+            continue;
+        }
         let meta = match std::fs::symlink_metadata(p) {
             Ok(m) => m,
             Err(e) => {
@@ -125,7 +141,7 @@ pub fn expand_dropped_paths(paths: Vec<String>) -> Result<ExpandedPaths, String>
             // walk_one_level returns true only when it stopped
             // mid-folder with more entries pending — that's the
             // intra-folder truncation signal.
-            if walk_one_level(p, &mut result) {
+            if walk_one_level(p, &mut result, &is_allowed) {
                 truncated = true;
             }
         }
@@ -166,6 +182,17 @@ pub fn expand_dropped_paths(paths: Vec<String>) -> Result<ExpandedPaths, String>
     })
 }
 
+/// Tauri command wrapper. Resolve the app-owned scope before any path is
+/// touched, then delegate to the testable inner implementation.
+#[tauri::command]
+pub fn expand_dropped_paths(
+    app: tauri::AppHandle,
+    paths: Vec<String>,
+) -> Result<ExpandedPaths, String> {
+    let scope = crate::fs_policy::app_fs_scope(&app)?;
+    expand_dropped_paths_inner(paths, move |path| scope.is_allowed(path))
+}
+
 /// Read a directory one level deep, appending regular files. Hidden
 /// entries (Unix dotfiles) and reparse points are skipped.
 ///
@@ -183,7 +210,10 @@ pub fn expand_dropped_paths(paths: Vec<String>) -> Result<ExpandedPaths, String>
 /// latter case we report `false` because no remainder existed in
 /// this folder. The caller still independently checks `idx + 1 <
 /// total_inputs` for the cross-input case.
-fn walk_one_level(dir: &Path, out: &mut Vec<String>) -> bool {
+fn walk_one_level<F>(dir: &Path, out: &mut Vec<String>, is_allowed: &F) -> bool
+where
+    F: Fn(&Path) -> bool,
+{
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
         Err(e) => {
@@ -219,6 +249,13 @@ fn walk_one_level(dir: &Path, out: &mut Vec<String>) -> bool {
             if name.starts_with('.') {
                 continue;
             }
+        }
+        // A parent directory may be allowed while an exact child path is
+        // denied. Filter before metadata/type inspection and never log the
+        // child name, otherwise the expansion response or logs would leak
+        // the denied entry discovered by read_dir.
+        if !is_allowed(&entry_path) {
+            continue;
         }
         if is_reparse_point(&entry_path) {
             continue;
@@ -283,12 +320,17 @@ mod tests {
         dir
     }
 
+    fn allow_all(_: &std::path::Path) -> bool {
+        true
+    }
+
     #[test]
     fn passes_through_files_unchanged() {
         let dir = make_tempdir("passthrough");
         let p = dir.join("a.ass");
         fs::File::create(&p).unwrap().write_all(b"x").unwrap();
-        let result = expand_dropped_paths(vec![p.to_str().unwrap().to_string()]).unwrap();
+        let result =
+            expand_dropped_paths_inner(vec![p.to_str().unwrap().to_string()], allow_all).unwrap();
         assert_eq!(result.files.len(), 1);
         assert!(!result.truncated);
         // The response carries the cap so the frontend banner
@@ -314,7 +356,8 @@ mod tests {
             .write_all(b"x")
             .unwrap();
 
-        let result = expand_dropped_paths(vec![dir.to_str().unwrap().to_string()]).unwrap();
+        let result =
+            expand_dropped_paths_inner(vec![dir.to_str().unwrap().to_string()], allow_all).unwrap();
         assert_eq!(
             result.files.len(),
             3,
@@ -339,9 +382,72 @@ mod tests {
             .unwrap()
             .write_all(b"x")
             .unwrap();
-        let result = expand_dropped_paths(vec![dir.to_str().unwrap().to_string()]).unwrap();
+        let result =
+            expand_dropped_paths_inner(vec![dir.to_str().unwrap().to_string()], allow_all).unwrap();
         assert_eq!(result.files.len(), 1);
         assert!(result.files[0].ends_with("visible.ass"));
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scope_denied_top_level_directory_is_not_enumerated() {
+        let dir = make_tempdir("scope_denied_directory");
+        fs::File::create(dir.join("must-not-leak.ass"))
+            .unwrap()
+            .write_all(b"x")
+            .unwrap();
+
+        // Deny only the root while allowing its child. If the root gate is
+        // ever dropped, the walk will expose must-not-leak.ass and fail.
+        let denied_root = dir.clone();
+        let result =
+            expand_dropped_paths_inner(vec![dir.to_str().unwrap().to_string()], move |path| {
+                path != denied_root.as_path()
+            })
+            .unwrap();
+
+        assert!(result.files.is_empty());
+        assert!(!result.truncated);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scope_denied_top_level_file_is_not_returned() {
+        let dir = make_tempdir("scope_denied_file");
+        let file = dir.join("denied.ass");
+        fs::File::create(&file).unwrap().write_all(b"x").unwrap();
+
+        let denied_file = file.clone();
+        let result =
+            expand_dropped_paths_inner(vec![file.to_str().unwrap().to_string()], move |path| {
+                path != denied_file.as_path()
+            })
+            .unwrap();
+
+        assert!(result.files.is_empty());
+        assert!(!result.truncated);
+        let _ = fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn scope_denied_child_is_skipped_without_poisoning_siblings() {
+        let dir = make_tempdir("scope_denied_child");
+        let allowed = dir.join("allowed.ass");
+        let denied = dir.join("denied.ass");
+        fs::File::create(&allowed).unwrap().write_all(b"x").unwrap();
+        fs::File::create(&denied).unwrap().write_all(b"x").unwrap();
+
+        let denied_child = denied.clone();
+        let result =
+            expand_dropped_paths_inner(vec![dir.to_str().unwrap().to_string()], move |path| {
+                path != denied_child.as_path()
+            })
+            .unwrap();
+
+        assert_eq!(result.files.len(), 1);
+        assert!(result.files[0].ends_with("allowed.ass"));
+        assert!(!result.files.iter().any(|path| path.ends_with("denied.ass")));
+        assert!(!result.truncated);
         let _ = fs::remove_dir_all(&dir);
     }
 
@@ -350,7 +456,7 @@ mod tests {
         let many: Vec<String> = (0..(MAX_INPUT_PATHS + 1))
             .map(|i| format!("/tmp/x{i}.ass"))
             .collect();
-        assert!(expand_dropped_paths(many).is_err());
+        assert!(expand_dropped_paths_inner(many, allow_all).is_err());
     }
 
     /// (boundary-pair discipline): the
@@ -365,7 +471,7 @@ mod tests {
         let at_limit: Vec<String> = (0..MAX_INPUT_PATHS)
             .map(|i| format!("/tmp/x{i}.ass"))
             .collect();
-        let result = expand_dropped_paths(at_limit);
+        let result = expand_dropped_paths_inner(at_limit, allow_all);
         assert!(
             result.is_ok(),
             "exactly MAX_INPUT_PATHS entries should not trigger the cap-reject; \
@@ -375,7 +481,9 @@ mod tests {
 
     #[test]
     fn rejects_control_chars_in_path() {
-        let result = expand_dropped_paths(vec!["/tmp/foo\u{0000}bar.ass".to_string()]).unwrap();
+        let result =
+            expand_dropped_paths_inner(vec!["/tmp/foo\u{0000}bar.ass".to_string()], allow_all)
+                .unwrap();
         // Silently skipped, not errored.
         assert!(result.files.is_empty());
         assert!(!result.truncated);
@@ -383,7 +491,7 @@ mod tests {
 
     #[test]
     fn empty_input_returns_empty() {
-        let result = expand_dropped_paths(Vec::new()).unwrap();
+        let result = expand_dropped_paths_inner(Vec::new(), allow_all).unwrap();
         assert!(result.files.is_empty());
         assert!(!result.truncated);
     }
@@ -404,10 +512,13 @@ mod tests {
             .unwrap()
             .write_all(b"x")
             .unwrap();
-        let result = expand_dropped_paths(vec![
-            folder.to_str().unwrap().to_string(),
-            standalone.to_str().unwrap().to_string(),
-        ])
+        let result = expand_dropped_paths_inner(
+            vec![
+                folder.to_str().unwrap().to_string(),
+                standalone.to_str().unwrap().to_string(),
+            ],
+            allow_all,
+        )
         .unwrap();
         assert_eq!(
             result.files.len(),
@@ -431,7 +542,8 @@ mod tests {
                 .write_all(b"x")
                 .unwrap();
         }
-        let result = expand_dropped_paths(vec![dir.to_str().unwrap().to_string()]).unwrap();
+        let result =
+            expand_dropped_paths_inner(vec![dir.to_str().unwrap().to_string()], allow_all).unwrap();
         assert_eq!(
             result.files.len(),
             MAX_RESULT_FILES,
@@ -456,7 +568,8 @@ mod tests {
                 .write_all(b"x")
                 .unwrap();
         }
-        let result = expand_dropped_paths(vec![dir.to_str().unwrap().to_string()]).unwrap();
+        let result =
+            expand_dropped_paths_inner(vec![dir.to_str().unwrap().to_string()], allow_all).unwrap();
         assert_eq!(result.files.len(), MAX_RESULT_FILES);
         assert!(
             !result.truncated,

--- a/src-tauri/src/dropzone.rs
+++ b/src-tauri/src/dropzone.rs
@@ -182,9 +182,9 @@ where
     })
 }
 
-/// Tauri command wrapper. Resolve the app-owned scope before any path is
-/// touched, then delegate to the testable inner implementation.
-#[tauri::command]
+/// Blocking command implementation. The async Tauri boundary in
+/// `ipc_commands` moves scope resolution and path expansion to the blocking
+/// pool before calling this function.
 pub fn expand_dropped_paths(
     app: tauri::AppHandle,
     paths: Vec<String>,

--- a/src-tauri/src/encoding.rs
+++ b/src-tauri/src/encoding.rs
@@ -1,6 +1,7 @@
 //! Encoding detection and decoding for subtitle files.
 //!
-//! Strategy: BOM detection first (deterministic), then chardetng (heuristic).
+//! Strategy: BOM detection first, then conservative BOM-less UTF-16
+//! inference, then chardetng for the remaining encodings.
 //! Returns UTF-8 text + detected encoding name so the frontend always gets
 //! clean Unicode regardless of the original file encoding.
 
@@ -41,6 +42,7 @@ fn decoded_result(
     encoding_id: &str,
     had_bom: bool,
     lossy: bool,
+    inferred_without_bom: bool,
     source_bytes: &[u8],
 ) -> ReadTextResult {
     ReadTextResult {
@@ -49,6 +51,7 @@ fn decoded_result(
         encoding_id: encoding_id.to_string(),
         had_bom,
         lossy,
+        inferred_without_bom,
         source_revision: source_revision(source_bytes),
         source_byte_length: source_bytes.len() as u64,
     }
@@ -92,13 +95,22 @@ fn sanitize_io_error(e: &std::io::Error, action: &str) -> String {
 
 /// Detect encoding and decode bytes to UTF-8. Shared logic for both the
 /// Tauri command and unit tests (which can't call Tauri commands directly).
-pub(crate) fn decode_bytes(bytes: &[u8]) -> ReadTextResult {
+pub(crate) fn decode_bytes(bytes: &[u8]) -> Result<ReadTextResult, String> {
     // 1. BOM detection
     if let Some(result) = detect_bom(bytes) {
-        return result;
+        return Ok(result);
     }
 
-    // 2. chardetng heuristic
+    // 2. Conservative BOM-less UTF-16 inference. chardetng intentionally
+    // does not consider UTF-16, and NUL bytes are valid UTF-8, so an
+    // ASCII-heavy UTF-16 subtitle would otherwise be returned as NUL-filled
+    // mojibake. Only accept a strong byte-lane pattern plus recognizable
+    // subtitle structure; ambiguous data fails instead of being rewritten.
+    if let Some(result) = detect_bomless_utf16(bytes)? {
+        return Ok(result);
+    }
+
+    // 3. chardetng heuristic
     //
     // chardetng 1.0 broke two API points compared with 0.1:
     //   - `EncodingDetector::new()` now takes an `Iso2022JpDetection`
@@ -131,24 +143,26 @@ pub(crate) fn decode_bytes(bytes: &[u8]) -> ReadTextResult {
         // return UTF-8-lossy mojibake of GBK bytes — content and label
         // disagree, and the content is much worse than `cow` already
         // contained.
-        return decoded_result(
+        return Ok(decoded_result(
             cow.into_owned(),
             format!("{} (lossy)", encoding.name()),
             encoding.name(),
             false,
             true,
+            false,
             bytes,
-        );
+        ));
     }
 
-    decoded_result(
+    Ok(decoded_result(
         cow.into_owned(),
         encoding.name().to_string(),
         encoding.name(),
         false,
         false,
+        false,
         bytes,
-    )
+    ))
 }
 
 /// Result of reading a text file with encoding detection.
@@ -165,6 +179,8 @@ pub struct ReadTextResult {
     pub had_bom: bool,
     /// Whether decoding replaced malformed source bytes.
     pub lossy: bool,
+    /// True only when UTF-16LE/BE was inferred conservatively without a BOM.
+    pub inferred_without_bom: bool,
     /// SHA-256 of the exact source bytes used for this decoded result.
     pub source_revision: String,
     /// Exact byte length used for bounded batch planning in the GUI.
@@ -176,8 +192,8 @@ pub struct ReadTextResult {
 ///
 /// Detection order:
 /// 1. BOM (UTF-8, UTF-16 LE/BE) — deterministic, highest priority
-/// 2. chardetng heuristic — handles GBK, Big5, Shift_JIS, EUC-KR, etc.
-/// 3. Lossy UTF-8 fallback — if all else fails
+/// 2. Conservative BOM-less UTF-16 inference from byte-lane structure
+/// 3. chardetng heuristic — handles GBK, Big5, Shift_JIS, EUC-KR, etc.
 ///
 /// The Tauri command (`read_text_detect_encoding`) wraps this with the
 /// app-owned fs scope; the CLI binary (which has no Tauri app
@@ -385,7 +401,7 @@ pub fn read_text_detect_encoding_inner(
         return Err("UTF-32 subtitle encoding is not supported".to_string());
     }
 
-    Ok(decode_bytes(&bytes))
+    decode_bytes(&bytes)
 }
 
 /// Tauri command wrapper. Resolves the app-owned fs scope then
@@ -397,6 +413,206 @@ pub fn read_text_detect_encoding(
 ) -> Result<ReadTextResult, String> {
     let scope = crate::fs_policy::app_fs_scope(&app)?;
     read_text_detect_encoding_inner(&path, move |p| scope.is_allowed(p))
+}
+
+fn looks_like_subtitle_text(text: &str) -> bool {
+    if text
+        .chars()
+        .any(|ch| ch.is_control() && !matches!(ch, '\t' | '\r' | '\n'))
+        || text
+            .chars()
+            .filter(|ch| !ch.is_whitespace())
+            .take(4)
+            .count()
+            < 4
+    {
+        return false;
+    }
+
+    text.lines().any(|line| {
+        let trimmed = line.trim_start_matches('\u{feff}').trim();
+        trimmed.starts_with("WEBVTT")
+            || trimmed.eq_ignore_ascii_case("[Script Info]")
+            || trimmed.eq_ignore_ascii_case("[Events]")
+            || trimmed.eq_ignore_ascii_case("[V4+ Styles]")
+            || trimmed.eq_ignore_ascii_case("[V4 Styles]")
+            || trimmed
+                .get(..9)
+                .is_some_and(|prefix| prefix.eq_ignore_ascii_case("Dialogue:"))
+            || (trimmed.contains("-->")
+                && trimmed.contains(':')
+                && (trimmed.contains('.') || trimmed.contains(',')))
+            || (trimmed.starts_with('{') && trimmed.contains("}{"))
+    })
+}
+
+fn looks_like_bomless_utf32(bytes: &[u8]) -> bool {
+    if bytes.len() < 16 || !bytes.len().is_multiple_of(4) {
+        return false;
+    }
+
+    const STRUCTURE_PROBE_BYTES: usize = 64 * 1024;
+    let probe_len = bytes.len().min(STRUCTURE_PROBE_BYTES) & !3;
+    let probe = &bytes[..probe_len];
+    if decode_utf32_probe(probe, true)
+        .as_deref()
+        .is_some_and(looks_like_subtitle_text)
+        || decode_utf32_probe(probe, false)
+            .as_deref()
+            .is_some_and(looks_like_subtitle_text)
+    {
+        return true;
+    }
+
+    let units = probe.len() / 4;
+    let high_nul_lanes = (0..4)
+        .filter(|lane| {
+            probe
+                .iter()
+                .skip(*lane)
+                .step_by(4)
+                .filter(|byte| **byte == 0)
+                .count()
+                * 10
+                >= units * 8
+        })
+        .count();
+    // ASCII-heavy UTF-32 has at least three nearly-empty byte lanes. UTF-16
+    // has two, so requiring three avoids classifying ordinary UTF-16 text as
+    // UTF-32 while the structural probe above still catches CJK-heavy UTF-32.
+    high_nul_lanes >= 3
+}
+
+fn decode_utf32_probe(bytes: &[u8], little_endian: bool) -> Option<String> {
+    bytes
+        .chunks_exact(4)
+        .map(|unit| {
+            let value = if little_endian {
+                u32::from_le_bytes([unit[0], unit[1], unit[2], unit[3]])
+            } else {
+                u32::from_be_bytes([unit[0], unit[1], unit[2], unit[3]])
+            };
+            char::from_u32(value)
+        })
+        .collect()
+}
+
+fn detect_bomless_utf16(bytes: &[u8]) -> Result<Option<ReadTextResult>, String> {
+    if bytes.len() < 8 {
+        return Ok(None);
+    }
+
+    if looks_like_bomless_utf32(bytes) {
+        return Err("UTF-32 subtitle encoding is not supported".to_string());
+    }
+
+    let even_len = bytes.len() & !1;
+    let even_bytes = &bytes[..even_len];
+
+    const SAMPLE_BYTES: usize = 8 * 1024;
+    let sample_len = even_bytes.len().min(SAMPLE_BYTES);
+    let sample = &even_bytes[..sample_len];
+    let even_nuls = sample.iter().step_by(2).filter(|byte| **byte == 0).count();
+    let odd_nuls = sample
+        .iter()
+        .skip(1)
+        .step_by(2)
+        .filter(|byte| **byte == 0)
+        .count();
+
+    // NUL-lane evidence catches ordinary ASCII-heavy UTF-16. A fixed density
+    // threshold is insufficient for Chinese-heavy captions, so candidate
+    // selection also decodes a bounded prefix in both byte orders and looks
+    // for actual subtitle structure. The wrong byte order turns ASCII syntax
+    // into unrelated code points and therefore cannot satisfy that check.
+    let likely_le = odd_nuls >= 4 && odd_nuls >= even_nuls.saturating_mul(4);
+    let likely_be = even_nuls >= 4 && even_nuls >= odd_nuls.saturating_mul(4);
+
+    const STRUCTURE_PROBE_BYTES: usize = 64 * 1024;
+    let probe_len = even_bytes.len().min(STRUCTURE_PROBE_BYTES);
+    let probe = &even_bytes[..probe_len];
+    let le_structure = decode_utf16_probe(probe, true)
+        .as_deref()
+        .is_some_and(looks_like_subtitle_text);
+    let be_structure = decode_utf16_probe(probe, false)
+        .as_deref()
+        .is_some_and(looks_like_subtitle_text);
+
+    let little_endian = match (le_structure, be_structure, likely_le, likely_be) {
+        (true, false, _, _) => Some(true),
+        (false, true, _, _) => Some(false),
+        (true, true, _, _) => {
+            return Err("BOM-less UTF-16 byte order is ambiguous; add a BOM and retry".to_string());
+        }
+        (false, false, true, false) => Some(true),
+        (false, false, false, true) => Some(false),
+        _ => None,
+    };
+
+    let Some(little_endian) = little_endian else {
+        return Ok(None);
+    };
+    let encoding_id = if little_endian {
+        "UTF-16LE"
+    } else {
+        "UTF-16BE"
+    };
+    if !bytes.len().is_multiple_of(2) {
+        return Err(format!(
+            "File resembles BOM-less {encoding_id} but has an odd byte length (truncated UTF-16 data)"
+        ));
+    }
+
+    let (cow, had_errors) = if little_endian {
+        let (cow, had_errors) = encoding_rs::UTF_16LE.decode_without_bom_handling(bytes);
+        (cow, had_errors)
+    } else {
+        let (cow, had_errors) = encoding_rs::UTF_16BE.decode_without_bom_handling(bytes);
+        (cow, had_errors)
+    };
+    if had_errors {
+        return Err(format!(
+            "File resembles BOM-less {encoding_id} but contains invalid UTF-16 data"
+        ));
+    }
+
+    let text = cow.into_owned();
+    if !looks_like_subtitle_text(&text) {
+        return Err(format!(
+            "File resembles BOM-less {encoding_id}, but its subtitle structure could not be verified"
+        ));
+    }
+
+    Ok(Some(decoded_result(
+        text,
+        format!("{encoding_id} (inferred, no BOM)"),
+        encoding_id,
+        false,
+        false,
+        true,
+        bytes,
+    )))
+}
+
+fn decode_utf16_probe(bytes: &[u8], little_endian: bool) -> Option<String> {
+    let mut probe = bytes;
+    if probe.len() >= 2 {
+        let last = if little_endian {
+            u16::from_le_bytes([probe[probe.len() - 2], probe[probe.len() - 1]])
+        } else {
+            u16::from_be_bytes([probe[probe.len() - 2], probe[probe.len() - 1]])
+        };
+        if (0xD800..=0xDBFF).contains(&last) {
+            probe = &probe[..probe.len() - 2];
+        }
+    }
+
+    let (decoded, had_errors) = if little_endian {
+        encoding_rs::UTF_16LE.decode_without_bom_handling(probe)
+    } else {
+        encoding_rs::UTF_16BE.decode_without_bom_handling(probe)
+    };
+    (!had_errors).then(|| decoded.into_owned())
 }
 
 /// Check for Byte Order Mark and decode accordingly. When the decoded text
@@ -425,6 +641,7 @@ fn detect_bom(bytes: &[u8]) -> Option<ReadTextResult> {
             "UTF-8",
             true,
             lossy,
+            false,
             bytes,
         ));
     }
@@ -447,6 +664,7 @@ fn detect_bom(bytes: &[u8]) -> Option<ReadTextResult> {
             "UTF-16LE",
             true,
             had_errors,
+            false,
             bytes,
         ));
     }
@@ -464,6 +682,7 @@ fn detect_bom(bytes: &[u8]) -> Option<ReadTextResult> {
             "UTF-16BE",
             true,
             had_errors,
+            false,
             bytes,
         ));
     }
@@ -482,7 +701,7 @@ mod tests {
         let path = format!("{}/tests/fixtures/{}", env!("CARGO_MANIFEST_DIR"), name);
         let bytes =
             std::fs::read(&path).unwrap_or_else(|e| panic!("Cannot read fixture {name}: {e}"));
-        decode_bytes(&bytes)
+        decode_bytes(&bytes).unwrap_or_else(|e| panic!("Cannot decode fixture {name}: {e}"))
     }
 
     fn temp_file_path(name: &str, ext: &str) -> std::path::PathBuf {
@@ -498,6 +717,18 @@ mod tests {
             ext
         ));
         path
+    }
+
+    fn encode_utf16_without_bom(text: &str, little_endian: bool) -> Vec<u8> {
+        text.encode_utf16()
+            .flat_map(|unit| {
+                if little_endian {
+                    unit.to_le_bytes()
+                } else {
+                    unit.to_be_bytes()
+                }
+            })
+            .collect()
     }
 
     #[test]
@@ -516,7 +747,7 @@ mod tests {
 
     #[test]
     fn read_result_exposes_exact_source_revision_and_camel_case_wire_fields() {
-        let result = decode_bytes(b"abc");
+        let result = decode_bytes(b"abc").unwrap();
         assert_eq!(result.source_byte_length, 3);
         assert_eq!(
             result.source_revision,
@@ -527,6 +758,7 @@ mod tests {
         assert_eq!(json["encodingId"], "UTF-8");
         assert_eq!(json["hadBom"], false);
         assert_eq!(json["lossy"], false);
+        assert_eq!(json["inferredWithoutBom"], false);
         assert_eq!(json["sourceByteLength"], 3);
         assert_eq!(json["sourceRevision"], result.source_revision);
         assert!(json.get("source_revision").is_none());
@@ -537,7 +769,7 @@ mod tests {
         // A file containing ONLY a UTF-8 BOM and nothing else should
         // decode cleanly to an empty string with the BOM-stripped
         // label — not panic, not mis-detect as another encoding.
-        let result = decode_bytes(&[0xEF, 0xBB, 0xBF]);
+        let result = decode_bytes(&[0xEF, 0xBB, 0xBF]).unwrap();
         assert_eq!(result.encoding, "UTF-8 (BOM)");
         assert_eq!(result.text, "");
     }
@@ -550,20 +782,141 @@ mod tests {
         let mut bytes = vec![0xFE, 0xFF];
         // "AB" in UTF-16BE: 0x00 0x41, 0x00 0x42
         bytes.extend_from_slice(&[0x00, 0x41, 0x00, 0x42]);
-        let result = decode_bytes(&bytes);
+        let result = decode_bytes(&bytes).unwrap();
         assert_eq!(result.encoding, "UTF-16BE");
         assert_eq!(result.text, "AB");
     }
 
     #[test]
     fn utf16_payload_leading_bom_character_is_preserved() {
-        let le = decode_bytes(&[0xFF, 0xFE, 0xFF, 0xFE, 0x41, 0x00]);
+        let le = decode_bytes(&[0xFF, 0xFE, 0xFF, 0xFE, 0x41, 0x00]).unwrap();
         assert_eq!(le.encoding, "UTF-16LE");
         assert_eq!(le.text, "\u{feff}A");
 
-        let be = decode_bytes(&[0xFE, 0xFF, 0xFE, 0xFF, 0x00, 0x41]);
+        let be = decode_bytes(&[0xFE, 0xFF, 0xFE, 0xFF, 0x00, 0x41]).unwrap();
         assert_eq!(be.encoding, "UTF-16BE");
         assert_eq!(be.text, "\u{feff}A");
+    }
+
+    #[test]
+    fn infers_bomless_utf16le_only_after_subtitle_structure_check() {
+        let source =
+            "[Script Info]\r\n\r\n[Events]\r\nDialogue: 0,0:00:01.00,0:00:02.00,Default,Hello\r\n";
+        let bytes = encode_utf16_without_bom(source, true);
+
+        let result = decode_bytes(&bytes).unwrap();
+
+        assert_eq!(result.text, source);
+        assert_eq!(result.encoding, "UTF-16LE (inferred, no BOM)");
+        assert_eq!(result.encoding_id, "UTF-16LE");
+        assert!(!result.had_bom);
+        assert!(!result.lossy);
+        assert!(result.inferred_without_bom);
+    }
+
+    #[test]
+    fn infers_bomless_utf16be_only_after_subtitle_structure_check() {
+        let source = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHello\n";
+        let bytes = encode_utf16_without_bom(source, false);
+
+        let result = decode_bytes(&bytes).unwrap();
+
+        assert_eq!(result.text, source);
+        assert_eq!(result.encoding, "UTF-16BE (inferred, no BOM)");
+        assert_eq!(result.encoding_id, "UTF-16BE");
+        assert!(!result.had_bom);
+        assert!(!result.lossy);
+        assert!(result.inferred_without_bom);
+    }
+
+    #[test]
+    fn infers_cjk_heavy_bomless_utf16_srt_and_microdvd() {
+        let cjk = "中".repeat(100);
+        let sources = [
+            format!("1\n00:00:01,000 --> 00:00:02,000\n{cjk}\n"),
+            format!("{{24}}{{48}}{cjk}\n"),
+        ];
+
+        for source in sources {
+            for little_endian in [true, false] {
+                let bytes = encode_utf16_without_bom(&source, little_endian);
+                let result = decode_bytes(&bytes).unwrap();
+                let expected_id = if little_endian {
+                    "UTF-16LE"
+                } else {
+                    "UTF-16BE"
+                };
+
+                assert_eq!(result.text, source);
+                assert_eq!(result.encoding_id, expected_id);
+                assert!(result.inferred_without_bom);
+            }
+        }
+    }
+
+    #[test]
+    fn infers_bomless_utf16_style_only_ass_and_ssa_documents() {
+        let sources = [
+            "[V4+ Styles]\nFormat: Name, Fontname\nStyle: Default,Arial\n",
+            "[V4 Styles]\nFormat: Name, Fontname\nStyle: Default,Arial\n",
+        ];
+
+        for source in sources {
+            for little_endian in [true, false] {
+                let bytes = encode_utf16_without_bom(source, little_endian);
+                let result = decode_bytes(&bytes).unwrap();
+
+                assert_eq!(result.text, source);
+                assert!(result.inferred_without_bom);
+            }
+        }
+    }
+
+    #[test]
+    fn truncated_bomless_utf16_returns_a_targeted_error() {
+        let source = "1\n00:00:01,000 --> 00:00:02,000\nHello\n";
+
+        for little_endian in [true, false] {
+            let mut bytes = encode_utf16_without_bom(source, little_endian);
+            bytes.pop();
+            let error = decode_bytes(&bytes).unwrap_err();
+
+            assert!(error.contains("odd byte length"), "got: {error}");
+            assert!(error.contains("truncated UTF-16"), "got: {error}");
+        }
+    }
+
+    #[test]
+    fn bomless_utf32_is_not_misclassified_as_utf16() {
+        let source = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHello\n";
+        for little_endian in [true, false] {
+            let bytes: Vec<u8> = source
+                .chars()
+                .flat_map(|ch| {
+                    if little_endian {
+                        (ch as u32).to_le_bytes()
+                    } else {
+                        (ch as u32).to_be_bytes()
+                    }
+                })
+                .collect();
+            let decoded = decode_bytes(&bytes);
+            assert!(
+                decoded
+                    .as_ref()
+                    .is_err_and(|error| error.contains("UTF-32")),
+                "unexpected UTF-32 result: {decoded:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn alternating_zero_binary_is_not_accepted_as_utf16_subtitle_text() {
+        let bytes = [b'A', 0, 1, 0, b'B', 0, 2, 0, b'C', 0, 3, 0];
+
+        let error = decode_bytes(&bytes).unwrap_err();
+
+        assert!(error.contains("subtitle structure"), "got: {error}");
     }
 
     #[test]

--- a/src-tauri/src/encoding.rs
+++ b/src-tauri/src/encoding.rs
@@ -404,9 +404,9 @@ pub fn read_text_detect_encoding_inner(
     decode_bytes(&bytes)
 }
 
-/// Tauri command wrapper. Resolves the app-owned fs scope then
-/// delegates to `read_text_detect_encoding_inner`.
-#[tauri::command]
+/// Blocking command implementation. The async Tauri boundary in
+/// `ipc_commands` moves scope resolution, file reading, and decoding to the
+/// blocking pool before calling this function.
 pub fn read_text_detect_encoding(
     app: tauri::AppHandle,
     path: String,

--- a/src-tauri/src/font_cache.rs
+++ b/src-tauri/src/font_cache.rs
@@ -208,6 +208,27 @@ pub const SCHEMA_VERSION: i32 = 6;
 const KEY_KIND_FAMILY: i32 = 0;
 const KEY_KIND_FACE_ALIAS: i32 = 1;
 
+/// Filesystem-probe budget for one family lookup. A normal cache has one or
+/// two same-family candidates; a hostile or badly stale cache could otherwise
+/// make a single lookup hold the cache mutex across thousands of canonicalize
+/// and metadata calls (including slow mapped-drive failures).
+const MAX_CACHE_LOOKUP_CANDIDATES: usize = 64;
+
+const FAMILY_LOOKUP_SQL: &str =
+    "SELECT k.font_path, k.face_index, s.source_root, f.file_size, f.file_mtime \
+     FROM cached_family_keys k \
+     INNER JOIN cached_fonts f \
+       ON f.source_root = k.source_root AND f.scope = k.scope \
+      AND f.font_path = k.font_path AND f.face_index = k.face_index \
+     INNER JOIN cached_sources s \
+       ON s.source_root = f.source_root AND s.scope = f.scope \
+     WHERE k.family_name_key = ?1 \
+       AND ((k.key_kind = ?2 AND k.bold = ?3 AND k.italic = ?4) \
+            OR (k.key_kind = ?5 AND k.bold = 0 AND k.italic = 0)) \
+     ORDER BY k.key_kind ASC, s.scope ASC, s.source_order DESC, \
+              k.font_path ASC, k.face_index ASC \
+     LIMIT ?6";
+
 /// DoS-class sanity cap on the number of `cached_sources` rows
 /// `list_sources` / `diff_sources` will return. A hostile cache file
 /// (untrusted-input via `--cache-file`) populated with hundreds of fabricated
@@ -396,6 +417,49 @@ fn validate_cached_font_hit(
     }
 
     Ok(())
+}
+
+fn validate_cached_font_candidate(
+    font_path: &str,
+    face_index: i32,
+    folder_path: &str,
+    cached_file_size: i64,
+    cached_file_mtime: i64,
+) -> Result<(), CacheError> {
+    reject_unsupported_cached_folder_path(folder_path)?;
+    reject_unsupported_cached_font_path(font_path)?;
+    let face_index_supported =
+        u32::try_from(face_index).is_ok_and(|index| index <= crate::fonts::MAX_SUBSET_FONT_INDEX);
+    if !face_index_supported {
+        return Err(CacheError::Io(
+            "cached_fonts.face_index is outside the supported range; cache file appears corrupted or hostile — rebuild required"
+                .to_string(),
+        ));
+    }
+    let extension_allowed = Path::new(font_path)
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(|extension| extension.to_ascii_lowercase())
+        .is_some_and(|extension| {
+            crate::fonts::ALLOWED_FONT_EXTENSIONS.contains(&extension.as_str())
+        });
+    if !extension_allowed {
+        return Err(CacheError::Io(
+            "cached_fonts.font_path has an unsupported font extension; cache file appears corrupted or hostile — rebuild required"
+                .to_string(),
+        ));
+    }
+    validate_cached_font_hit(font_path, folder_path, cached_file_size, cached_file_mtime)
+}
+
+fn warn_skipped_cache_candidates(skipped: usize) {
+    if skipped > 0 {
+        // Deliberately path- and family-free: FontCache is also callable by
+        // internal code that has not passed the IPC family-name validator.
+        log::warn!(
+            "font cache lookup skipped {skipped} stale or invalid higher-priority candidate(s); rebuild the font cache to restore source priority"
+        );
+    }
 }
 
 /// Normalize a family-name string into the lookup key used by
@@ -1676,41 +1740,86 @@ impl FontCache {
         italic: bool,
     ) -> Result<Option<FontLookupResult>, CacheError> {
         let lookup_key = family_lookup_key(family_name);
-        let row: Result<(String, i32, String, i64, i64), _> = self.conn.query_row(
-            "SELECT k.font_path, k.face_index, s.source_root, f.file_size, f.file_mtime \
-             FROM cached_family_keys k \
-             INNER JOIN cached_fonts f \
-               ON f.source_root = k.source_root AND f.scope = k.scope \
-              AND f.font_path = k.font_path AND f.face_index = k.face_index \
-             INNER JOIN cached_sources s \
-               ON s.source_root = f.source_root AND s.scope = f.scope \
-             WHERE k.family_name_key = ?1 \
-               AND ((k.key_kind = ?2 AND k.bold = ?3 AND k.italic = ?4) \
-                    OR (k.key_kind = ?5 AND k.bold = 0 AND k.italic = 0)) \
-             ORDER BY k.key_kind ASC, s.scope ASC, s.source_order DESC, \
-                      k.font_path ASC, k.face_index ASC \
-             LIMIT 1",
-            params![
+        let mut statement = self
+            .conn
+            .prepare(FAMILY_LOOKUP_SQL)
+            .map_err(|error| CacheError::Io(format!("prepare lookup_family: {error}")))?;
+        let candidate_limit = i64::try_from(MAX_CACHE_LOOKUP_CANDIDATES + 1)
+            .expect("cache lookup candidate limit fits i64");
+        let mut rows = statement
+            .query(params![
                 lookup_key,
                 KEY_KIND_FAMILY,
                 i32::from(bold),
                 i32::from(italic),
-                KEY_KIND_FACE_ALIAS
-            ],
-            |r| Ok((r.get(0)?, r.get(1)?, r.get(2)?, r.get(3)?, r.get(4)?)),
-        );
-        match row {
-            Ok((font_path, face_index, folder_path, file_size, file_mtime)) => {
-                reject_unsupported_cached_folder_path(&folder_path)?;
-                reject_unsupported_cached_font_path(&font_path)?;
-                validate_cached_font_hit(&font_path, &folder_path, file_size, file_mtime)?;
-                Ok(Some(FontLookupResult {
-                    font_path,
-                    face_index,
-                }))
+                KEY_KIND_FACE_ALIAS,
+                candidate_limit,
+            ])
+            .map_err(|error| CacheError::Io(format!("query lookup_family: {error}")))?;
+
+        let mut skipped = 0usize;
+        let mut first_validation_error = None;
+        while let Some(row) = rows
+            .next()
+            .map_err(|error| CacheError::Io(format!("read lookup_family row: {error}")))?
+        {
+            if skipped >= MAX_CACHE_LOOKUP_CANDIDATES {
+                warn_skipped_cache_candidates(skipped);
+                return Err(first_validation_error.unwrap_or_else(|| {
+                    CacheError::Io(format!(
+                        "font cache lookup exceeds the {MAX_CACHE_LOOKUP_CANDIDATES}-candidate filesystem-probe budget; rebuild required"
+                    ))
+                }));
             }
-            Err(rusqlite::Error::QueryReturnedNoRows) => Ok(None),
-            Err(e) => Err(CacheError::Io(format!("lookup_family: {e}"))),
+            let candidate = (
+                row.get::<_, String>(0),
+                row.get::<_, i32>(1),
+                row.get::<_, String>(2),
+                row.get::<_, i64>(3),
+                row.get::<_, i64>(4),
+            );
+            let (font_path, face_index, folder_path, file_size, file_mtime) = match candidate {
+                (Ok(font_path), Ok(face_index), Ok(folder_path), Ok(file_size), Ok(file_mtime)) => {
+                    (font_path, face_index, folder_path, file_size, file_mtime)
+                }
+                _ => {
+                    skipped += 1;
+                    if first_validation_error.is_none() {
+                        first_validation_error = Some(CacheError::Io(
+                            "lookup_family row has invalid column types; rebuild required"
+                                .to_string(),
+                        ));
+                    }
+                    continue;
+                }
+            };
+            match validate_cached_font_candidate(
+                &font_path,
+                face_index,
+                &folder_path,
+                file_size,
+                file_mtime,
+            ) {
+                Ok(()) => {
+                    warn_skipped_cache_candidates(skipped);
+                    return Ok(Some(FontLookupResult {
+                        font_path,
+                        face_index,
+                    }));
+                }
+                Err(error) => {
+                    skipped += 1;
+                    if first_validation_error.is_none() {
+                        first_validation_error = Some(error);
+                    }
+                }
+            }
+        }
+
+        warn_skipped_cache_candidates(skipped);
+        match first_validation_error {
+            Some(error) => Err(error),
+            None => Ok(None),
         }
     }
 
@@ -2151,26 +2260,20 @@ mod tests {
     fn family_lookup_uses_the_family_first_index() {
         let (_guard, path) = temp_cache_path();
         let cache = FontCache::open_or_create(&path).expect("fresh cache opens");
-        let mut statement = cache
-            .conn
-            .prepare(
-                "EXPLAIN QUERY PLAN \
-                 SELECT k.font_path, k.face_index, s.source_root, f.file_size, f.file_mtime \
-                 FROM cached_family_keys k \
-                 INNER JOIN cached_fonts f \
-                   ON f.source_root = k.source_root AND f.scope = k.scope \
-                  AND f.font_path = k.font_path AND f.face_index = k.face_index \
-                 INNER JOIN cached_sources s \
-                   ON s.source_root = f.source_root AND s.scope = f.scope \
-                 WHERE k.family_name_key = ?1 \
-                   AND ((k.key_kind = ?2 AND k.bold = ?3 AND k.italic = ?4) \
-                        OR (k.key_kind = ?5 AND k.bold = 0 AND k.italic = 0)) \
-                 ORDER BY k.key_kind, s.scope, s.source_order DESC, \
-                          k.font_path, k.face_index LIMIT 1",
-            )
-            .unwrap();
+        let explain_sql = format!("EXPLAIN QUERY PLAN {FAMILY_LOOKUP_SQL}");
+        let mut statement = cache.conn.prepare(&explain_sql).unwrap();
         let details: Vec<String> = statement
-            .query_map(params!["demo", 0, 0, 0, 1], |row| row.get(3))
+            .query_map(
+                params![
+                    "demo",
+                    0,
+                    0,
+                    0,
+                    1,
+                    i64::try_from(MAX_CACHE_LOOKUP_CANDIDATES + 1).unwrap()
+                ],
+                |row| row.get(3),
+            )
             .unwrap()
             .map(Result::unwrap)
             .collect();
@@ -3183,6 +3286,171 @@ mod tests {
                 .contains("cached_fonts metadata no longer matches the live font file"),
             "expected stale cached font metadata rejection, got: {err}"
         );
+    }
+
+    #[test]
+    fn lookup_family_skips_stale_newest_candidate_and_returns_valid_older_source() {
+        let (guard, path) = temp_cache_path();
+        let mut cache = FontCache::open_or_create(&path).expect("open");
+        let older_dir = guard.0.join("fallback-older");
+        let newer_dir = guard.0.join("fallback-newer");
+        let older = real_font_metadata(
+            &older_dir,
+            "older.ttf",
+            0,
+            vec![family_key("Fallback Sans", false, false)],
+            Vec::new(),
+        );
+        let newer = real_font_metadata(
+            &newer_dir,
+            "newer.ttf",
+            0,
+            vec![family_key("Fallback Sans", false, false)],
+            Vec::new(),
+        );
+        cache
+            .replace_folder(
+                &real_folder_path(&older_dir),
+                100,
+                std::slice::from_ref(&older),
+            )
+            .unwrap();
+        cache
+            .replace_folder(
+                &real_folder_path(&newer_dir),
+                200,
+                std::slice::from_ref(&newer),
+            )
+            .unwrap();
+        fs::remove_file(&newer.file_path).expect("make highest-priority cache row stale");
+
+        let result = cache
+            .lookup_family("Fallback Sans", false, false)
+            .expect("a valid lower-ranked cache candidate should recover the lookup")
+            .expect("older source should match");
+        assert_eq!(result.font_path, older.file_path);
+        assert_eq!(result.face_index, 0);
+    }
+
+    #[test]
+    fn lookup_family_skips_malformed_top_row_and_returns_valid_lower_source() {
+        let (guard, path) = temp_cache_path();
+        let mut cache = FontCache::open_or_create(&path).expect("open");
+        let valid_dir = guard.0.join("malformed-row-valid");
+        let malformed_dir = guard.0.join("malformed-row-top");
+        let valid = real_font_metadata(
+            &valid_dir,
+            "valid.ttf",
+            0,
+            vec![family_key("Malformed Fallback", false, false)],
+            Vec::new(),
+        );
+        cache
+            .replace_folder(
+                &real_folder_path(&valid_dir),
+                100,
+                std::slice::from_ref(&valid),
+            )
+            .unwrap();
+        let malformed =
+            real_font_metadata(&malformed_dir, "malformed.ttf", 0, Vec::new(), Vec::new());
+        let malformed_root = real_folder_path(&malformed_dir);
+        cache
+            .conn
+            .pragma_update(None, "foreign_keys", "OFF")
+            .unwrap();
+        cache
+            .conn
+            .execute(
+                "INSERT INTO cached_sources(source_root, scope, source_order, last_scanned_at) \
+                 VALUES(?1, 0, 999, 1)",
+                params![&malformed_root],
+            )
+            .unwrap();
+        cache
+            .conn
+            .execute(
+                "INSERT INTO cached_fonts(\
+                    source_root, scope, font_path, face_index, file_size, file_mtime\
+                 ) VALUES(?1, 0, ?2, 'not-an-int', ?3, ?4)",
+                params![
+                    &malformed_root,
+                    &malformed.file_path,
+                    malformed.file_size,
+                    malformed.file_mtime
+                ],
+            )
+            .unwrap();
+        cache
+            .conn
+            .execute(
+                "INSERT INTO cached_family_keys(\
+                    source_root, scope, font_path, face_index, family_name, \
+                    family_name_key, key_kind, bold, italic\
+                 ) VALUES(?1, 0, ?2, 'not-an-int', ?3, ?4, ?5, 0, 0)",
+                params![
+                    &malformed_root,
+                    &malformed.file_path,
+                    "Malformed Fallback",
+                    family_lookup_key("Malformed Fallback"),
+                    KEY_KIND_FAMILY
+                ],
+            )
+            .unwrap();
+        cache
+            .conn
+            .pragma_update(None, "foreign_keys", "ON")
+            .unwrap();
+
+        let result = cache
+            .lookup_family("Malformed Fallback", false, false)
+            .expect("malformed top row should not suppress a valid candidate")
+            .expect("valid lower source should match");
+        assert_eq!(result.font_path, valid.file_path);
+        assert_eq!(result.face_index, 0);
+    }
+
+    #[test]
+    fn lookup_family_skips_over_limit_face_index_and_returns_valid_lower_source() {
+        let (guard, path) = temp_cache_path();
+        let mut cache = FontCache::open_or_create(&path).expect("open");
+        let valid_dir = guard.0.join("index-limit-valid");
+        let invalid_dir = guard.0.join("index-limit-top");
+        let valid = real_font_metadata(
+            &valid_dir,
+            "valid.ttf",
+            0,
+            vec![family_key("Index Fallback", false, false)],
+            Vec::new(),
+        );
+        cache
+            .replace_folder(
+                &real_folder_path(&valid_dir),
+                100,
+                std::slice::from_ref(&valid),
+            )
+            .unwrap();
+        let invalid = real_font_metadata(
+            &invalid_dir,
+            "invalid.ttf",
+            i32::try_from(crate::fonts::MAX_SUBSET_FONT_INDEX + 1).unwrap(),
+            vec![family_key("Index Fallback", false, false)],
+            Vec::new(),
+        );
+        cache
+            .replace_folder(
+                &real_folder_path(&invalid_dir),
+                200,
+                std::slice::from_ref(&invalid),
+            )
+            .unwrap();
+
+        let result = cache
+            .lookup_family("Index Fallback", false, false)
+            .expect("over-limit top row should not suppress a valid candidate")
+            .expect("valid lower source should match");
+        assert_eq!(result.font_path, valid.file_path);
+        assert_eq!(result.face_index, 0);
     }
 
     #[test]

--- a/src-tauri/src/font_cache.rs
+++ b/src-tauri/src/font_cache.rs
@@ -1321,6 +1321,17 @@ impl FontCache {
     /// A missing or unparseable row counts as mismatch (cache predates
     /// version tracking, or corrupt).
     fn verify_schema_version(&self) -> Result<(), CacheError> {
+        let has_cache_meta = self
+            .conn
+            .table_exists(None::<&str>, "cache_meta")
+            .map_err(|e| CacheError::Io(format!("checking cache_meta table: {e}")))?;
+        if !has_cache_meta {
+            return Err(CacheError::SchemaVersionMismatch {
+                found: -1,
+                expected: SCHEMA_VERSION,
+            });
+        }
+
         let row: Result<String, _> = self.conn.query_row(
             "SELECT value FROM cache_meta WHERE key = 'schema_version'",
             [],
@@ -1346,20 +1357,6 @@ impl FontCache {
                 found: -1,
                 expected: SCHEMA_VERSION,
             }),
-            // A pre-versioned file or a partial-init crash that left
-            // the database file without a `cache_meta` table surfaces
-            // as a "no such table" SqliteFailure. Route to the same
-            // drift-equivalent path as missing-row (-1) so the user
-            // sees the rebuild prompt instead of a raw SQL error
-            // string. Other SQL errors (locked, permission denied,
-            // disk corruption) still flow to Io for the
-            // "couldn't open cache" branch upstream.
-            Err(e) if format!("{e}").contains("no such table") => {
-                Err(CacheError::SchemaVersionMismatch {
-                    found: -1,
-                    expected: SCHEMA_VERSION,
-                })
-            }
             Err(e) => Err(CacheError::Io(format!("reading schema_version: {e}"))),
         }
     }
@@ -2463,6 +2460,31 @@ mod tests {
             }
             other => panic!("expected SchemaVersionMismatch, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn missing_cache_meta_table_treated_as_mismatch_for_both_open_modes() {
+        let (_guard, path) = temp_cache_path();
+        {
+            let conn = Connection::open(&path).unwrap();
+            conn.execute("CREATE TABLE unrelated(value TEXT)", [])
+                .unwrap();
+        }
+
+        let assert_mismatch = |mode: &str, result: Result<FontCache, CacheError>| {
+            match result {
+                Err(CacheError::SchemaVersionMismatch { found, expected }) => {
+                    assert_eq!(found, -1, "missing-table sentinel in {mode} mode");
+                    assert_eq!(expected, SCHEMA_VERSION);
+                }
+                other => panic!(
+                    "expected SchemaVersionMismatch for missing cache_meta in {mode} mode, got {other:?}"
+                ),
+            }
+        };
+
+        assert_mismatch("read-write", FontCache::open_or_create(&path));
+        assert_mismatch("read-only", FontCache::open_existing_read_only(&path));
     }
 
     #[test]

--- a/src-tauri/src/font_cache_commands.rs
+++ b/src-tauri/src/font_cache_commands.rs
@@ -1,10 +1,10 @@
-//! Tauri command wrappers for the persistent font cache.
+//! Blocking implementations and shared state for the persistent font cache.
 //!
 //! `font_cache.rs` itself stays Tauri-free so the CLI binary can use it
-//! without pulling in the GUI's IPC layer. This module is the GUI-only
-//! IPC surface: a static `Mutex<Option<FontCache>>` initialized once
-//! during Tauri setup, plus the five commands the React drift modal +
-//! embed-time lookup tier call into.
+//! without pulling in the GUI's IPC layer. The async Tauri wrappers live in
+//! `ipc_commands`; this module owns the static `Mutex<Option<FontCache>>`
+//! initialized during Tauri setup plus the synchronous operations used by the
+//! React drift modal and embed-time lookup tier.
 //!
 //! The GUI command surface stays deliberately small: cache status,
 //! drift detection, drift rescan, clear/rebuild, and lookup. The
@@ -505,12 +505,11 @@ fn classify_unreadable_existing_as_modified(
     report.modified.sort();
 }
 
-// ---- Tauri commands ----------------------------------------------------
+// ---- Blocking cache operations -----------------------------------------
 
 /// Report the current cache status. Useful for the launch-time check
 /// (frontend asks "is cache ready?" before calling detect_drift) and
 /// for re-checking after `clear_font_cache`.
-#[tauri::command]
 pub fn open_font_cache() -> Result<CacheStatus, String> {
     let path = GUI_FONT_CACHE_PATH
         .lock()
@@ -583,7 +582,6 @@ pub fn open_font_cache() -> Result<CacheStatus, String> {
 /// lock. A mismatch means the filesystem snapshot describes an obsolete source
 /// set, so this call returns `DriftReport::default()` and a later check starts
 /// from the current cache.
-#[tauri::command]
 pub fn detect_font_cache_drift() -> Result<DriftReport, String> {
     // Phase 1: snapshot the cached source list + capture the cache
     // generation under the lock. Capturing the generation INSIDE the
@@ -676,7 +674,6 @@ fn finalize_drift(
 /// `detect_font_cache_drift`) so this command does not scan new sources — those
 /// enter through guarded publication after a successful directory scan or the
 /// CLI's `refresh-fonts` subcommand.
-#[tauri::command]
 pub fn rescan_font_cache_drift() -> Result<RescanResult, String> {
     // Block parallel `clear_font_cache` between Phase 1 and Phase 3 so
     // Clear can't drop+recreate the cache mid-rescan and have Phase 3's
@@ -1018,7 +1015,6 @@ fn apply_rescan_to_cache<C: RescanCacheWriter>(
 ///
 /// Used as the "Clear cache" button in the drift modal AND as the
 /// rebuild path when `open_font_cache` reports `schema_mismatch`.
-#[tauri::command]
 pub fn clear_font_cache() -> Result<(), String> {
     // Refuse mid-rescan AND block a concurrent rescan from starting
     // while clear is running. Acquiring the guard via CAS (not just
@@ -1202,7 +1198,6 @@ pub(crate) fn clear_all_sources_in_gui_cache_locked(
 /// (already serde-derived for IPC) instead of wrapping cache's
 /// internal `FontLookupResult` (different field names: font_path/face_index
 /// vs path/index, different int types).
-#[tauri::command]
 pub fn lookup_font_family(
     family: String,
     bold: bool,

--- a/src-tauri/src/font_cache_commands.rs
+++ b/src-tauri/src/font_cache_commands.rs
@@ -738,21 +738,8 @@ pub fn rescan_font_cache_drift() -> Result<RescanResult, String> {
     let mut skipped: Vec<SkippedFolder> = Vec::new();
     for source in &report.modified {
         let folder_path = Path::new(&source.source_root);
-        let snapshot = match snapshot_source_directories(folder_path, source.scope) {
-            Ok(snapshot) => snapshot,
-            Err(err) => {
-                log::warn!("rescan: skipping {} — {err}", source.source_root);
-                skipped.push(SkippedFolder {
-                    folder: source.source_root.clone(),
-                    scope: source.scope,
-                    reason: err,
-                    kind: SkipKind::ScanFailed,
-                });
-                continue;
-            }
-        };
-        match crate::fonts::scan_directory_collecting_with_scope(folder_path, source.scope) {
-            Ok(entries) => {
+        match crate::fonts::scan_directory_collecting_with_snapshot(folder_path, source.scope) {
+            Ok((entries, snapshot)) => {
                 let metadata = match entries_to_cache_metadata(&entries) {
                     Ok(metadata) => metadata,
                     Err(err) => {
@@ -765,15 +752,7 @@ pub fn rescan_font_cache_drift() -> Result<RescanResult, String> {
                         continue;
                     }
                 };
-                match validate_cache_source_stability(&snapshot, &metadata) {
-                    Ok(()) => scanned.push((snapshot, metadata)),
-                    Err(err) => skipped.push(SkippedFolder {
-                        folder: source.source_root.clone(),
-                        scope: source.scope,
-                        reason: err.to_string(),
-                        kind: SkipKind::ScanFailed,
-                    }),
-                }
+                scanned.push((snapshot, metadata));
             }
             Err(err) => {
                 log::warn!("rescan: skipping {} — {err}", source.source_root);
@@ -787,10 +766,17 @@ pub fn rescan_font_cache_drift() -> Result<RescanResult, String> {
         }
     }
 
-    // Phase 2b — still outside the cache slot, immediately revalidate every
-    // completed scan and re-probe every allegedly removed root. The mutation
-    // guard freezes in-process cache writers throughout this phase; keeping
-    // the filesystem walks out here lets lookups remain responsive.
+    // Phase 2b — still outside the cache slot, revalidate every completed scan
+    // at the final pre-apply point and re-probe every allegedly removed root.
+    // The scan already returned the exact snapshot produced by its discovery
+    // walk, so a separate pre-scan snapshot and an immediate post-scan rewalk
+    // would add two full enumerations without strengthening the final
+    // applied-state invariant. This full final rewalk remains necessary:
+    // parsed faces are only a subset of the snapshot and cannot reveal added,
+    // removed, unreadable, or unparseable candidates or directory changes.
+    // The mutation guard freezes in-process cache writers throughout this
+    // phase; keeping the filesystem walks out here lets lookups remain
+    // responsive.
     let scanned = validate_scanned_sources_before_apply(scanned, &mut skipped);
     let removed = confirm_removed_sources_before_apply(&report.removed);
 

--- a/src-tauri/src/fonts.rs
+++ b/src-tauri/src/fonts.rs
@@ -4272,9 +4272,10 @@ fn is_in_system_fonts_dir(canonical: &Path) -> bool {
 ///
 /// Public IPC entry point + the CLI's standalone-embed callsite both
 /// invoke this function as a regular `pub fn`; the GUI reaches it through
-/// `ipc_commands::subset_font_b64`, which runs the base64 helper below on the
-/// blocking pool so the frontend doesn't pay the JSON `[byte, ...]` expansion
-/// (~4–5× per byte → ~50 MB on a worst-case 10 MB subset).
+/// `ipc_commands::subset_font_bytes`, which runs this function on the blocking
+/// pool. Windows/Linux use a raw `tauri::ipc::Response`; Apple targets retain
+/// base64 because Tauri 2.11's eval fallback JSON-serializes raw bytes as a
+/// numeric array there. Both forms avoid the worst wire shape on their target.
 /// CLI's chain mode marshals subsets via base64 inline (see
 /// `process_one_chain_input`); CLI's standalone embed bundles them
 /// into `engine::FontSubsetPayload` and ships through the engine's
@@ -4284,9 +4285,10 @@ fn is_in_system_fonts_dir(canonical: &Path) -> bool {
 /// **IMPORTANT **: do NOT add `#[tauri::command]`
 /// to this function. The Vec<u8> return shape would JSON-encode as
 /// `[byte, byte, ...]` over the GUI IPC wire, hitting the same ~4-5×
-/// expansion `subset_font_b64` exists specifically to dodge. The GUI-side IPC
-/// path MUST go through `ipc_commands::subset_font_b64`; adding the attribute
-/// here would silently bypass that guard and pressure V8 heap on every embed.
+/// expansion the target-aware wrapper exists specifically to dodge. The
+/// GUI-side IPC path MUST go through `ipc_commands::subset_font_bytes`; adding
+/// the attribute here would silently bypass that guard and pressure the JS heap
+/// on every embed.
 /// Future direct exposure must go through an explicit security and
 /// resource-budget audit.
 pub fn subset_font(
@@ -4696,23 +4698,6 @@ pub fn subset_font(
             Err(format!("Subsetting failed: {e}"))
         }
     }
-}
-
-/// Blocking base64 implementation called by `ipc_commands::subset_font_b64`
-/// so the GUI's frontend doesn't pay the JSON `[byte, byte, …]` expansion.
-/// Pre-fix this returned `Vec<u8>` directly; serde-json would write each
-/// byte as decimal+comma (~4–5× per byte), and a 10 MB legitimate subset
-/// would expand to ~50 MB IPC payload + a main-thread JSON parse pass.
-/// Frontend `subsetFont()` decodes with the shared local byte decoder
-/// instead of relying on host-provided Web APIs.
-pub fn subset_font_b64(
-    font_path: String,
-    font_index: u32,
-    codepoints: Vec<u32>,
-) -> Result<String, String> {
-    use base64::Engine as _;
-    let bytes = subset_font(font_path, font_index, codepoints)?;
-    Ok(base64::engine::general_purpose::STANDARD.encode(&bytes))
 }
 
 /// Returns true if `font_data` begins with the **TrueType / OpenType

--- a/src-tauri/src/fonts.rs
+++ b/src-tauri/src/fonts.rs
@@ -213,7 +213,7 @@ pub const MAX_SUBSET_CODEPOINTS: usize = 200_000;
 /// any legitimate font collection and inside u8 range so the value
 /// fits the OpenType `numFonts` field shape. Extracted from an inline
 /// `255` literal in `subset_font`.
-const MAX_SUBSET_FONT_INDEX: u32 = 255;
+pub(crate) const MAX_SUBSET_FONT_INDEX: u32 = 255;
 
 /// Strip the Win32 extended-length prefix (`\\?\` / `\\?\UNC\`) that
 /// `canonicalize()` adds on Windows, so paths compare consistently
@@ -1281,8 +1281,18 @@ pub fn find_system_font(
 /// (8 family rows + 8 alias rows), not 8 + (8 × 4 style rows).
 const MAX_FAMILY_VARIANTS_PER_FACE: usize = 8;
 const MAX_FACE_NAME_VARIANTS_PER_FACE: usize = 8;
-const MAX_LEGACY_NAME_RECORD_BYTES: usize = 4096;
-const MAX_LEGACY_NAME_DECODE_ATTEMPTS_PER_FACE: usize = 256;
+/// Shared bound for both the skrifa and legacy OpenType `name` decoders.
+/// A family name accepted by this app is at most 256 Unicode scalars, so a
+/// record larger than 4 KiB cannot add a useful name. Keeping one limit for
+/// both paths prevents a crafted table from escaping through whichever
+/// decoder happens to understand its platform/encoding tuple.
+const MAX_NAME_RECORD_BYTES: usize = 4096;
+
+/// Maximum unique name records whose string payload may be decoded for one
+/// face. The OpenType record count is a u16, but payload offsets may overlap,
+/// so an attacker can otherwise make tens of thousands of records repeatedly
+/// decode the same large invalid string.
+const MAX_NAME_DECODE_ATTEMPTS_PER_FACE: usize = 256;
 const MAX_CMAP12_ENCODING_RECORDS_PER_FACE: usize = 1024;
 const MAX_CMAP12_SUBTABLES_PER_FACE: usize = 128;
 const MAX_CMAP12_GROUPS_PER_FACE: usize = 65_536;
@@ -1636,7 +1646,7 @@ fn decode_legacy_name_record(
     language: u16,
     raw: &[u8],
 ) -> Option<String> {
-    if raw.len() > MAX_LEGACY_NAME_RECORD_BYTES {
+    if raw.len() > MAX_NAME_RECORD_BYTES {
         return None;
     }
 
@@ -1710,9 +1720,13 @@ fn parse_legacy_name_table_entries(
     size_bytes: u64,
     is_collection: bool,
     max_faces: u32,
+    scan_id: u64,
 ) -> Vec<LocalFontEntry> {
     let mut entries = Vec::new();
     for (face_index, face_offset) in sfnt_face_offsets(data, is_collection, max_faces) {
+        if font_scan_cancelled(scan_id) {
+            break;
+        }
         let Some((name_offset, name_len)) = table_range(data, face_offset, b"name") else {
             continue;
         };
@@ -1745,6 +1759,9 @@ fn parse_legacy_name_table_entries(
         let mut seen_records = HashSet::new();
         let mut decode_attempts = 0usize;
         for record_index in 0..record_count {
+            if font_scan_cancelled(scan_id) {
+                break;
+            }
             let Some(record) = name_offset
                 .checked_add(6)
                 .and_then(|v| v.checked_add(record_index.checked_mul(12)?))
@@ -1780,7 +1797,7 @@ fn parse_legacy_name_table_entries(
             let Some(len) = read_be_u16(data, record + 8).map(usize::from) else {
                 continue;
             };
-            if len == 0 || len > MAX_LEGACY_NAME_RECORD_BYTES {
+            if len == 0 || len > MAX_NAME_RECORD_BYTES {
                 continue;
             }
             let Some(offset) = read_be_u16(data, record + 10).map(usize::from) else {
@@ -1798,7 +1815,7 @@ fn parse_legacy_name_table_entries(
             if !seen_records.insert((platform, encoding, language, name_id, start, end)) {
                 continue;
             }
-            if decode_attempts >= MAX_LEGACY_NAME_DECODE_ATTEMPTS_PER_FACE {
+            if decode_attempts >= MAX_NAME_DECODE_ATTEMPTS_PER_FACE {
                 break;
             }
             decode_attempts += 1;
@@ -1884,6 +1901,278 @@ fn merge_legacy_name_table_entries(entries: &mut Vec<LocalFontEntry>, legacy: Ve
     }
 }
 
+#[derive(Default)]
+struct CollectedSkrifaFaceNames {
+    family_variants: HashSet<String>,
+    face_name_variants: HashSet<String>,
+    primary_hint: Option<String>,
+}
+
+enum SkrifaNameWalkOutcome {
+    Completed(CollectedSkrifaFaceNames),
+    Cancelled,
+}
+
+fn decode_skrifa_name_bucket<'a, C>(
+    name_table: &fontcull_skrifa::raw::tables::name::Name<'a>,
+    records: &[&fontcull_skrifa::raw::tables::name::NameRecord],
+    variants: &mut HashSet<String>,
+    max_variants: usize,
+    track_primary: bool,
+    decode_attempts: &mut usize,
+    is_cancelled: &mut C,
+) -> Result<Option<String>, ()>
+where
+    C: FnMut() -> bool,
+{
+    use fontcull_skrifa::string::LocalizedString;
+
+    let mut best_primary_rank = -1i8;
+    let mut best_primary = None;
+    for (record_index, record) in records.iter().enumerate() {
+        if is_cancelled() {
+            return Err(());
+        }
+        if *decode_attempts >= MAX_NAME_DECODE_ATTEMPTS_PER_FACE {
+            break;
+        }
+        if !track_primary && variants.len() >= max_variants {
+            break;
+        }
+        *decode_attempts += 1;
+
+        let localized = LocalizedString::new(name_table, record);
+        let primary_rank = if track_primary {
+            match localized.language() {
+                Some("en-US") => 3,
+                Some("en") => 2,
+                None => 1,
+                Some(_) if record_index == 0 => 0,
+                Some(_) => -1,
+            }
+        } else {
+            -1
+        };
+        let decoded = bounded_font_family_name(localized.chars());
+
+        // Match skrifa's `english_or_first` ranking. The selected record may
+        // itself be malformed; retaining `None` in that case deliberately
+        // permits the typographic-family ID to supply the primary hint.
+        if primary_rank > best_primary_rank {
+            best_primary_rank = primary_rank;
+            best_primary = decoded.clone();
+        }
+        if let Some(value) = decoded {
+            if variants.len() < max_variants || variants.contains(&value) {
+                variants.insert(value);
+            }
+        }
+    }
+    Ok(best_primary)
+}
+
+fn retain_preferred_name(
+    variants: &mut HashSet<String>,
+    preferred: &Option<String>,
+    max_variants: usize,
+) {
+    let Some(preferred) = preferred else {
+        return;
+    };
+    if variants.contains(preferred) {
+        return;
+    }
+    if variants.len() >= max_variants {
+        // Deterministic replacement keeps the bucket bounded while preserving
+        // the preferred English name. Appending here used to produce a ninth
+        // family despite the documented eight-variant ceiling.
+        if let Some(to_remove) = variants.iter().max().cloned() {
+            variants.remove(&to_remove);
+        }
+    }
+    variants.insert(preferred.clone());
+}
+
+/// Collect the four name IDs used by the cache without calling
+/// `MetadataProvider::localized_strings`. That high-level iterator starts at
+/// the beginning of the full name-record slice for every ID and hides the
+/// scan inside `next()`, so caller-side `.take()` cannot bound or cancel it.
+///
+/// This function performs one raw-record pass, polls cancellation at every
+/// record, stores at most one decode budget per target ID, then decodes at
+/// most `MAX_NAME_DECODE_ATTEMPTS_PER_FACE` unique records in the same ID
+/// priority used by the previous implementation.
+fn collect_skrifa_face_names<C>(
+    font_ref: &fontcull_skrifa::FontRef<'_>,
+    mut is_cancelled: C,
+) -> SkrifaNameWalkOutcome
+where
+    C: FnMut() -> bool,
+{
+    use fontcull_skrifa::raw::TableProvider;
+    use fontcull_skrifa::string::StringId;
+
+    if is_cancelled() {
+        return SkrifaNameWalkOutcome::Cancelled;
+    }
+    let name_table = match font_ref.name() {
+        Ok(name_table) => name_table,
+        Err(_) => return SkrifaNameWalkOutcome::Completed(Default::default()),
+    };
+
+    let mut buckets: [Vec<&fontcull_skrifa::raw::tables::name::NameRecord>; 4] =
+        std::array::from_fn(|_| Vec::with_capacity(MAX_NAME_DECODE_ATTEMPTS_PER_FACE));
+    let mut seen_records = HashSet::new();
+    for record in name_table.name_record() {
+        if is_cancelled() {
+            return SkrifaNameWalkOutcome::Cancelled;
+        }
+        let bucket_index = match record.name_id() {
+            StringId::FAMILY_NAME => 0,
+            StringId::TYPOGRAPHIC_FAMILY_NAME => 1,
+            StringId::FULL_NAME => 2,
+            StringId::POSTSCRIPT_NAME => 3,
+            _ => continue,
+        };
+        let length = usize::from(record.length());
+        if length == 0 || length > MAX_NAME_RECORD_BYTES {
+            continue;
+        }
+        let dedup_key = (
+            record.platform_id(),
+            record.encoding_id(),
+            record.language_id(),
+            record.name_id(),
+            record.length(),
+            record.string_offset().to_u32(),
+        );
+        if !seen_records.insert(dedup_key) {
+            continue;
+        }
+        if buckets[bucket_index].len() < MAX_NAME_DECODE_ATTEMPTS_PER_FACE {
+            buckets[bucket_index].push(record);
+        }
+        if buckets
+            .iter()
+            .all(|bucket| bucket.len() >= MAX_NAME_DECODE_ATTEMPTS_PER_FACE)
+        {
+            break;
+        }
+    }
+
+    let mut collected = CollectedSkrifaFaceNames::default();
+    let mut decode_attempts = 0usize;
+    let primary_family = match decode_skrifa_name_bucket(
+        &name_table,
+        &buckets[0],
+        &mut collected.family_variants,
+        MAX_FAMILY_VARIANTS_PER_FACE,
+        true,
+        &mut decode_attempts,
+        &mut is_cancelled,
+    ) {
+        Ok(primary) => primary,
+        Err(()) => return SkrifaNameWalkOutcome::Cancelled,
+    };
+    collected.primary_hint = primary_family;
+
+    if collected.family_variants.len() < MAX_FAMILY_VARIANTS_PER_FACE {
+        let track_primary = collected.primary_hint.is_none();
+        let typographic_primary = match decode_skrifa_name_bucket(
+            &name_table,
+            &buckets[1],
+            &mut collected.family_variants,
+            MAX_FAMILY_VARIANTS_PER_FACE,
+            track_primary,
+            &mut decode_attempts,
+            &mut is_cancelled,
+        ) {
+            Ok(primary) => primary,
+            Err(()) => return SkrifaNameWalkOutcome::Cancelled,
+        };
+        if collected.primary_hint.is_none() {
+            collected.primary_hint = typographic_primary;
+        }
+    }
+
+    for bucket in [&buckets[2], &buckets[3]] {
+        if decode_skrifa_name_bucket(
+            &name_table,
+            bucket,
+            &mut collected.face_name_variants,
+            MAX_FACE_NAME_VARIANTS_PER_FACE,
+            false,
+            &mut decode_attempts,
+            &mut is_cancelled,
+        )
+        .is_err()
+        {
+            return SkrifaNameWalkOutcome::Cancelled;
+        }
+        if collected.face_name_variants.len() >= MAX_FACE_NAME_VARIANTS_PER_FACE {
+            break;
+        }
+    }
+
+    retain_preferred_name(
+        &mut collected.family_variants,
+        &collected.primary_hint,
+        MAX_FAMILY_VARIANTS_PER_FACE,
+    );
+    SkrifaNameWalkOutcome::Completed(collected)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum FontFileSkipReason {
+    MetadataUnreadable,
+    TooLargeBeforeRead,
+    OpenFailed,
+    ReadFailed,
+    GrewPastReadLimit,
+    NoUsableFaces,
+}
+
+impl std::fmt::Display for FontFileSkipReason {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let message = match self {
+            Self::MetadataUnreadable => "metadata could not be read",
+            Self::TooLargeBeforeRead => "file exceeds the 64 MiB font-scan limit",
+            Self::OpenFailed => "file could not be opened",
+            Self::ReadFailed => "file could not be read",
+            Self::GrewPastReadLimit => "file grew beyond the 64 MiB font-scan limit while reading",
+            Self::NoUsableFaces => "no usable OpenType faces or family names were found",
+        };
+        formatter.write_str(message)
+    }
+}
+
+fn safe_font_file_log_label(path: &Path) -> String {
+    path.file_name()
+        .and_then(|name| name.to_str())
+        .filter(|name| validate_ipc_path(name, "Font filename").is_ok())
+        .map(str::to_owned)
+        .unwrap_or_else(|| "<unsafe font filename>".to_string())
+}
+
+fn format_font_file_skip_warning(path: &Path, reason: FontFileSkipReason) -> String {
+    format!(
+        "Skipping font file '{}': {reason}",
+        safe_font_file_log_label(path)
+    )
+}
+
+fn parse_local_font_file(canonical: &Path, scan_id: u64) -> Vec<LocalFontEntry> {
+    match try_parse_local_font_file(canonical, scan_id) {
+        Ok(entries) => entries,
+        Err(reason) => {
+            // One warning per wholly skipped candidate. Use only the validated
+            // basename so local library layout never leaks into a shared log.
+            log::warn!("{}", format_font_file_skip_warning(canonical, reason));
+            Vec::new()
+        }
+    }
+}
+
 /// Parse one font file (TTF/OTF/TTC/OTC) and return a `LocalFontEntry` per
 /// face **and per distinct localized family name** in the face's name table.
 ///
@@ -1898,20 +2187,20 @@ fn merge_legacy_name_table_entries(entries: &mut Vec<LocalFontEntry>, legacy: Ve
 /// is registered later when the emitted batch is committed to the session
 /// SQLite index.
 ///
-/// `scan_id` lets the per-face inner loop poll cancellation BETWEEN faces.
-/// Without this, a single TTC with up to `MAX_TTC_FACES` slow-to-parse
-/// faces could stall the cancel-acknowledge loop for several seconds (the
-/// outer scan only polls between FILES). Also bounds the work a crafted
-/// TTC can demand by giving cancellation a chance to land between face
-/// parses.
+/// `scan_id` lets the parser poll cancellation between faces and during both
+/// raw name-record walks. Without the in-table poll, a crafted face with the
+/// u16 maximum record count could hide a long scan inside skrifa before the
+/// outer file loop observed Cancel.
 ///
 /// `NO_SCAN_ID` is the no-cancellation sentinel. `scan_directory_collecting`
 /// passes it on the cache-populate path (CLI `refresh-fonts` + GUI
 /// post-commit cache populate, neither of which participates in the
 /// scan-cancel system). Interactive scan workers pass a positive id
 /// minted by `begin_font_scan`.
-fn parse_local_font_file(canonical: &Path, scan_id: u64) -> Vec<LocalFontEntry> {
-    use fontcull_skrifa::string::StringId;
+fn try_parse_local_font_file(
+    canonical: &Path,
+    scan_id: u64,
+) -> Result<Vec<LocalFontEntry>, FontFileSkipReason> {
     use fontcull_skrifa::{FontRef, MetadataProvider};
 
     // Extension check is intentionally case-insensitive (.TTF vs .ttf are the
@@ -1927,7 +2216,10 @@ fn parse_local_font_file(canonical: &Path, scan_id: u64) -> Vec<LocalFontEntry> 
         .map(|e| e.to_ascii_lowercase())
         .unwrap_or_default();
     if !ALLOWED_FONT_EXTENSIONS.contains(&ext.as_str()) {
-        return Vec::new();
+        return Ok(Vec::new());
+    }
+    if font_scan_cancelled(scan_id) {
+        return Ok(Vec::new());
     }
 
     // Stat + size-cap guard before fs::read — a malicious user-picked
@@ -1937,11 +2229,11 @@ fn parse_local_font_file(canonical: &Path, scan_id: u64) -> Vec<LocalFontEntry> 
     let size_bytes = match fs::metadata(canonical) {
         Ok(m) => {
             if m.len() > MAX_FONT_DATA_SIZE {
-                return Vec::new();
+                return Err(FontFileSkipReason::TooLargeBeforeRead);
             }
             m.len()
         }
-        Err(_) => return Vec::new(),
+        Err(_) => return Err(FontFileSkipReason::MetadataUnreadable),
     };
     let is_collection = ext == "ttc" || ext == "otc";
     let max_faces = if is_collection { MAX_TTC_FACES } else { 1 };
@@ -1969,11 +2261,11 @@ fn parse_local_font_file(canonical: &Path, scan_id: u64) -> Vec<LocalFontEntry> 
     {
         let file = match std::fs::File::open(canonical) {
             Ok(f) => f,
-            Err(_) => return Vec::new(),
+            Err(_) => return Err(FontFileSkipReason::OpenFailed),
         };
         let mut limited = file.take(MAX_FONT_DATA_SIZE + 1);
         if limited.read_to_end(&mut data).is_err() {
-            return Vec::new();
+            return Err(FontFileSkipReason::ReadFailed);
         }
     }
 
@@ -1986,7 +2278,7 @@ fn parse_local_font_file(canonical: &Path, scan_id: u64) -> Vec<LocalFontEntry> 
     // Err); per-face errors here are all consumed by the scan loop
     // the same way.
     if data.len() as u64 > MAX_FONT_DATA_SIZE {
-        return Vec::new();
+        return Err(FontFileSkipReason::GrewPastReadLimit);
     }
 
     let mut entries = Vec::new();
@@ -2003,11 +2295,10 @@ fn parse_local_font_file(canonical: &Path, scan_id: u64) -> Vec<LocalFontEntry> 
     const MAX_CONSECUTIVE_FAILURES: u32 = 1;
     let mut consecutive_failures: u32 = 0;
     for i in 0..max_faces {
-        // Per-face cancel poll. The outer scan_*_inner loops only check
-        // between files; a 16-face TTC where each face triggers expensive
-        // skrifa name-table walks can otherwise eat several seconds of
-        // unresponsive Cancel button. NO_SCAN_ID is the "no active scan"
-        // sentinel and must never trigger cancellation.
+        // Per-face cancel poll. The raw name-table collectors also poll within
+        // each face; this outer check keeps the common small-table path cheap
+        // and avoids opening the next TTC face after cancellation. NO_SCAN_ID
+        // is the "no active scan" sentinel and must never trigger cancellation.
         //
         // Returning early with the already-parsed faces is safe — the
         // outer scan's cancel branch flushes the buffer (which now
@@ -2048,44 +2339,14 @@ fn parse_local_font_file(canonical: &Path, scan_id: u64) -> Vec<LocalFontEntry> 
             let attrs = font_ref.attributes();
             let bold = attrs.weight.value() >= 600.0;
             let italic = !matches!(attrs.style, fontcull_skrifa::attribute::Style::Normal);
-
-            let mut family_variants: HashSet<String> = HashSet::new();
-            let mut face_name_variants: HashSet<String> = HashSet::new();
-            let mut primary_hint: Option<String> = None;
-            for id in [StringId::FAMILY_NAME, StringId::TYPOGRAPHIC_FAMILY_NAME] {
-                if primary_hint.is_none() {
-                    primary_hint = font_ref
-                        .localized_strings(id)
-                        .english_or_first()
-                        .and_then(|localized| bounded_font_family_name(localized.chars()));
-                }
-
-                for localized in font_ref.localized_strings(id) {
-                    if let Some(name) = bounded_font_family_name(localized.chars()) {
-                        family_variants.insert(name);
-                        if family_variants.len() >= MAX_FAMILY_VARIANTS_PER_FACE {
-                            break;
-                        }
-                    }
-                }
-                if family_variants.len() >= MAX_FAMILY_VARIANTS_PER_FACE {
-                    break;
-                }
-            }
-
-            for id in [StringId::FULL_NAME, StringId::POSTSCRIPT_NAME] {
-                for localized in font_ref.localized_strings(id) {
-                    if let Some(name) = bounded_font_family_name(localized.chars()) {
-                        face_name_variants.insert(name);
-                        if face_name_variants.len() >= MAX_FACE_NAME_VARIANTS_PER_FACE {
-                            break;
-                        }
-                    }
-                }
-                if face_name_variants.len() >= MAX_FACE_NAME_VARIANTS_PER_FACE {
-                    break;
-                }
-            }
+            let CollectedSkrifaFaceNames {
+                mut family_variants,
+                face_name_variants,
+                mut primary_hint,
+            } = match collect_skrifa_face_names(&font_ref, || font_scan_cancelled(scan_id)) {
+                SkrifaNameWalkOutcome::Completed(collected) => collected,
+                SkrifaNameWalkOutcome::Cancelled => return None,
+            };
 
             // Last-resort fallback: malformed fonts may have no family IDs but
             // still have a full name. Indexing that is better than silently
@@ -2097,23 +2358,18 @@ fn parse_local_font_file(canonical: &Path, scan_id: u64) -> Vec<LocalFontEntry> 
                 }
             }
 
-            (
+            Some((
                 family_variants,
                 face_name_variants,
                 primary_hint,
                 bold,
                 italic,
-            )
+            ))
         }));
         let (family_variants, face_name_variants, primary_hint, bold, italic) = match face_result {
-            Ok(t) => t,
-            Err(_) => {
-                log::warn!(
-                    "skrifa panicked while parsing face {i} in '{}' — skipping face",
-                    canonical.display()
-                );
-                continue;
-            }
+            Ok(Some(values)) => values,
+            Ok(None) => break,
+            Err(_) => continue,
         };
 
         if family_variants.is_empty() {
@@ -2137,33 +2393,17 @@ fn parse_local_font_file(canonical: &Path, scan_id: u64) -> Vec<LocalFontEntry> 
         let mut families: Vec<String> = family_variants.into_iter().collect();
         families.sort();
         if let Some(ref primary) = primary_hint {
-            match families.iter().position(|v| v == primary) {
-                Some(pos) => {
-                    // rotate_right(1) moves families[pos] to index 0 while keeping
-                    // the elements before it in alphabetical order — swap(0, pos)
-                    // would displace the element at 0 to pos, breaking sort order.
-                    families[..=pos].rotate_right(1);
-                }
-                None => {
-                    // structural fallback when
-                    // `primary_hint` is Some but doesn't appear in
-                    // family_variants. The current
-                    // bounded_font_family_name + localized_strings
-                    // path guarantees primary_hint round-trips through
-                    // the variant set (deterministic on today's
-                    // skrifa builds), but a future skrifa upgrade with
-                    // caller-time normalization could break that
-                    // implicit alignment. Without the explicit push,
-                    // the UI primary name silently reverts to
-                    // sorted-first; pushing primary at index 0 keeps
-                    // the contract structural (not security-relevant,
-                    // but matches the "type-system over doc discipline"
-                    // posture used elsewhere, e.g. current_unix_seconds).
-                    log::debug!(
-                        "primary_hint '{primary}' not in family_variants; prepending explicitly"
-                    );
-                    families.insert(0, primary.clone());
-                }
+            if let Some(pos) = families.iter().position(|value| value == primary) {
+                // rotate_right(1) moves families[pos] to index 0 while keeping
+                // the elements before it in alphabetical order — swap(0, pos)
+                // would displace the element at 0 to pos, breaking sort order.
+                families[..=pos].rotate_right(1);
+            } else {
+                // `collect_skrifa_face_names` structurally retains a preferred
+                // name inside the eight-entry bucket. Keep this loud tripwire
+                // local to materialization in case a future collector changes
+                // that contract.
+                debug_assert!(false, "primary font name missing from bounded variants");
             }
         }
 
@@ -2179,17 +2419,25 @@ fn parse_local_font_file(canonical: &Path, scan_id: u64) -> Vec<LocalFontEntry> 
             size_bytes,
         });
     }
+    if font_scan_cancelled(scan_id) {
+        return Ok(entries);
+    }
     let legacy_entries = parse_legacy_name_table_entries(
         &data,
         &canonical_string,
         size_bytes,
         is_collection,
         max_faces,
+        scan_id,
     );
     if !legacy_entries.is_empty() {
         merge_legacy_name_table_entries(&mut entries, legacy_entries);
     }
-    entries
+    if entries.is_empty() && !font_scan_cancelled(scan_id) {
+        Err(FontFileSkipReason::NoUsableFaces)
+    } else {
+        Ok(entries)
+    }
 }
 
 #[derive(serde::Serialize)]
@@ -2855,19 +3103,22 @@ where
     // rejects.
     //
     // Batch-send failures stay swallowed (UX progress is informational —
-    // missing a few batches is harmless), but the Done send is load-
-    // bearing: `runStreamingScan` on the JS side awaits a donePromise
-    // that only resolves when this event arrives. A dropped receiver
-    // (Channel.onmessage cleared, page unloaded) would otherwise leave
-    // that promise hanging silently. Log WARN so the asymmetric failure
-    // mode is visible in diagnostics.
+    // missing a few batches is harmless), but the Done send remains
+    // diagnostic because `runStreamingScan` awaits it. Tauri owns the JS
+    // callback registration until the Rust Channel is dropped; React renders,
+    // modal hides, and `onmessage` replacement do not unregister it. In the
+    // installed Wry runtime, this send can therefore fail only after the app
+    // event loop/webview is tearing down (or serialization fails), at which
+    // point the old JS realm and its promise are no longer user-visible.
+    // Returning Err here would be worse: the SQLite transaction has already
+    // committed, so an IPC rejection would falsely report a rolled-back scan.
     if let Err(e) = progress.send(ScanProgress::Done {
         reason: outcome.reason,
         added: import.added,
         duplicated: import.duplicated,
     }) {
         log::warn!(
-            "scan {scan_id}: Done sentinel send failed — frontend may be hanging on donePromise ({e})"
+            "scan {scan_id}: Done sentinel send failed after scan commit during app teardown ({e})"
         );
     }
 
@@ -2951,6 +3202,27 @@ pub fn scan_directory_collecting_with_scope(
     dir: &Path,
     scope: FontDirectoryScope,
 ) -> Result<Vec<LocalFontEntry>, String> {
+    scan_directory_collecting_impl(dir, scope, None)
+}
+
+pub(crate) fn scan_directory_collecting_with_snapshot(
+    dir: &Path,
+    scope: FontDirectoryScope,
+) -> Result<(Vec<LocalFontEntry>, crate::font_cache::CacheSourceSnapshot), String> {
+    let mut snapshot = None;
+    let entries = scan_directory_collecting_impl(dir, scope, Some(&mut snapshot))?;
+    let snapshot = snapshot.ok_or_else(|| {
+        "Font source scan completed without a cache snapshot; persistent cache was not changed"
+            .to_string()
+    })?;
+    Ok((entries, snapshot))
+}
+
+fn scan_directory_collecting_impl(
+    dir: &Path,
+    scope: FontDirectoryScope,
+    captured_snapshot: Option<&mut Option<crate::font_cache::CacheSourceSnapshot>>,
+) -> Result<Vec<LocalFontEntry>, String> {
     // (considered, rejected): GUI's
     // scan_font_directory validates inside because it's an IPC entry
     // point (untrusted JS string). The CLI's scan_directory_collecting
@@ -2978,24 +3250,30 @@ pub fn scan_directory_collecting_with_scope(
         return Err(format!("Not a directory: {}", canonical.display()));
     }
     let mut entries: Vec<LocalFontEntry> = Vec::new();
-    let outcome = scan_directory_with_scope_inner(&canonical, scope, NO_SCAN_ID, None, |batch| {
-        // Defense-in-depth against refresh-fonts OOM on crafted font
-        // folders: fail fast if a single source would
-        // push us past the cache-populate cap. The CLI caller in
-        // run_refresh_fonts catches this and continues with the next
-        // dir; without the cap, a malicious pack could hold hundreds
-        // of MB to multi-GB of font metadata in memory before the
-        // `cache.replace_folder` write would even start.
-        if entries.len() + batch.len() > MAX_CACHE_POPULATE_FACES {
-            return Err(format!(
-                "Source has more font faces than the persistent cache safely accepts \
-                 ({}+ faces, cap {MAX_CACHE_POPULATE_FACES}). Skipping this source.",
-                entries.len() + batch.len()
-            ));
-        }
-        entries.extend(batch);
-        Ok(())
-    })?;
+    let outcome = scan_directory_with_scope_inner(
+        &canonical,
+        scope,
+        NO_SCAN_ID,
+        captured_snapshot,
+        |batch| {
+            // Defense-in-depth against refresh-fonts OOM on crafted font
+            // folders: fail fast if a single source would
+            // push us past the cache-populate cap. The CLI caller in
+            // run_refresh_fonts catches this and continues with the next
+            // dir; without the cap, a malicious pack could hold hundreds
+            // of MB to multi-GB of font metadata in memory before the
+            // `cache.replace_folder` write would even start.
+            if entries.len() + batch.len() > MAX_CACHE_POPULATE_FACES {
+                return Err(format!(
+                    "Source has more font faces than the persistent cache safely accepts \
+                     ({}+ faces, cap {MAX_CACHE_POPULATE_FACES}). Skipping this source.",
+                    entries.len() + batch.len()
+                ));
+            }
+            entries.extend(batch);
+            Ok(())
+        },
+    )?;
     if outcome.reason != ScanStopReason::Natural {
         return Err(format!(
             "Font source scan was incomplete ({:?}); persistent cache was not changed",
@@ -4657,6 +4935,60 @@ mod tests {
     }
 
     #[test]
+    fn skrifa_name_decode_cap_accepts_valid_record_at_limit() {
+        let mut records: Vec<(u16, u16, Vec<u8>)> =
+            (0..255).map(|_| (1, 0x0409, vec![0])).collect();
+        records.push((16, 0x0409, utf16be_test_bytes("Boundary Family")));
+        let font = font_with_name_records(&records);
+
+        let collected = collected_skrifa_names(&font);
+        assert!(collected.family_variants.contains("Boundary Family"));
+    }
+
+    #[test]
+    fn skrifa_name_decode_cap_rejects_valid_record_over_limit() {
+        let mut records: Vec<(u16, u16, Vec<u8>)> =
+            (0..256).map(|_| (1, 0x0409, vec![0])).collect();
+        records.push((16, 0x0409, utf16be_test_bytes("Over Budget Family")));
+        let font = font_with_name_records(&records);
+
+        let collected = collected_skrifa_names(&font);
+        assert!(!collected.family_variants.contains("Over Budget Family"));
+        assert!(collected.family_variants.is_empty());
+    }
+
+    #[test]
+    fn skrifa_name_collection_keeps_preferred_name_inside_eight_variant_cap() {
+        let mut records: Vec<(u16, u16, Vec<u8>)> = (0..8)
+            .map(|index| (1, 0x0411, utf16be_test_bytes(&format!("Variant {index}"))))
+            .collect();
+        records.push((1, 0x0409, utf16be_test_bytes("English Preferred")));
+        let font = font_with_name_records(&records);
+
+        let collected = collected_skrifa_names(&font);
+        assert_eq!(collected.family_variants.len(), 8);
+        assert!(collected.family_variants.contains("English Preferred"));
+        assert_eq!(collected.primary_hint.as_deref(), Some("English Preferred"));
+    }
+
+    #[test]
+    fn skrifa_name_collection_polls_cancel_during_raw_record_walk() {
+        let mut records: Vec<(u16, u16, Vec<u8>)> =
+            (0..100).map(|_| (2, 0x0409, vec![0])).collect();
+        records.push((1, 0x0409, utf16be_test_bytes("Too Late")));
+        let font = font_with_name_records(&records);
+        let font_ref = fontcull_skrifa::FontRef::from_index(&font, 0).unwrap();
+        let mut polls = 0usize;
+
+        let outcome = collect_skrifa_face_names(&font_ref, || {
+            polls += 1;
+            polls > 10
+        });
+        assert!(matches!(outcome, SkrifaNameWalkOutcome::Cancelled));
+        assert!(polls <= 11, "raw record walk ignored cancellation: {polls}");
+    }
+
+    #[test]
     fn is_ttc_data_recognizes_ttcf_magic() {
         // Minimal valid TTC header: `ttcf` magic + version + numFonts.
         let data = b"ttcf\x00\x01\x00\x00\x00\x00\x00\x02";
@@ -4697,6 +5029,54 @@ mod tests {
         font.extend_from_slice(&table_len.to_be_bytes());
         font.extend_from_slice(table_data);
         font
+    }
+
+    fn font_with_name_records(records: &[(u16, u16, Vec<u8>)]) -> Vec<u8> {
+        let record_bytes = records
+            .len()
+            .checked_mul(12)
+            .and_then(|bytes| bytes.checked_add(6))
+            .expect("test name table size fits usize");
+        let storage_offset = u16::try_from(record_bytes).expect("test records fit name offset");
+        let mut string_offset = 0usize;
+        let mut table = Vec::new();
+        table.extend_from_slice(&0u16.to_be_bytes());
+        table.extend_from_slice(
+            &u16::try_from(records.len())
+                .expect("test record count fits u16")
+                .to_be_bytes(),
+        );
+        table.extend_from_slice(&storage_offset.to_be_bytes());
+        for (name_id, language_id, bytes) in records {
+            table.extend_from_slice(&3u16.to_be_bytes());
+            table.extend_from_slice(&1u16.to_be_bytes());
+            table.extend_from_slice(&language_id.to_be_bytes());
+            table.extend_from_slice(&name_id.to_be_bytes());
+            table.extend_from_slice(
+                &u16::try_from(bytes.len())
+                    .expect("test name length fits u16")
+                    .to_be_bytes(),
+            );
+            table.extend_from_slice(
+                &u16::try_from(string_offset)
+                    .expect("test string offset fits u16")
+                    .to_be_bytes(),
+            );
+            string_offset += bytes.len();
+        }
+        for (_, _, bytes) in records {
+            table.extend_from_slice(bytes);
+        }
+        font_with_single_table(b"name", &table)
+    }
+
+    fn collected_skrifa_names(font: &[u8]) -> CollectedSkrifaFaceNames {
+        let font_ref = fontcull_skrifa::FontRef::from_index(font, 0)
+            .expect("synthetic name-table font should parse");
+        match collect_skrifa_face_names(&font_ref, || false) {
+            SkrifaNameWalkOutcome::Completed(collected) => collected,
+            SkrifaNameWalkOutcome::Cancelled => panic!("unexpected cancellation"),
+        }
     }
 
     fn cmap12_subtable_with_group_count(group_count: usize) -> Vec<u8> {
@@ -5107,6 +5487,7 @@ mod tests {
             font.len() as u64,
             false,
             1,
+            NO_SCAN_ID,
         );
         assert!(
             entries.is_empty(),
@@ -5116,12 +5497,84 @@ mod tests {
 
     #[test]
     fn decode_legacy_name_record_rejects_oversized_raw_records() {
-        let mut raw = Vec::with_capacity(MAX_LEGACY_NAME_RECORD_BYTES + 2);
-        while raw.len() <= MAX_LEGACY_NAME_RECORD_BYTES {
+        let mut raw = Vec::with_capacity(MAX_NAME_RECORD_BYTES + 2);
+        while raw.len() <= MAX_NAME_RECORD_BYTES {
             raw.extend_from_slice(&[0, b'A']);
         }
 
         assert!(decode_legacy_name_record(3, 1, 0x0409, &raw).is_none());
+    }
+
+    #[test]
+    fn font_file_skip_reason_distinguishes_missing_over_limit_and_malformed_files() {
+        let root = std::env::temp_dir().join(format!(
+            "ssahdrify-font-skip-reasons-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+
+        let missing = root.join("missing.ttf");
+        assert_eq!(
+            try_parse_local_font_file(&missing, NO_SCAN_ID)
+                .err()
+                .expect("missing file should be skipped"),
+            FontFileSkipReason::MetadataUnreadable
+        );
+
+        let oversized = root.join("oversized.ttf");
+        fs::File::create(&oversized)
+            .unwrap()
+            .set_len(MAX_FONT_DATA_SIZE + 1)
+            .unwrap();
+        assert_eq!(
+            try_parse_local_font_file(&oversized, NO_SCAN_ID)
+                .err()
+                .expect("oversized file should be skipped"),
+            FontFileSkipReason::TooLargeBeforeRead
+        );
+
+        let malformed = root.join("malformed.ttf");
+        fs::write(&malformed, b"not an OpenType font").unwrap();
+        assert_eq!(
+            try_parse_local_font_file(&malformed, NO_SCAN_ID)
+                .err()
+                .expect("malformed file should be skipped"),
+            FontFileSkipReason::NoUsableFaces
+        );
+
+        let unreadable = root.join("directory.ttf");
+        fs::create_dir_all(&unreadable).unwrap();
+        assert!(matches!(
+            try_parse_local_font_file(&unreadable, NO_SCAN_ID),
+            Err(FontFileSkipReason::OpenFailed | FontFileSkipReason::ReadFailed)
+        ));
+
+        let unsupported = root.join("not-a-candidate.txt");
+        assert!(
+            try_parse_local_font_file(&unsupported, NO_SCAN_ID)
+                .unwrap()
+                .is_empty(),
+            "unsupported extensions should remain a quiet non-candidate"
+        );
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn font_file_skip_warning_uses_only_a_validated_basename() {
+        let safe = Path::new("/private/library/Broken Font.ttf");
+        let warning = format_font_file_skip_warning(safe, FontFileSkipReason::NoUsableFaces);
+        assert!(warning.contains("Broken Font.ttf"));
+        assert!(!warning.contains("private"));
+        assert!(!warning.contains("library"));
+
+        let unsafe_name = Path::new("/private/library/evil\u{202e}.ttf");
+        let redacted =
+            format_font_file_skip_warning(unsafe_name, FontFileSkipReason::NoUsableFaces);
+        assert!(redacted.contains("<unsafe font filename>"));
+        assert!(!redacted.contains("evil"));
+        assert!(!redacted.contains("private"));
     }
 
     /// Boundary tests for the TTC numFonts peek inside
@@ -6155,6 +6608,28 @@ mod tests {
             })
             .collect();
         assert_eq!(ordered, vec!["first.otf", "last.ttc", "top.ttf"]);
+
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn collecting_scan_returns_its_full_recursive_snapshot_when_no_face_parses() {
+        let root = std::env::temp_dir().join(format!(
+            "ssahdrify-collecting-snapshot-{}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&root);
+        let nested = root.join("nested");
+        fs::create_dir_all(&nested).unwrap();
+        fs::write(nested.join("broken.ttf"), b"not a font").unwrap();
+
+        let (entries, snapshot) =
+            scan_directory_collecting_with_snapshot(&root, FontDirectoryScope::Recursive)
+                .expect("complete scan should return its discovery snapshot");
+        assert!(entries.is_empty(), "malformed font must not produce faces");
+        assert_eq!(snapshot.directories.len(), 2);
+        assert_eq!(snapshot.files.len(), 1);
+        assert!(snapshot.files[0].file_path.ends_with("broken.ttf"));
 
         let _ = fs::remove_dir_all(&root);
     }

--- a/src-tauri/src/fonts.rs
+++ b/src-tauri/src/fonts.rs
@@ -1191,7 +1191,6 @@ fn is_user_font_face_registered(canonical_path: &str, face_index: u32) -> Result
 /// Find a system font file path by family name, bold, and italic flags.
 /// Returns the path + face index. Prefers TTF/TTC over OTF/OTC for subtitle
 /// renderer compatibility (libass/VSFilter don't support OTF bold).
-#[tauri::command]
 pub fn find_system_font(
     family: String,
     bold: bool,
@@ -3458,9 +3457,9 @@ pub fn cancel_font_scan(scan_id: u64) {
     CANCEL_SCAN_ID.fetch_max(scan_id, Ordering::Release);
 }
 
-/// Look up a font face in the user's local source index by family
-/// + bold + italic. Returns `None` if no match — callers fall back
-/// to system fonts.
+/// Look up a font face in the user's local source index by family plus the
+/// bold and italic flags. Returns `None` if no match — callers fall back to
+/// system fonts.
 ///
 /// Stale-path note: a path returned here is one that was on disk at
 /// the time of the most-recent scan that produced this row. If the
@@ -3471,7 +3470,6 @@ pub fn cancel_font_scan(scan_id: u64) {
 /// embed-pass IO without changing the outcome (subset_font would
 /// fail the same way half a second later). The scan-then-resolve
 /// model assumes the user doesn't shuffle font files mid-embed.
-#[tauri::command]
 pub fn resolve_user_font(
     family: String,
     bold: bool,
@@ -3516,7 +3514,6 @@ pub fn resolve_user_font(
     .map_err(|e| db_error("lookup failed", e))
 }
 
-#[tauri::command]
 pub fn remove_font_source(source_id: String, kind: Option<String>) -> Result<(), String> {
     validate_font_source_id(&source_id)?;
     let _mutation_guard =
@@ -3576,7 +3573,6 @@ pub fn remove_font_source(source_id: String, kind: Option<String>) -> Result<(),
     Ok(())
 }
 
-#[tauri::command]
 pub fn clear_font_sources() -> Result<(), String> {
     // Acquire CacheMutationGuard upfront so session-DB clear and
     // persistent-cache eviction commit atomically.
@@ -3997,10 +3993,10 @@ fn is_in_system_fonts_dir(canonical: &Path) -> bool {
 /// Returns an error on subsetting failure instead of embedding the full font.
 ///
 /// Public IPC entry point + the CLI's standalone-embed callsite both
-/// invoke this function as a regular `pub fn`; the `#[tauri::command]`
-/// shim `subset_font_b64` below wraps it for the GUI's IPC path with
-/// base64 encoding so the frontend doesn't pay the JSON `[byte, ...]`
-/// expansion (~4–5× per byte → ~50 MB on a worst-case 10 MB subset).
+/// invoke this function as a regular `pub fn`; the GUI reaches it through
+/// `ipc_commands::subset_font_b64`, which runs the base64 helper below on the
+/// blocking pool so the frontend doesn't pay the JSON `[byte, ...]` expansion
+/// (~4–5× per byte → ~50 MB on a worst-case 10 MB subset).
 /// CLI's chain mode marshals subsets via base64 inline (see
 /// `process_one_chain_input`); CLI's standalone embed bundles them
 /// into `engine::FontSubsetPayload` and ships through the engine's
@@ -4010,11 +4006,11 @@ fn is_in_system_fonts_dir(canonical: &Path) -> bool {
 /// **IMPORTANT **: do NOT add `#[tauri::command]`
 /// to this function. The Vec<u8> return shape would JSON-encode as
 /// `[byte, byte, ...]` over the GUI IPC wire, hitting the same ~4-5×
-/// expansion `subset_font_b64` exists specifically to dodge. The
-/// GUI-side IPC path MUST go through `subset_font_b64`; adding the
-/// attribute here would silently bypass that guard and pressure V8
-/// heap on every embed. Future direct exposure must go through an
-/// explicit security and resource-budget audit.
+/// expansion `subset_font_b64` exists specifically to dodge. The GUI-side IPC
+/// path MUST go through `ipc_commands::subset_font_b64`; adding the attribute
+/// here would silently bypass that guard and pressure V8 heap on every embed.
+/// Future direct exposure must go through an explicit security and
+/// resource-budget audit.
 pub fn subset_font(
     font_path: String,
     font_index: u32,
@@ -4424,14 +4420,13 @@ pub fn subset_font(
     }
 }
 
-/// IPC wrapper around `subset_font` that base64-encodes the result so
-/// the GUI's frontend doesn't pay the JSON `[byte, byte, …]` expansion.
+/// Blocking base64 implementation called by `ipc_commands::subset_font_b64`
+/// so the GUI's frontend doesn't pay the JSON `[byte, byte, …]` expansion.
 /// Pre-fix this returned `Vec<u8>` directly; serde-json would write each
 /// byte as decimal+comma (~4–5× per byte), and a 10 MB legitimate subset
 /// would expand to ~50 MB IPC payload + a main-thread JSON parse pass.
 /// Frontend `subsetFont()` decodes with the shared local byte decoder
 /// instead of relying on host-provided Web APIs.
-#[tauri::command]
 pub fn subset_font_b64(
     font_path: String,
     font_index: u32,

--- a/src-tauri/src/fonts.rs
+++ b/src-tauri/src/fonts.rs
@@ -4743,8 +4743,16 @@ fn is_ttc_data(font_data: &[u8]) -> bool {
 ///   original font, which in turn lets the TS embed layer dedup
 ///   aliases that resolve to the same face — without dedup, the
 ///   same face would be subset and embedded once per family alias.
+fn is_gpos_subset_error(error: &fontcull_klippa::SubsetError) -> bool {
+    matches!(
+        error,
+        fontcull_klippa::SubsetError::SubsetTableError(tag)
+            if *tag == fontcull_skrifa::Tag::new(b"GPOS")
+    )
+}
+
 fn subset_with_index(font_data: &[u8], index: u32, codepoints: &[u32]) -> Result<Vec<u8>, String> {
-    use fontcull_klippa::{subset_font, Plan, SubsetFlags};
+    use fontcull_klippa::{subset_font, Plan, SubsetError, SubsetFlags};
     use fontcull_read_fonts::collections::IntSet;
     use fontcull_skrifa::{FontRef, GlyphId, Tag};
     use fontcull_write_fonts::types::NameId;
@@ -4835,21 +4843,27 @@ fn subset_with_index(font_data: &[u8], index: u32, codepoints: &[u32]) -> Result
             &langs,
         );
 
-        // Display, not Debug — same reasoning as above.
-        subset_font(&font, &plan).map_err(|e| format!("Subset failed for face {index}: {e}"))
+        subset_font(&font, &plan)
     };
+
+    let format_subset_error =
+        |error: &SubsetError| format!("Subset failed for face {index}: {error}");
 
     match subset_once(false) {
         Ok(subsetted) => Ok(subsetted),
-        Err(error) if error.contains("table 'GPOS'") => {
+        Err(error) if is_gpos_subset_error(&error) => {
+            let initial_error = format_subset_error(&error);
             log::warn!(
                 "Subsetting face {index} failed on GPOS; retrying with the GPOS table dropped"
             );
             subset_once(true).map_err(|fallback_error| {
-                format!("{error}; retry without GPOS also failed: {fallback_error}")
+                format!(
+                    "{initial_error}; retry without GPOS also failed: {}",
+                    format_subset_error(&fallback_error)
+                )
             })
         }
-        Err(error) => Err(error),
+        Err(error) => Err(format_subset_error(&error)),
     }
 }
 
@@ -5744,6 +5758,22 @@ mod tests {
             "Expected ratio < 30% with tuned Plan, got {:.1}%",
             ratio
         );
+    }
+
+    #[test]
+    fn gpos_retry_classification_uses_the_structured_table_tag() {
+        use fontcull_klippa::SubsetError;
+        use fontcull_skrifa::Tag;
+
+        assert!(is_gpos_subset_error(&SubsetError::SubsetTableError(
+            Tag::new(b"GPOS")
+        )));
+        assert!(!is_gpos_subset_error(&SubsetError::SubsetTableError(
+            Tag::new(b"GSUB")
+        )));
+        assert!(!is_gpos_subset_error(&SubsetError::InvalidTag(
+            "message happens to mention table 'GPOS'".to_string()
+        )));
     }
 
     #[test]

--- a/src-tauri/src/ipc_commands.rs
+++ b/src-tauri/src/ipc_commands.rs
@@ -56,14 +56,32 @@ pub async fn find_system_font(
     .await
 }
 
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 #[tauri::command]
-pub async fn subset_font_b64(
+pub async fn subset_font_bytes(
+    font_path: String,
+    font_index: u32,
+    codepoints: Vec<u32>,
+) -> Result<tauri::ipc::Response, String> {
+    let bytes = run_blocking_command("subset_font_bytes", move || {
+        crate::fonts::subset_font(font_path, font_index, codepoints)
+    })
+    .await?;
+    Ok(tauri::ipc::Response::new(bytes))
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[tauri::command]
+pub async fn subset_font_bytes(
     font_path: String,
     font_index: u32,
     codepoints: Vec<u32>,
 ) -> Result<String, String> {
-    run_blocking_command("subset_font_b64", move || {
-        crate::fonts::subset_font_b64(font_path, font_index, codepoints)
+    run_blocking_command("subset_font_bytes", move || {
+        use base64::Engine as _;
+
+        let bytes = crate::fonts::subset_font(font_path, font_index, codepoints)?;
+        Ok(base64::engine::general_purpose::STANDARD.encode(bytes))
     })
     .await
 }

--- a/src-tauri/src/ipc_commands.rs
+++ b/src-tauri/src/ipc_commands.rs
@@ -1,0 +1,237 @@
+//! Async Tauri boundary for operations that use blocking filesystem, SQLite,
+//! system-font, or font-parser APIs.
+//!
+//! The synchronous implementations stay in their domain modules so the CLI
+//! and focused Rust tests can call them without starting an async runtime.
+//! Every GUI command here moves the complete operation onto Tauri's dedicated
+//! blocking pool; keeping the wrapper layer centralized makes it difficult to
+//! accidentally register a blocking implementation directly.
+
+use crate::dropzone::ExpandedPaths;
+use crate::encoding::ReadTextResult;
+use crate::font_cache_commands::{CacheStatus, DriftReport, RescanResult};
+use crate::fonts::FontLookupResult;
+
+async fn run_blocking_command<T, F>(command: &'static str, operation: F) -> Result<T, String>
+where
+    T: Send + 'static,
+    F: FnOnce() -> Result<T, String> + Send + 'static,
+{
+    tauri::async_runtime::spawn_blocking(operation)
+        .await
+        .map_err(|error| format!("{command} worker failed: {error}"))?
+}
+
+#[tauri::command]
+pub async fn expand_dropped_paths(
+    app: tauri::AppHandle,
+    paths: Vec<String>,
+) -> Result<ExpandedPaths, String> {
+    run_blocking_command("expand_dropped_paths", move || {
+        crate::dropzone::expand_dropped_paths(app, paths)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn read_text_detect_encoding(
+    app: tauri::AppHandle,
+    path: String,
+) -> Result<ReadTextResult, String> {
+    run_blocking_command("read_text_detect_encoding", move || {
+        crate::encoding::read_text_detect_encoding(app, path)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn find_system_font(
+    family: String,
+    bold: bool,
+    italic: bool,
+) -> Result<FontLookupResult, String> {
+    run_blocking_command("find_system_font", move || {
+        crate::fonts::find_system_font(family, bold, italic)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn subset_font_b64(
+    font_path: String,
+    font_index: u32,
+    codepoints: Vec<u32>,
+) -> Result<String, String> {
+    run_blocking_command("subset_font_b64", move || {
+        crate::fonts::subset_font_b64(font_path, font_index, codepoints)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn resolve_user_font(
+    family: String,
+    bold: bool,
+    italic: bool,
+) -> Result<Option<FontLookupResult>, String> {
+    run_blocking_command("resolve_user_font", move || {
+        crate::fonts::resolve_user_font(family, bold, italic)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn remove_font_source(source_id: String, kind: Option<String>) -> Result<(), String> {
+    run_blocking_command("remove_font_source", move || {
+        crate::fonts::remove_font_source(source_id, kind)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn clear_font_sources() -> Result<(), String> {
+    run_blocking_command("clear_font_sources", crate::fonts::clear_font_sources).await
+}
+
+#[tauri::command]
+pub async fn open_font_cache() -> Result<CacheStatus, String> {
+    run_blocking_command(
+        "open_font_cache",
+        crate::font_cache_commands::open_font_cache,
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn detect_font_cache_drift() -> Result<DriftReport, String> {
+    run_blocking_command(
+        "detect_font_cache_drift",
+        crate::font_cache_commands::detect_font_cache_drift,
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn rescan_font_cache_drift() -> Result<RescanResult, String> {
+    run_blocking_command(
+        "rescan_font_cache_drift",
+        crate::font_cache_commands::rescan_font_cache_drift,
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn clear_font_cache() -> Result<(), String> {
+    run_blocking_command(
+        "clear_font_cache",
+        crate::font_cache_commands::clear_font_cache,
+    )
+    .await
+}
+
+#[tauri::command]
+pub async fn lookup_font_family(
+    family: String,
+    bold: bool,
+    italic: bool,
+) -> Result<Option<FontLookupResult>, String> {
+    run_blocking_command("lookup_font_family", move || {
+        crate::font_cache_commands::lookup_font_family(family, bold, italic)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn safe_output_path_exists(app: tauri::AppHandle, path: String) -> Result<bool, String> {
+    run_blocking_command("safe_output_path_exists", move || {
+        crate::safe_io::safe_output_path_exists(app, path)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn safe_write_text_file(
+    app: tauri::AppHandle,
+    path: String,
+    content: String,
+    overwrite: bool,
+) -> Result<(), String> {
+    run_blocking_command("safe_write_text_file", move || {
+        crate::safe_io::safe_write_text_file(app, path, content, overwrite)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn safe_write_style_edit_output(
+    app: tauri::AppHandle,
+    source_path: String,
+    expected_revision: String,
+    output_path: String,
+    content: String,
+) -> Result<(), String> {
+    run_blocking_command("safe_write_style_edit_output", move || {
+        crate::safe_io::safe_write_style_edit_output(
+            app,
+            source_path,
+            expected_revision,
+            output_path,
+            content,
+        )
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn safe_copy_file(
+    app: tauri::AppHandle,
+    src: String,
+    dst: String,
+    overwrite: bool,
+) -> Result<(), String> {
+    run_blocking_command("safe_copy_file", move || {
+        crate::safe_io::safe_copy_file(app, src, dst, overwrite)
+    })
+    .await
+}
+
+#[tauri::command]
+pub async fn safe_rename_file(
+    app: tauri::AppHandle,
+    src: String,
+    dst: String,
+    overwrite: bool,
+) -> Result<(), String> {
+    run_blocking_command("safe_rename_file", move || {
+        crate::safe_io::safe_rename_file(app, src, dst, overwrite)
+    })
+    .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn blocking_dispatch_runs_on_a_worker_thread() {
+        let caller_thread = std::thread::current().id();
+        let worker_thread =
+            tauri::async_runtime::block_on(run_blocking_command("thread_probe", || {
+                Ok(std::thread::current().id())
+            }))
+            .expect("thread probe should complete");
+
+        assert_ne!(caller_thread, worker_thread);
+    }
+
+    #[test]
+    fn blocking_dispatch_preserves_operation_errors() {
+        let error =
+            tauri::async_runtime::block_on(run_blocking_command::<(), _>("error_probe", || {
+                Err("original operation error".to_string())
+            }))
+            .expect_err("operation error should be returned");
+
+        assert_eq!(error, "original operation error");
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -12,11 +12,21 @@ use tauri::Manager;
 
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
-    tauri::Builder::default()
+    let builder = tauri::Builder::default();
+    #[cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))]
+    let builder = builder.plugin(tauri_plugin_single_instance::init(|app, _args, _cwd| {
+        if let Some(window) = app.get_webview_window("main") {
+            let _ = window.show();
+            let _ = window.unminimize();
+            let _ = window.set_focus();
+        }
+    }));
+
+    builder
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
         .setup(|app| {
-            // Install the log plugin FIRST so any `log::warn!` / `log::info!`
+            // Install the log plugin before init helpers so any `log::warn!` / `log::info!`
             // calls from `init_system_dirs`, `init_user_font_db`,
             // `init_gui_font_cache`, or any helper they call have a
             // subscriber to receive them. Without this ordering, early-init

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,6 +4,7 @@ pub mod font_cache;
 pub mod font_cache_commands;
 pub mod fonts;
 pub mod fs_policy;
+mod ipc_commands;
 pub mod safe_io;
 pub mod util;
 
@@ -120,28 +121,30 @@ pub fn run() {
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
-            dropzone::expand_dropped_paths,
-            encoding::read_text_detect_encoding,
-            fonts::find_system_font,
-            fonts::subset_font_b64,
+            ipc_commands::expand_dropped_paths,
+            ipc_commands::read_text_detect_encoding,
+            ipc_commands::find_system_font,
+            ipc_commands::subset_font_b64,
             fonts::preflight_font_directory,
             fonts::preflight_font_files,
             fonts::scan_font_directory,
             fonts::scan_font_files,
+            // Atomic-only control path: keep cancellation immediately available
+            // even when Tauri's blocking pool is busy with font or file work.
             fonts::cancel_font_scan,
-            fonts::resolve_user_font,
-            fonts::remove_font_source,
-            fonts::clear_font_sources,
-            font_cache_commands::open_font_cache,
-            font_cache_commands::detect_font_cache_drift,
-            font_cache_commands::rescan_font_cache_drift,
-            font_cache_commands::clear_font_cache,
-            font_cache_commands::lookup_font_family,
-            safe_io::safe_output_path_exists,
-            safe_io::safe_write_text_file,
-            safe_io::safe_write_style_edit_output,
-            safe_io::safe_copy_file,
-            safe_io::safe_rename_file,
+            ipc_commands::resolve_user_font,
+            ipc_commands::remove_font_source,
+            ipc_commands::clear_font_sources,
+            ipc_commands::open_font_cache,
+            ipc_commands::detect_font_cache_drift,
+            ipc_commands::rescan_font_cache_drift,
+            ipc_commands::clear_font_cache,
+            ipc_commands::lookup_font_family,
+            ipc_commands::safe_output_path_exists,
+            ipc_commands::safe_write_text_file,
+            ipc_commands::safe_write_style_edit_output,
+            ipc_commands::safe_copy_file,
+            ipc_commands::safe_rename_file,
         ])
         .run(tauri::generate_context!())
         .unwrap_or_else(|e| {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -124,7 +124,7 @@ pub fn run() {
             ipc_commands::expand_dropped_paths,
             ipc_commands::read_text_detect_encoding,
             ipc_commands::find_system_font,
-            ipc_commands::subset_font_b64,
+            ipc_commands::subset_font_bytes,
             fonts::preflight_font_directory,
             fonts::preflight_font_files,
             fonts::scan_font_directory,

--- a/src-tauri/src/safe_io.rs
+++ b/src-tauri/src/safe_io.rs
@@ -871,12 +871,13 @@ fn safe_rename_file_inner_with_rename(
     rename_file(src_ref, dst_ref).map_err(|e| format!("Failed to rename file: {e}"))
 }
 
-// ── Tauri commands (production) ────────────────────────────────
+// ── Blocking command implementations ───────────────────────────
+// Async Tauri wrappers live in `ipc_commands`; keeping all scope resolution
+// and filesystem work here lets the CLI/tests reuse the same exact behavior.
 
 /// Check whether an output path already exists before a GUI overwrite
 /// preflight. This intentionally covers subtitle text outputs and
 /// rename-only sidecars, but not arbitrary files.
-#[tauri::command]
 pub fn safe_output_path_exists(app: tauri::AppHandle, path: String) -> Result<bool, String> {
     let scope = crate::fs_policy::app_fs_scope(&app)?;
     safe_output_path_exists_inner(&path, move |p| scope.is_allowed(p))
@@ -884,7 +885,6 @@ pub fn safe_output_path_exists(app: tauri::AppHandle, path: String) -> Result<bo
 /// Write a text file safely. Layered defenses: scope deny enforcement,
 /// subtitle-extension whitelist, symlink rejection on destination,
 /// atomic `create_new(true)` open.
-#[tauri::command]
 pub fn safe_write_text_file(
     app: tauri::AppHandle,
     path: String,
@@ -897,7 +897,6 @@ pub fn safe_write_text_file(
 
 /// Write a previewed style edit to a new sibling file. Existing outputs are
 /// never replaced; the exclusive create-new open is the final collision gate.
-#[tauri::command]
 pub fn safe_write_style_edit_output(
     app: tauri::AppHandle,
     source_path: String,
@@ -920,7 +919,6 @@ pub fn safe_write_style_edit_output(
 /// reparse-point-rejected (a symlinked input would otherwise resolve
 /// to e.g. `~/.ssh/id_rsa` and copy its bytes as if they were a
 /// subtitle).
-#[tauri::command]
 pub fn safe_copy_file(
     app: tauri::AppHandle,
     src: String,
@@ -936,7 +934,6 @@ pub fn safe_copy_file(
 /// unsupported moves fail without pre-deleting an existing destination. Both
 /// endpoints are reparse-checked before the final call so planted shortcuts
 /// fail shut.
-#[tauri::command]
 pub fn safe_rename_file(
     app: tauri::AppHandle,
     src: String,

--- a/src-tauri/src/safe_io.rs
+++ b/src-tauri/src/safe_io.rs
@@ -27,7 +27,7 @@
 //!      `.ass / .ssa / .srt / .vtt / .sub`, matching
 //!      `read_text_detect_encoding` and the TS parser-aligned
 //!      `SUBTITLE_EXTS` set. Copy/rename allows those same text
-//!      extensions plus opaque rename-only sidecars such as `.sup`, but
+//!      extensions plus opaque file-preserving sidecars such as `.sup`, but
 //!      sidecar copies/renames must preserve the sidecar extension
 //!      (`.sup -> .sup`) so a binary subtitle cannot be laundered into a
 //!      future text-readable `.ass`.
@@ -183,7 +183,12 @@ fn check_scope_allows(
     Ok(())
 }
 
-fn scope_resolved_path(path: &Path, label: &str) -> Result<PathBuf, String> {
+struct ResolvedScopePath {
+    path: PathBuf,
+    terminal_reparse_parent: Option<PathBuf>,
+}
+
+fn scope_resolved_path(path: &Path, label: &str) -> Result<ResolvedScopePath, String> {
     let absolute = if path.is_absolute() {
         path.to_path_buf()
     } else {
@@ -220,13 +225,53 @@ fn scope_resolved_path(path: &Path, label: &str) -> Result<PathBuf, String> {
         }
     }
 
-    let mut resolved = existing
-        .canonicalize()
-        .map_err(|e| format!("Failed to resolve {label} path for filesystem scope policy: {e}"))?;
+    let mut terminal_reparse_parent = None;
+    let mut resolved = match existing.canonicalize() {
+        Ok(resolved) => resolved,
+        Err(e)
+            if e.kind() == std::io::ErrorKind::NotFound
+                && missing.is_empty()
+                && is_reparse_point(existing) =>
+        {
+            // A terminal dangling symlink / reparse point occupies the output
+            // slot even though its target cannot be canonicalized. Resolve the
+            // parent instead so scope checks still see through any live alias
+            // ancestors, then append the link's own filename without following
+            // its missing target.
+            let parent = existing.parent().ok_or_else(|| {
+                format!(
+                    "Cannot resolve {label} path for filesystem scope policy: {}",
+                    path.display()
+                )
+            })?;
+            let file_name = existing.file_name().ok_or_else(|| {
+                format!(
+                    "Cannot resolve {label} path for filesystem scope policy: {}",
+                    path.display()
+                )
+            })?;
+            let mut resolved_parent = parent.canonicalize().map_err(|parent_error| {
+                format!(
+                    "Failed to resolve {label} parent for filesystem scope policy: {parent_error}"
+                )
+            })?;
+            terminal_reparse_parent = Some(resolved_parent.clone());
+            resolved_parent.push(file_name);
+            resolved_parent
+        }
+        Err(e) => {
+            return Err(format!(
+                "Failed to resolve {label} path for filesystem scope policy: {e}"
+            ));
+        }
+    };
     for component in missing.iter().rev() {
         resolved.push(component);
     }
-    Ok(resolved)
+    Ok(ResolvedScopePath {
+        path: resolved,
+        terminal_reparse_parent,
+    })
 }
 
 fn check_scope_allows_resolved(
@@ -235,7 +280,21 @@ fn check_scope_allows_resolved(
     label: &str,
 ) -> Result<(), String> {
     let resolved = scope_resolved_path(path, label)?;
-    check_scope_allows(is_allowed, &resolved, label)
+    check_resolved_scope_path(is_allowed, &resolved, label)
+}
+
+fn check_resolved_scope_path(
+    is_allowed: &impl Fn(&Path) -> bool,
+    resolved: &ResolvedScopePath,
+    label: &str,
+) -> Result<(), String> {
+    // Tauri's scope helper follows a terminal symlink before matching policy.
+    // For a dangling relative target that can discard the canonical parent, so
+    // explicitly check the parent captured by the no-follow fallback first.
+    if let Some(parent) = &resolved.terminal_reparse_parent {
+        check_scope_allows(is_allowed, parent, label)?;
+    }
+    check_scope_allows(is_allowed, &resolved.path, label)
 }
 
 fn ensure_parent_dir(path: &Path) -> Result<(), String> {
@@ -263,11 +322,9 @@ fn ensure_parent_dir(path: &Path) -> Result<(), String> {
     Ok(())
 }
 
-/// Remove a destination that already exists, after rejecting any
-/// reparse-point destination. Symlinks/junctions never overwrite —
-/// even when `overwrite=true`, the caller is asked to clear the
-/// shortcut manually rather than let us follow it.
-fn clear_existing_destination(path: &Path, overwrite: bool) -> Result<(), String> {
+/// Inspect an existing destination without mutating it. Returns true for a
+/// replaceable ordinary file and false when the path is absent.
+fn inspect_existing_destination(path: &Path, overwrite: bool) -> Result<bool, String> {
     // `symlink_metadata` (= lstat) returns the link's own metadata
     // without following it. Path::exists() follows symlinks on Unix
     // and would return false for a dangling shortcut, which is the
@@ -315,48 +372,34 @@ fn clear_existing_destination(path: &Path, overwrite: bool) -> Result<(), String
                     path.display()
                 ));
             }
-            // re-check is_reparse_point immediately
-            // before fs::remove_file for posture parity with
-            // safe_copy_file_inner / safe_rename_file_inner's
-            // late re-checks. fs::remove_file of a symlink on
-            // Windows removes the link itself (not the target),
-            // so the security delta is small — but the
-            // codebase pattern is "stat-then-act narrowness via
-            // an immediate re-check", and this site was the lone
-            // remaining outlier. One cheap syscall.
-            //
-            // (syscall count WHY): this is the THIRD
-            // `is_reparse_point` lstat on `path` inside
-            // `clear_existing_destination`: the initial
-            // `fs::symlink_metadata`, the first reparse check, and
-            // this race-time re-check. The first two form a
-            // stat-then-act pair documented earlier; the third was
-            // added for late-race parity. All three are deliberate:
-            // the helper is a
-            // failure-path-only helper (only fires when an existing
-            // destination needs clearing) so the extra syscalls cost
-            // nothing on the happy path. A future round that's
-            // tempted to add a FOURTH lstat here should first factor
-            // `is_reparse_point_from_meta(&meta)` to consume the
-            // already-fetched `meta` instead of paying for another
-            // syscall.
-            if is_reparse_point(path) {
-                log::warn!(
-                    "Refusing to overwrite reparse point at remove-time: {}",
-                    path.display()
-                );
-                return Err(format!(
-                    "Refusing to overwrite a symlink / junction at the destination (race-time detection): {}",
-                    path.display()
-                ));
-            }
-            fs::remove_file(path)
-                .map_err(|e| format!("Failed to remove existing destination: {e}"))?;
-            Ok(())
+            Ok(true)
         }
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(false),
         Err(e) => Err(format!("Failed to stat destination path: {e}")),
     }
+}
+
+/// Remove a destination that already exists, after rejecting any
+/// reparse-point destination. Symlinks/junctions never overwrite — even when
+/// `overwrite=true`, the caller is asked to clear the shortcut manually.
+fn clear_existing_destination(path: &Path, overwrite: bool) -> Result<(), String> {
+    if !inspect_existing_destination(path, overwrite)? {
+        return Ok(());
+    }
+
+    // Re-check immediately before deletion to narrow the window in which an
+    // ordinary destination could be replaced by a reparse point.
+    if is_reparse_point(path) {
+        log::warn!(
+            "Refusing to overwrite reparse point at remove-time: {}",
+            path.display()
+        );
+        return Err(format!(
+            "Refusing to overwrite a symlink / junction at the destination (race-time detection): {}",
+            path.display()
+        ));
+    }
+    fs::remove_file(path).map_err(|e| format!("Failed to remove existing destination: {e}"))
 }
 
 /// Reject a source that is itself a symlink / junction. Caller's
@@ -381,10 +424,8 @@ fn reject_reparse_source(path: &Path, label: &str) -> Result<(), String> {
 /// file. That's a blind spot of process-level OS-gated heuristics like
 /// the TS-side `isCaseInsensitiveFs`, which derives from `process.platform`
 /// rather than the mount's behavior. Without this gate,
-/// `clear_existing_destination(dst, overwrite=true)` removes dst first
-/// — which IS src under FS-level case-fold — then `fs::rename` /
-/// `fs::copy` fails because src is gone, silently destroying the user's
-/// input . Both paths must canonicalize for the check
+/// removing/replacing dst would therefore operate on src itself under
+/// filesystem-level case-folding. Both paths must canonicalize for the check
 /// to fire; a not-yet-existing dst (normal rename to a new name)
 /// returns Ok here and the downstream existence checks proceed.
 ///
@@ -403,8 +444,8 @@ fn reject_reparse_source(path: &Path, label: &str) -> Result<(), String> {
 /// Mixed canonicalize-result cases : when EITHER src
 /// OR dst canonicalize-fails (e.g., dst doesn't yet exist, which is
 /// the common "rename to a new name" case), this helper returns Ok
-/// and the downstream `clear_existing_destination` + `fs::rename` /
-/// `fs::copy` chain takes over. Mixed-Ok-Err is symmetric with
+/// and the downstream destination inspection plus `fs::rename` / `fs::copy`
+/// chain takes over. Mixed-Ok-Err is symmetric with
 /// both-Err: the gate only fires when both sides resolve. The
 /// `fs::rename` /  `fs::copy` calls will surface a focused error if
 /// the side that canonicalize-failed turns out to be the problem,
@@ -433,9 +474,9 @@ fn reject_same_canonical_path(src: &Path, dst: &Path) -> Result<(), String> {
 /// while the user's prior data is already gone — they get the error
 /// but no recovery path. A tmp-file + atomic-rename pattern would
 /// close this gap, but this desktop app's current scope accepts the
-/// simpler shape: subtitle files are
-/// small (under 100 MB hard cap), local disks are reliable, the user
-/// can rerun the conversion. Don't refactor to tmp+rename without
+/// simpler shape: generated subtitle text outputs are capped at 50 MiB by
+/// `MAX_TEXT_SIZE`, local disks are reliable, and the user can rerun the
+/// conversion. Don't refactor to tmp+rename without
 /// re-checking the scope — the create_new gate ABOVE is load-bearing
 /// against symlink races; a naive `fs::write` to a tmp path would
 /// need the same gate transplanted onto the tmp file.
@@ -447,6 +488,13 @@ fn create_new_and_write_bytes(path: &Path, content: &[u8]) -> Result<(), String>
         .map_err(|e| format!("Failed to create destination: {e}"))?;
     file.write_all(content)
         .map_err(|e| format!("Failed to write destination: {e}"))
+}
+
+fn check_plain_text_size(content_len: usize) -> Result<(), String> {
+    if content_len > MAX_TEXT_SIZE as usize {
+        return Err("Subtitle content exceeds the 50 MB limit".to_string());
+    }
+    Ok(())
 }
 
 fn create_new_and_write_bytes_exclusive(path: &Path, content: &[u8]) -> Result<(), String> {
@@ -585,6 +633,7 @@ pub fn safe_write_text_file_inner(
     check_subtitle_extension(path_ref, "Output")?;
     check_scope_allows(&is_allowed, path_ref, "Output")?;
     check_scope_allows_resolved(&is_allowed, path_ref, "Output")?;
+    check_plain_text_size(content.len())?;
     ensure_parent_dir(path_ref)?;
     clear_existing_destination(path_ref, overwrite)?;
     create_new_and_write_bytes(path_ref, content.as_bytes())
@@ -684,6 +733,11 @@ pub fn safe_write_style_edit_output_inner(
     create_new_and_write_bytes_exclusive(output_ref, &bytes)
 }
 
+/// File-preserving copies intentionally have no decoded-text size cap: they
+/// stream bytes and also support opaque subtitle sidecars such as `.sup`.
+/// The source is opened and confirmed to be a regular file before an existing
+/// destination is removed. Once copying begins, a destination write failure can
+/// still leave a partial file; the source remains intact so the user can retry.
 pub fn safe_copy_file_inner(
     src: &str,
     dst: &str,
@@ -702,10 +756,9 @@ pub fn safe_copy_file_inner(
     reject_reparse_source(src_ref, "copy")?;
     reject_same_canonical_path(src_ref, dst_ref)?;
     ensure_parent_dir(dst_ref)?;
-    clear_existing_destination(dst_ref, overwrite)?;
 
-    // re-check `is_reparse_point` immediately
-    // before `File::open` to close the TOCTOU window where an
+    // Re-check `is_reparse_point` immediately before `File::open` to narrow the
+    // TOCTOU window where an
     // attacker could swap the source for a symlink between
     // `reject_reparse_source` (above) and the open below. Mirrors the
     // pattern `encoding.rs::read_text_detect_encoding` already
@@ -722,6 +775,20 @@ pub fn safe_copy_file_inner(
     }
 
     let mut source = fs::File::open(src_ref).map_err(|e| format!("Failed to open source: {e}"))?;
+    let source_metadata = source
+        .metadata()
+        .map_err(|e| format!("Failed to inspect opened source: {e}"))?;
+    if !source_metadata.is_file() {
+        return Err(format!(
+            "Source is not a regular file: {}",
+            src_ref.display()
+        ));
+    }
+
+    // Only after the source is ready do we remove an existing destination.
+    // Missing, locked, or directory-shaped sources must never destroy the old
+    // destination before the copy has even started.
+    clear_existing_destination(dst_ref, overwrite)?;
     let mut destination = fs::OpenOptions::new()
         .write(true)
         .create_new(true)
@@ -732,11 +799,26 @@ pub fn safe_copy_file_inner(
         .map_err(|e| format!("Failed to copy file: {e}"))
 }
 
+/// File-preserving renames intentionally have no decoded-text size cap: they
+/// move filesystem entries and also support opaque subtitle sidecars such as
+/// `.sup`.
 pub fn safe_rename_file_inner(
     src: &str,
     dst: &str,
     overwrite: bool,
     is_allowed: impl Fn(&Path) -> bool,
+) -> Result<(), String> {
+    safe_rename_file_inner_with_rename(src, dst, overwrite, is_allowed, |source, destination| {
+        fs::rename(source, destination)
+    })
+}
+
+fn safe_rename_file_inner_with_rename(
+    src: &str,
+    dst: &str,
+    overwrite: bool,
+    is_allowed: impl Fn(&Path) -> bool,
+    rename_file: impl FnOnce(&Path, &Path) -> std::io::Result<()>,
 ) -> Result<(), String> {
     validate_ipc_path(src, "Source")?;
     validate_ipc_path(dst, "Destination")?;
@@ -750,7 +832,10 @@ pub fn safe_rename_file_inner(
     reject_reparse_source(src_ref, "rename")?;
     reject_same_canonical_path(src_ref, dst_ref)?;
     ensure_parent_dir(dst_ref)?;
-    clear_existing_destination(dst_ref, overwrite)?;
+    // Keep an ordinary existing destination in place until the OS performs the
+    // rename. A cross-volume, permission, or sharing failure must not destroy
+    // the user's prior destination.
+    inspect_existing_destination(dst_ref, overwrite)?;
 
     // Re-check `is_reparse_point` immediately before `fs::rename` for
     // parity with `safe_copy_file_inner`'s open-time re-check.
@@ -768,9 +853,8 @@ pub fn safe_rename_file_inner(
     // Rename destination TOCTOU symmetry: copy's destination
     // is implicitly protected by `OpenOptions::create_new(true)` at
     // open time; rename has no equivalent atomic guard. Between
-    // `clear_existing_destination` (which removed dst after its own
-    // reparse pre-check) and the `fs::rename` below, an attacker can
-    // re-plant a symlink at dst — same window copy already closes.
+    // destination inspection and the `fs::rename` below, an attacker can
+    // replace dst with a symlink — same window copy already closes.
     // One syscall (`is_reparse_point` = lstat on POSIX, file_attributes
     // on Windows); race window is narrow but the cost is trivial.
     if is_reparse_point(dst_ref) {
@@ -784,7 +868,7 @@ pub fn safe_rename_file_inner(
         );
     }
 
-    fs::rename(src_ref, dst_ref).map_err(|e| format!("Failed to rename file: {e}"))
+    rename_file(src_ref, dst_ref).map_err(|e| format!("Failed to rename file: {e}"))
 }
 
 // ── Tauri commands (production) ────────────────────────────────
@@ -849,8 +933,9 @@ pub fn safe_copy_file(
 
 /// Rename / move `src` to `dst` safely. Same gating as `safe_copy_file`.
 /// `fs::rename` is atomic when the platform supports the requested move;
-/// unsupported moves fail through the returned error. Both endpoints are
-/// reparse-checked before the final call so planted shortcuts fail shut.
+/// unsupported moves fail without pre-deleting an existing destination. Both
+/// endpoints are reparse-checked before the final call so planted shortcuts
+/// fail shut.
 #[tauri::command]
 pub fn safe_rename_file(
     app: tauri::AppHandle,
@@ -924,6 +1009,22 @@ mod tests {
         let err = safe_output_path_exists_inner(&path.to_string_lossy(), deny_all).unwrap_err();
         assert!(err.contains("filesystem scope"));
     }
+
+    #[test]
+    fn resolved_scope_check_rejects_denied_terminal_reparse_parent_before_slot() {
+        let denied_parent = PathBuf::from("denied-parent");
+        let resolved = ResolvedScopePath {
+            path: denied_parent.join("out.ass"),
+            terminal_reparse_parent: Some(denied_parent.clone()),
+        };
+
+        let err =
+            check_resolved_scope_path(&|path| path != denied_parent.as_path(), &resolved, "Output")
+                .unwrap_err();
+
+        assert!(err.contains("denied by"), "got: {err}");
+    }
+
     #[test]
     fn write_creates_file_when_dest_missing() {
         let dir = temp_dir("write_missing");
@@ -953,6 +1054,25 @@ mod tests {
         assert!(err.contains("already exists"));
         let content = fs::read_to_string(&path).unwrap();
         assert_eq!(content, "old");
+    }
+
+    #[test]
+    fn plain_text_size_accepts_content_at_50_mib_limit() {
+        assert!(check_plain_text_size(MAX_TEXT_SIZE as usize).is_ok());
+    }
+
+    #[test]
+    fn write_refuses_content_one_byte_over_limit_before_overwrite() {
+        let dir = temp_dir("write_over_limit");
+        let path = dir.join("out.ass");
+        fs::write(&path, b"keep me").unwrap();
+        let oversized = "x".repeat(MAX_TEXT_SIZE as usize + 1);
+
+        let err = safe_write_text_file_inner(&path.to_string_lossy(), &oversized, true, allow_all)
+            .unwrap_err();
+
+        assert_eq!(err, "Subtitle content exceeds the 50 MB limit");
+        assert_eq!(fs::read(&path).unwrap(), b"keep me");
     }
 
     #[test]
@@ -1276,6 +1396,45 @@ mod tests {
     }
 
     #[test]
+    fn copy_missing_source_preserves_existing_destination() {
+        let dir = temp_dir("copy_missing_source");
+        let src = dir.join("missing.ass");
+        let dst = dir.join("dst.ass");
+        fs::write(&dst, b"old destination").unwrap();
+
+        let err = safe_copy_file_inner(
+            &src.to_string_lossy(),
+            &dst.to_string_lossy(),
+            true,
+            allow_all,
+        )
+        .unwrap_err();
+
+        assert!(err.to_ascii_lowercase().contains("source"), "got: {err}");
+        assert_eq!(fs::read(&dst).unwrap(), b"old destination");
+    }
+
+    #[test]
+    fn copy_directory_source_preserves_existing_destination() {
+        let dir = temp_dir("copy_directory_source");
+        let src = dir.join("folder.ass");
+        let dst = dir.join("dst.ass");
+        fs::create_dir(&src).unwrap();
+        fs::write(&dst, b"old destination").unwrap();
+
+        let err = safe_copy_file_inner(
+            &src.to_string_lossy(),
+            &dst.to_string_lossy(),
+            true,
+            allow_all,
+        )
+        .unwrap_err();
+
+        assert!(err.to_ascii_lowercase().contains("source"), "got: {err}");
+        assert_eq!(fs::read(&dst).unwrap(), b"old destination");
+    }
+
+    #[test]
     fn copy_allows_sup_sidecar_when_extension_is_preserved() {
         let dir = temp_dir("copy_sup_sidecar");
         let src = dir.join("src.sup");
@@ -1382,6 +1541,76 @@ mod tests {
     }
 
     #[test]
+    fn rename_overwrite_failure_preserves_source_and_existing_destination() {
+        let dir = temp_dir("rename_overwrite_failure");
+        let src = dir.join("src.ass");
+        let dst = dir.join("dst.ass");
+        fs::write(&src, b"new payload").unwrap();
+        fs::write(&dst, b"old destination").unwrap();
+
+        let err = safe_rename_file_inner_with_rename(
+            &src.to_string_lossy(),
+            &dst.to_string_lossy(),
+            true,
+            allow_all,
+            |source, destination| {
+                assert_eq!(fs::read(source).unwrap(), b"new payload");
+                assert_eq!(fs::read(destination).unwrap(), b"old destination");
+                Err(std::io::Error::other("simulated cross-volume failure"))
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.contains("simulated cross-volume failure"), "got: {err}");
+        assert_eq!(fs::read(&src).unwrap(), b"new payload");
+        assert_eq!(fs::read(&dst).unwrap(), b"old destination");
+    }
+
+    #[test]
+    fn rename_overwrites_existing_destination_when_flag_set() {
+        let dir = temp_dir("rename_overwrite_success");
+        let src = dir.join("src.ass");
+        let dst = dir.join("dst.ass");
+        fs::write(&src, b"new payload").unwrap();
+        fs::write(&dst, b"old destination").unwrap();
+
+        safe_rename_file_inner(
+            &src.to_string_lossy(),
+            &dst.to_string_lossy(),
+            true,
+            allow_all,
+        )
+        .unwrap();
+
+        assert!(!src.exists());
+        assert_eq!(fs::read(&dst).unwrap(), b"new payload");
+    }
+
+    #[test]
+    fn rename_refuses_existing_destination_before_rename_when_overwrite_is_unset() {
+        let dir = temp_dir("rename_no_overwrite");
+        let src = dir.join("src.ass");
+        let dst = dir.join("dst.ass");
+        fs::write(&src, b"new payload").unwrap();
+        fs::write(&dst, b"old destination").unwrap();
+
+        let err = safe_rename_file_inner_with_rename(
+            &src.to_string_lossy(),
+            &dst.to_string_lossy(),
+            false,
+            allow_all,
+            |_, _| -> std::io::Result<()> {
+                panic!("rename callback must not run when overwrite is disabled")
+            },
+        )
+        .unwrap_err();
+
+        assert!(err.contains("overwrite not enabled"), "got: {err}");
+        assert_eq!(fs::read(&src).unwrap(), b"new payload");
+        assert_eq!(fs::read(&dst).unwrap(), b"old destination");
+    }
+
+    #[test]
     fn rename_allows_sup_sidecar_when_extension_is_preserved() {
         let dir = temp_dir("rename_sup_sidecar");
         let src = dir.join("src.sup");
@@ -1454,11 +1683,132 @@ mod tests {
         assert!(!dir.join("dst.ass").exists());
     }
 
-    // Symlink tests are POSIX-only because Windows symlink creation
-    // requires admin or developer mode. The reparse-point detection on
-    // Windows is exercised via `is_reparse_point` unit tests in util.rs;
-    // the safe-io behavior on top of that helper is identical to the
-    // POSIX path tested here.
+    // Symlink tests are POSIX-only because Windows symlink creation may require
+    // admin or Developer Mode. Windows still compile-checks the shared
+    // reparse-point branches; these fixtures pin the filesystem behavior on
+    // platforms where symlink creation is reliable in unprivileged tests.
+    #[cfg(unix)]
+    #[test]
+    fn output_exists_probe_treats_dangling_symlink_as_occupied() {
+        use std::os::unix::fs::symlink;
+        let dir = temp_dir("exists_probe_dangling_symlink");
+        let target = dir.join("missing.ass");
+        let link = dir.join("out.ass");
+        symlink(&target, &link).unwrap();
+
+        assert!(safe_output_path_exists_inner(&link.to_string_lossy(), allow_all).unwrap());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn output_exists_probe_resolves_parent_alias_before_scope_checking_dangling_symlink() {
+        use std::os::unix::fs::symlink;
+        let dir = temp_dir("exists_probe_dangling_scope");
+        let real_parent = dir.join("real");
+        let alias_parent = dir.join("alias");
+        fs::create_dir(&real_parent).unwrap();
+        symlink(&real_parent, &alias_parent).unwrap();
+        let target = real_parent.join("missing.ass");
+        let real_link = real_parent.join("out.ass");
+        symlink(&target, &real_link).unwrap();
+        let raw_link = alias_parent.join("out.ass");
+        let denied_slot = real_parent.canonicalize().unwrap().join("out.ass");
+
+        let err = safe_output_path_exists_inner(&raw_link.to_string_lossy(), move |path| {
+            path != denied_slot
+        })
+        .unwrap_err();
+
+        assert!(err.contains("denied by"), "got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn output_exists_probe_checks_denied_parent_before_relative_dangling_target() {
+        use std::os::unix::fs::symlink;
+        let dir = temp_dir("exists_probe_relative_dangling_scope");
+        let denied_parent = dir.canonicalize().unwrap();
+        let link = dir.join("out.ass");
+        symlink("missing.ass", &link).unwrap();
+
+        // Mirror Tauri 2.11's relevant callback behavior: a terminal symlink
+        // is replaced with read_link's result before policy matching. Its
+        // relative target therefore looks allowed unless our resolver checks
+        // the canonical parent independently.
+        let err = safe_output_path_exists_inner(&link.to_string_lossy(), move |path| {
+            if path == denied_parent {
+                return false;
+            }
+            if fs::symlink_metadata(path)
+                .map(|metadata| metadata.file_type().is_symlink())
+                .unwrap_or(false)
+            {
+                return fs::read_link(path)
+                    .map(|target| target == Path::new("missing.ass"))
+                    .unwrap_or(false);
+            }
+            true
+        })
+        .unwrap_err();
+
+        assert!(err.contains("denied by"), "got: {err}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_refuses_dangling_symlink_destination() {
+        use std::os::unix::fs::symlink;
+        let dir = temp_dir("write_dangling_symlink_dst");
+        let target = dir.join("missing.ass");
+        let link = dir.join("out.ass");
+        symlink(&target, &link).unwrap();
+
+        let err =
+            safe_write_text_file_inner(&link.to_string_lossy(), "replacement", true, allow_all)
+                .unwrap_err();
+
+        assert!(err.contains("symlink"), "got: {err}");
+        assert!(fs::symlink_metadata(&link).is_ok());
+        assert!(!target.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rename_refuses_live_and_dangling_symlink_destinations() {
+        use std::os::unix::fs::symlink;
+        let root = temp_dir("rename_symlink_dst");
+
+        for (case, target_exists) in [("live", true), ("dangling", false)] {
+            let dir = root.join(case);
+            fs::create_dir(&dir).unwrap();
+            let source = dir.join("src.ass");
+            let target = dir.join("target.ass");
+            let link = dir.join("dst.ass");
+            fs::write(&source, b"new payload").unwrap();
+            if target_exists {
+                fs::write(&target, b"sensitive target").unwrap();
+            }
+            symlink("target.ass", &link).unwrap();
+
+            let err = safe_rename_file_inner(
+                &source.to_string_lossy(),
+                &link.to_string_lossy(),
+                true,
+                allow_all,
+            )
+            .unwrap_err();
+
+            assert!(err.contains("symlink"), "{case}: got {err}");
+            assert_eq!(fs::read(&source).unwrap(), b"new payload", "{case}");
+            assert!(fs::symlink_metadata(&link).is_ok(), "{case}");
+            if target_exists {
+                assert_eq!(fs::read(&target).unwrap(), b"sensitive target", "{case}");
+            } else {
+                assert!(!target.exists(), "{case}");
+            }
+        }
+    }
+
     #[cfg(unix)]
     #[test]
     fn write_refuses_existing_symlink_destination() {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -4,7 +4,7 @@
   "identifier": "com.koagaroon.ssahdrify",
   "build": {
     "frontendDist": "../dist",
-    "devUrl": "http://localhost:5173",
+    "devUrl": "http://127.0.0.1:5173",
     "beforeDevCommand": "npm run dev",
     "beforeBuildCommand": "npm run build"
   },
@@ -22,6 +22,7 @@
       }
     ],
     "security": {
+      "devCsp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' ws://127.0.0.1:5173; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; frame-src 'none'; worker-src 'none'; media-src 'none'; manifest-src 'none'",
       "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; frame-src 'none'; worker-src 'none'; media-src 'none'; manifest-src 'none'"
     }
   },

--- a/src-tauri/tests/test_chain.rs
+++ b/src-tauri/tests/test_chain.rs
@@ -417,7 +417,7 @@ fn chain_post_v8_failed_surfaces_oversized_warning() {
     // a skippedCount. Shift's `shiftSubtitles` parses captions
     // line-by-line and emits `skipped: true` placeholders, which
     // shiftTransform forwards to TransformResult.skippedCount —
-    // exactly the surface format_oversized_skipped_warning consumes.
+    // exactly the surface format_oversized_caption_warning consumes.
     let predicted_output = dir.join("oversized.shifted.ass");
     fs::create_dir(&predicted_output).expect("failed to pre-create directory at output path");
 

--- a/src-tauri/tests/test_cli_diagnostics.rs
+++ b/src-tauri/tests/test_cli_diagnostics.rs
@@ -86,6 +86,52 @@ fn engine_bundle_missing() -> Option<String> {
 }
 
 #[test]
+fn verbose_missing_font_diagnostic_strips_control_and_bidi_characters() {
+    if let Some(reason) = engine_bundle_missing() {
+        panic!("engine bundle missing — run `npm run build:engine` first ({reason})");
+    }
+
+    let work = temp_dir("verbose-sanitization");
+    let input = work.join("hostile-font-name.ass");
+    let content = MISSING_FONT_ASS.replace(
+        "DefinitelyMissingSsaHdrifyFont",
+        "Missing\u{202e}Font\u{001b}[2J",
+    );
+    fs::write(&input, content).expect("failed to write hostile font-name fixture");
+
+    let output = run_cli(&[
+        "--lang",
+        "en",
+        "--verbose",
+        "--no-cache",
+        "embed",
+        "--no-system-fonts",
+        input.to_str().unwrap(),
+    ]);
+
+    assert!(
+        output.status.success(),
+        "embed should retain warn-mode success: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("MissingFont[2J"),
+        "sanitized font label should remain readable: {stderr}"
+    );
+    assert!(
+        !stderr.contains('\u{202e}'),
+        "BiDi control leaked: {stderr:?}"
+    );
+    assert!(
+        !stderr.contains('\u{001b}'),
+        "ESC control leaked: {stderr:?}"
+    );
+
+    let _ = fs::remove_dir_all(work);
+}
+
+#[test]
 fn embed_diagnose_reports_written_with_warnings() {
     if let Some(reason) = engine_bundle_missing() {
         // Hard-fail instead of skip-and-return: a skip records PASS in Cargo,

--- a/src-tauri/tests/test_cli_shift.rs
+++ b/src-tauri/tests/test_cli_shift.rs
@@ -1,0 +1,338 @@
+//! End-to-end coverage for CLI path normalization, output reservations,
+//! zero-cue behavior, and BOM-less UTF-16 warning propagation.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+mod common;
+use common::make_real_font_dir;
+
+const VALID_SRT: &str = "1\n00:00:01,000 --> 00:00:02,000\nhello\n";
+const VALID_VTT: &str = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nhello\n";
+
+fn cli_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_ssahdrify-cli"))
+}
+
+fn temp_dir(label: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let dir = std::env::temp_dir().join(format!(
+        "ssahdrify-cli-shift-{label}-{}-{stamp}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&dir).unwrap();
+    dir
+}
+
+fn write_file(parent: &Path, name: &str, content: &str) -> PathBuf {
+    fs::create_dir_all(parent).unwrap();
+    let path = parent.join(name);
+    fs::write(&path, content).unwrap();
+    path
+}
+
+fn write_bomless_utf16le(parent: &Path, name: &str, content: &str) -> PathBuf {
+    fs::create_dir_all(parent).unwrap();
+    let path = parent.join(name);
+    let bytes: Vec<u8> = content.encode_utf16().flat_map(u16::to_le_bytes).collect();
+    fs::write(&path, bytes).unwrap();
+    path
+}
+
+fn run_shift(cwd: &Path, global_args: &[&str], inputs: &[&Path]) -> Output {
+    let mut command = Command::new(cli_path());
+    command.current_dir(cwd).args(["--lang", "en"]);
+    command.args(global_args);
+    command.args(["shift", "--offset", "+1s"]);
+    command.args(inputs);
+    command.output().expect("failed to run shift command")
+}
+
+fn combined_output(output: &Output) -> String {
+    format!(
+        "{}\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+#[test]
+fn shift_normalizes_parent_components_in_input_and_output_directory() {
+    let root = temp_dir("relative-paths");
+    let run_dir = root.join("run");
+    let subs_dir = root.join("subs");
+    let out_dir = root.join("out");
+    fs::create_dir_all(&run_dir).unwrap();
+    write_file(&subs_dir, "episode.srt", VALID_SRT);
+
+    let output = run_shift(
+        &run_dir,
+        &["--output-dir", "../out"],
+        &[Path::new("../subs/episode.srt")],
+    );
+
+    assert!(output.status.success(), "{}", combined_output(&output));
+    let shifted = fs::read_to_string(out_dir.join("episode.shifted.srt")).unwrap();
+    assert!(shifted.contains("00:00:02,000 --> 00:00:03,000"));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn existing_output_skip_releases_the_reservation_for_later_inputs() {
+    let root = temp_dir("skip-release");
+    let out_dir = root.join("out");
+    let first = write_file(&root.join("one"), "episode.srt", VALID_SRT);
+    let second = write_file(&root.join("two"), "episode.srt", VALID_SRT);
+    write_file(&out_dir, "episode.shifted.srt", "pre-existing");
+
+    let output = run_shift(
+        &root,
+        &["--output-dir", out_dir.to_str().unwrap()],
+        &[&first, &second],
+    );
+    let combined = combined_output(&output);
+
+    assert!(output.status.success(), "{combined}");
+    assert!(combined.contains("2 skipped"), "{combined}");
+    assert!(!combined.contains("duplicate output path"), "{combined}");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn failed_conversion_releases_the_reservation_for_a_later_valid_input() {
+    let root = temp_dir("failure-release");
+    let out_dir = root.join("out");
+    fs::create_dir_all(&out_dir).unwrap();
+    let first = write_file(
+        &root.join("one"),
+        "episode.vtt",
+        "WEBVTT\n\nNOTE no shiftable cue\ncomment\n",
+    );
+    let second = write_file(&root.join("two"), "episode.vtt", VALID_VTT);
+
+    let output = run_shift(
+        &root,
+        &["--output-dir", out_dir.to_str().unwrap()],
+        &[&first, &second],
+    );
+    let combined = combined_output(&output);
+
+    assert!(
+        !output.status.success(),
+        "one failed input should keep exit nonzero"
+    );
+    assert!(
+        combined.contains("No shiftable subtitle cues"),
+        "{combined}"
+    );
+    assert!(!combined.contains("duplicate output path"), "{combined}");
+    let shifted = fs::read_to_string(out_dir.join("episode.shifted.vtt")).unwrap();
+    assert!(shifted.contains("00:00:02.000 --> 00:00:03.000"));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn planned_and_written_outputs_keep_their_batch_reservations() {
+    for (label, global_mode) in [("planned", "--dry-run"), ("written", "--overwrite")] {
+        let root = temp_dir(label);
+        let out_dir = root.join("out");
+        fs::create_dir_all(&out_dir).unwrap();
+        let first = write_file(&root.join("one"), "episode.srt", VALID_SRT);
+        let second = write_file(&root.join("two"), "episode.srt", VALID_SRT);
+
+        let output = run_shift(
+            &root,
+            &[global_mode, "--output-dir", out_dir.to_str().unwrap()],
+            &[&first, &second],
+        );
+        let combined = combined_output(&output);
+
+        assert!(!output.status.success(), "{combined}");
+        assert!(combined.contains("duplicate output path"), "{combined}");
+        if global_mode == "--dry-run" {
+            assert!(!out_dir.join("episode.shifted.srt").exists());
+        } else {
+            assert!(out_dir.join("episode.shifted.srt").exists());
+        }
+        let _ = fs::remove_dir_all(root);
+    }
+}
+
+#[test]
+fn format_template_heavy_shift_keeps_planned_and_written_reservations() {
+    for (label, global_mode) in [
+        ("heavy-planned", "--dry-run"),
+        ("heavy-written", "--overwrite"),
+    ] {
+        let root = temp_dir(label);
+        let out_dir = root.join("out");
+        fs::create_dir_all(&out_dir).unwrap();
+        let first = write_file(&root.join("one"), "episode.srt", VALID_SRT);
+        let second = write_file(&root.join("two"), "episode.srt", VALID_SRT);
+
+        let output = Command::new(cli_path())
+            .current_dir(&root)
+            .args([
+                "--lang",
+                "en",
+                global_mode,
+                "--output-dir",
+                out_dir.to_str().unwrap(),
+                "shift",
+                "--offset",
+                "+1s",
+                "--output-template",
+                "{name}.{format}.shifted{ext}",
+            ])
+            .args([&first, &second])
+            .output()
+            .expect("failed to run heavy shift command");
+        let combined = combined_output(&output);
+
+        assert!(!output.status.success(), "{combined}");
+        assert!(combined.contains("duplicate output path"), "{combined}");
+        let expected = out_dir.join("episode.srt.shifted.srt");
+        assert_eq!(expected.exists(), global_mode == "--overwrite");
+        let _ = fs::remove_dir_all(root);
+    }
+}
+
+#[test]
+fn failed_hdr_conversion_releases_its_output_reservation() {
+    let root = temp_dir("hdr-failure-release");
+    let out_dir = root.join("out");
+    fs::create_dir_all(&out_dir).unwrap();
+    let first = write_file(
+        &root.join("one"),
+        "episode.vtt",
+        "WEBVTT\n\nNOTE no convertible cue\ncomment\n",
+    );
+    let second = write_file(&root.join("two"), "episode.srt", VALID_SRT);
+
+    let output = Command::new(cli_path())
+        .current_dir(&root)
+        .args([
+            "--lang",
+            "en",
+            "--output-dir",
+            out_dir.to_str().unwrap(),
+            "hdr",
+            "--eotf",
+            "pq",
+        ])
+        .args([&first, &second])
+        .output()
+        .expect("failed to run HDR command");
+    let combined = combined_output(&output);
+
+    assert!(!output.status.success(), "{combined}");
+    assert!(combined.contains("No subtitle cues detected"), "{combined}");
+    assert!(!combined.contains("duplicate output path"), "{combined}");
+    assert!(out_dir.join("episode.hdr.ass").exists());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn comment_only_vtt_fails_without_creating_an_output() {
+    let root = temp_dir("zero-cue");
+    let input = write_file(
+        &root,
+        "empty.vtt",
+        "WEBVTT\n\nNOTE no shiftable cue\ncomment\n",
+    );
+
+    let output = run_shift(&root, &[], &[&input]);
+
+    assert!(!output.status.success());
+    assert!(combined_output(&output).contains("No shiftable subtitle cues"));
+    assert!(!root.join("empty.shifted.vtt").exists());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn bomless_utf16_inference_is_reported_and_converted_safely() {
+    let root = temp_dir("bomless-utf16");
+    let input = write_bomless_utf16le(&root, "episode.srt", VALID_SRT);
+
+    let output = run_shift(&root, &["--json"], &[&input]);
+
+    assert!(output.status.success(), "{}", combined_output(&output));
+    let report: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be JSON");
+    assert_eq!(
+        report["results"][0]["encoding"],
+        "UTF-16LE (inferred, no BOM)"
+    );
+    assert!(
+        report["results"][0]["warnings"]
+            .as_array()
+            .is_some_and(|warnings| warnings.iter().any(|warning| warning
+                .as_str()
+                .is_some_and(|text| text.contains("best-effort inference")))),
+        "inference warning should be visible in JSON: {report}"
+    );
+    let shifted = fs::read_to_string(root.join("episode.shifted.srt"))
+        .expect("default output should be valid UTF-8");
+    assert!(shifted.contains("00:00:02,000 --> 00:00:03,000"));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn refresh_fonts_normalizes_relative_source_and_cache_paths() {
+    let root = temp_dir("relative-font-cache");
+    let run_dir = root.join("run");
+    fs::create_dir_all(&run_dir).unwrap();
+    make_real_font_dir(&root);
+
+    let output = Command::new(cli_path())
+        .current_dir(&run_dir)
+        .args([
+            "--lang",
+            "en",
+            "--cache-file",
+            "../cache.sqlite3",
+            "refresh-fonts",
+            "--font-dir",
+            "../fonts",
+        ])
+        .output()
+        .expect("failed to run refresh-fonts");
+
+    assert!(output.status.success(), "{}", combined_output(&output));
+    assert!(root.join("cache.sqlite3").exists());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn chain_normalizes_relative_input_and_output_directory() {
+    let root = temp_dir("relative-chain-paths");
+    let run_dir = root.join("run");
+    fs::create_dir_all(&run_dir).unwrap();
+    write_file(&root.join("subs"), "episode.srt", VALID_SRT);
+
+    let output = Command::new(cli_path())
+        .current_dir(&run_dir)
+        .args([
+            "--lang",
+            "en",
+            "--no-cache",
+            "--output-dir",
+            "../out",
+            "chain",
+            "shift",
+            "--offset",
+            "+1s",
+            "../subs/episode.srt",
+        ])
+        .output()
+        .expect("failed to run chain");
+
+    assert!(output.status.success(), "{}", combined_output(&output));
+    let shifted = fs::read_to_string(root.join("out").join("episode.shifted.ass")).unwrap();
+    assert!(shifted.contains("00:00:02,000 --> 00:00:03,000"));
+    let _ = fs::remove_dir_all(root);
+}

--- a/src-tauri/tests/test_cli_shift.rs
+++ b/src-tauri/tests/test_cli_shift.rs
@@ -52,6 +52,41 @@ fn run_shift(cwd: &Path, global_args: &[&str], inputs: &[&Path]) -> Output {
     command.output().expect("failed to run shift command")
 }
 
+#[test]
+fn standalone_shift_reports_inert_cache_flags_without_corrupting_json_stdout() {
+    let root = temp_dir("inert-cache-flags");
+    let input = write_file(&root, "episode.srt", VALID_SRT);
+    let cache = root.join("unused.sqlite3");
+
+    let output = run_shift(
+        &root,
+        &[
+            "--json",
+            "--dry-run",
+            "--no-cache",
+            "--cache-file",
+            cache.to_str().unwrap(),
+        ],
+        &[&input],
+    );
+
+    assert!(output.status.success(), "{}", combined_output(&output));
+    serde_json::from_slice::<serde_json::Value>(&output.stdout)
+        .expect("cache-flag notice must not corrupt JSON stdout");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("shift does not use the persistent font cache"));
+    assert!(stderr.contains("--no-cache"));
+    assert!(stderr.contains("--cache-file"));
+    assert_eq!(
+        stderr.matches("have no effect here").count(),
+        1,
+        "both inert flags should share one notice: {stderr}"
+    );
+    assert!(!cache.exists(), "inert cache path must not be created");
+    assert!(!root.join("episode.shifted.srt").exists());
+    let _ = fs::remove_dir_all(root);
+}
+
 fn combined_output(output: &Output) -> String {
     format!(
         "{}\n{}",

--- a/src/AppErrorBoundary.tsx
+++ b/src/AppErrorBoundary.tsx
@@ -1,0 +1,41 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import "./shell.css";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+export default class AppErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false };
+
+  static getDerivedStateFromError(): State {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo): void {
+    console.error("[ssaHdrify] React render failed", error, info.componentStack);
+  }
+
+  render(): ReactNode {
+    if (!this.state.hasError) return this.props.children;
+
+    return (
+      <main className="app-error-boundary" role="alert" aria-labelledby="app-error-title">
+        <section className="app-error-panel">
+          <h1 id="app-error-title">SSA HDRify ran into a display error</h1>
+          <p>Reload the app to try again. If the error returns, close and reopen SSA HDRify.</p>
+          <p lang="zh-CN">
+            SSA HDRify 界面发生错误。请重新加载应用；若错误再次出现，请关闭后重新打开。
+          </p>
+          <button type="button" onClick={() => window.location.reload()}>
+            Reload app / 重新加载应用
+          </button>
+        </section>
+      </main>
+    );
+  }
+}

--- a/src/cli-engine-entry.test.ts
+++ b/src/cli-engine-entry.test.ts
@@ -217,6 +217,67 @@ describe("time shift timing-map engine helpers", () => {
     expect(result.content).toContain("00:00:04,500 --> 00:00:05,500");
   });
 
+  it("treats a runtime-null timing map as an absent global-shift option", () => {
+    const result = convertShift({
+      inputPath: "C:\\subs\\sample.srt",
+      content: SIMPLE_SRT,
+      offsetMs: 1000,
+      timingMapRules: null as never,
+    });
+
+    expect(result.content).toBe(
+      [
+        "1",
+        "00:00:02,000 --> 00:00:03,000",
+        "one",
+        "",
+        "2",
+        "00:00:06,000 --> 00:00:07,000",
+        "two",
+        "",
+      ].join("\n")
+    );
+  });
+
+  it("treats a runtime-null threshold as absent for a timing-map shift", () => {
+    const result = convertShift({
+      inputPath: "C:\\subs\\sample.srt",
+      content: SIMPLE_SRT,
+      offsetMs: 0,
+      thresholdMs: null as never,
+      timingMapRules: [{ startMs: 0, offsetMs: 500 }],
+    });
+
+    expect(result.shiftedCount).toBe(2);
+    expect(result.content).toContain("00:00:01,500 --> 00:00:02,500");
+    expect(result.content).toContain("00:00:05,500 --> 00:00:06,500");
+  });
+
+  it.each([
+    [
+      "SRT",
+      "C:\\subs\\sample.srt",
+      "1\n00:00:01,000 --> 00:00:02,000\n" +
+        "Z".repeat(65_000) +
+        "\n\n2\n00:00:03,000 --> 00:00:04,000\nNORMAL\n",
+      "1\n00:00:04,000 --> 00:00:05,000\nNORMAL\n",
+    ],
+    [
+      "SUB",
+      "C:\\subs\\sample.sub",
+      `{0}{24}${"Z".repeat(65_000)}\n{48}{72}NORMAL\n`,
+      "{72}{96}NORMAL\n",
+    ],
+  ])(
+    "omits oversized %s captions from exact rebuilt output and reports the skip",
+    (_label, inputPath, content, expected) => {
+      const result = convertShift({ inputPath, content, offsetMs: 1000 });
+
+      expect(result.skippedCount).toBe(1);
+      expect(result.content).toBe(expected);
+    }
+  );
+
   it("rejects accidental mixing of timing map and global shift controls", () => {
     expect(() =>
       convertShift({

--- a/src/cli-engine-entry.ts
+++ b/src/cli-engine-entry.ts
@@ -255,24 +255,29 @@ export function convertHdr(request: HdrConversionRequest): HdrConversionResult {
 }
 
 export function convertShift(request: ShiftConversionRequest): ShiftConversionResult {
+  // Rust currently omits absent optionals, but canonicalize nullish values at
+  // this JS boundary for direct and future JSON callers without widening the
+  // public TypeScript contract.
+  const timingMapRules = request.timingMapRules ?? undefined;
+  const thresholdMs = request.thresholdMs ?? undefined;
   let result:
     | ReturnType<typeof shiftSubtitlesCompact>
     | ReturnType<typeof shiftSubtitlesWithTimingMapCompact>;
-  if (request.timingMapRules !== undefined) {
+  if (timingMapRules !== undefined) {
     if (request.offsetMs !== 0) {
       throw new Error("Timing map shift cannot be combined with a non-zero offsetMs");
     }
-    if (request.thresholdMs !== undefined) {
+    if (thresholdMs !== undefined) {
       throw new Error("Timing map shift cannot be combined with thresholdMs");
     }
     result = shiftSubtitlesWithTimingMapCompact(request.content, {
-      rules: request.timingMapRules,
+      rules: timingMapRules,
     });
   } else {
-    assertFiniteShiftMs(request.offsetMs, request.thresholdMs);
+    assertFiniteShiftMs(request.offsetMs, thresholdMs);
     result = shiftSubtitlesCompact(request.content, {
       offsetMs: request.offsetMs,
-      thresholdMs: request.thresholdMs,
+      thresholdMs,
     });
   }
 

--- a/src/cli-engine-roundtrip.test.ts
+++ b/src/cli-engine-roundtrip.test.ts
@@ -582,10 +582,9 @@ describe("CLI engine entry — input boundary validation", () => {
     expect(() =>
       convertShift({ inputPath: inputAss, content: ASS_FIXTURE, offsetMs: 1000, thresholdMs: NaN })
     ).toThrow(/Invalid thresholdMs/);
-    // A finite offset with NO threshold passes — covering BOTH the omitted
-    // (`undefined`) shape AND the CLI wire `null` shape. The null case
-    // regressed once because the guard only special-cased `undefined`, which
-    // broke the common `shift --offset N` (no --threshold) command.
+    // A finite offset with no threshold passes in both the typed omitted
+    // (`undefined`) shape and a defensive direct/future JSON `null` shape.
+    // The current Rust wire omits `None` optionals rather than sending null.
     expect(() =>
       convertShift({ inputPath: inputAss, content: ASS_FIXTURE, offsetMs: 1000 })
     ).not.toThrow();

--- a/src/features/batch-rename/BatchRename.tsx
+++ b/src/features/batch-rename/BatchRename.tsx
@@ -172,6 +172,10 @@ export default function BatchRename() {
   const [editedRows, setEditedRows] = useState<PairingRow[]>([]);
 
   const pickGenRef = useRef(0);
+  // Output-directory picks have their own generation because the chosen
+  // directory intentionally survives ordinary input re-picks, but Clear and
+  // a newer directory dialog must invalidate an older unresolved dialog.
+  const chosenDirPickGenRef = useRef(0);
   const abortRef = useRef<AbortController | null>(null);
   // Synchronous double-click guard — `busy` state lags setBusy(true) by
   // one render. busyRef is written synchronously at handler entry and
@@ -462,6 +466,7 @@ export default function BatchRename() {
 
   const handleClearFiles = useCallback(() => {
     pickGenRef.current = pickGenRef.current + 1;
+    chosenDirPickGenRef.current = chosenDirPickGenRef.current + 1;
     clearFile("rename");
     setChosenDir(null);
     setUnknownCount(0);
@@ -469,9 +474,20 @@ export default function BatchRename() {
   }, [clearFile]);
 
   const handlePickChosenDir = useCallback(async () => {
-    const dir = await pickOutputDirectory(t);
+    const gen = (chosenDirPickGenRef.current = chosenDirPickGenRef.current + 1);
+    let dir: string | null;
+    try {
+      dir = await pickOutputDirectory(t);
+    } catch (error) {
+      // A stale dialog belongs to an abandoned state and must not emit a
+      // confusing late error after Clear or a newer picker launch.
+      if (gen !== chosenDirPickGenRef.current) return;
+      addLog(t("error_prefix", sanitizeError(error)), "error");
+      return;
+    }
+    if (gen !== chosenDirPickGenRef.current) return;
     if (dir) setChosenDir(dir);
-  }, [t]);
+  }, [addLog, t]);
 
   const handleRunRename = useCallback(async () => {
     if (busy || actionableCount === 0) return;

--- a/src/features/batch-rename/pairing-engine.test.ts
+++ b/src/features/batch-rename/pairing-engine.test.ts
@@ -475,6 +475,18 @@ describe("deriveRenameOutputPath — exact basename match (no lang suffix)", () 
     expect(deriveRenameOutputPath(video, subSc, "rename", null)).toBe(expected);
   });
 
+  it("uses the subtitle directory for rename and the video directory for copy", () => {
+    const separatedVideo = "D:\\video\\Show.S01E01.mkv";
+    const separatedSubtitle = "C:\\subs\\old-name.ass";
+
+    expect(deriveRenameOutputPath(separatedVideo, separatedSubtitle, "rename", null)).toBe(
+      "C:\\subs\\Show.S01E01.ass"
+    );
+    expect(deriveRenameOutputPath(separatedVideo, separatedSubtitle, "copy_to_video", null)).toBe(
+      "D:\\video\\Show.S01E01.ass"
+    );
+  });
+
   it("copy_to_chosen → target dir is the chosen directory", () => {
     const chosen = "D:\\out";
     const out = deriveRenameOutputPath(video, subSc, "copy_to_chosen", chosen);

--- a/src/features/chain/chain-runtime.test.ts
+++ b/src/features/chain/chain-runtime.test.ts
@@ -125,7 +125,7 @@ describe("runChain — single shift step", () => {
   it("reports skippedCount = 0 on a clean shift (no oversized captions)", () => {
     // Pin the structured skippedCount field that replaced the
     // previous note-suffix shape. The Rust shell
-    // routes this through emit_oversized_skipped_warning when > 0;
+    // routes this through its oversized-caption warning when > 0;
     // the zero case must NOT trigger any warning, which the Rust
     // side guarantees only if the field is structurally a number
     // (not a string-parsed suffix).
@@ -137,14 +137,14 @@ describe("runChain — single shift step", () => {
     expect(result.skippedCount).toBe(0);
   });
 
-  it("aggregates skippedCount > 0 when shift parses oversized captions", () => {
+  it("reports skippedCount without recounting preserved cues across shifts", () => {
     // Companion to the standalone-side oversized SRT test in
     // cli-engine-roundtrip.test.ts. The chain runs against ASS, so
     // the fixture stuffs one Dialogue line with text exceeding
     // MAX_CAPTION_TEXT_LEN (64,000 chars). parseAss emits a skipped
     // placeholder for that line, shiftTransform forwards the count
-    // to TransformResult.skippedCount, runChain aggregates into
-    // ChainResult.skippedCount. The note must NOT carry the count
+    // to TransformResult.skippedCount, and runChain promotes it into
+    // ChainResult.skippedCount without recounting it. The note must NOT carry the count
     // as a string suffix (the earlier shape this replaced) —
     // it's structurally separate now.
     const huge = "A".repeat(65_000);
@@ -171,6 +171,20 @@ describe("runChain — single shift step", () => {
     // Note stays clean — no string-embedded skipped count.
     expect(result.notes[0]).not.toMatch(/oversized/i);
     expect(result.notes[0]).not.toMatch(/skipped/i);
+
+    const repeatedShiftPlan: ChainPlan = {
+      steps: [
+        { kind: "shift", params: { offsetMs: 1000 } },
+        { kind: "shift", params: { offsetMs: 2000 } },
+      ],
+      outputTemplate: "{name}.shifted-twice.ass",
+    };
+    const repeated = runChain({
+      plan: repeatedShiftPlan,
+      inputPath: INPUT_PATH,
+      content: oversizedAss,
+    });
+    expect(repeated.skippedCount).toBe(1);
   });
 });
 

--- a/src/features/chain/chain-runtime.test.ts
+++ b/src/features/chain/chain-runtime.test.ts
@@ -504,4 +504,27 @@ describe("resolveChainOutputPath", () => {
       /requires ASS.*SSA content[\s\S]*?Run `hdr` standalone first/
     );
   });
+
+  it.each([" [Script Info]", "\t[V4+ Styles]", "[ Script Info]", "[Script Info ]"])(
+    "hdr step rejects malformed whitespace in an ASS-like header: %j",
+    (header) => {
+      const plan: ChainPlan = {
+        steps: [{ kind: "hdr", params: { eotf: "PQ", brightness: 1000 } }],
+        outputTemplate: "{name}.hdr.ass",
+      };
+      const malformed = [
+        header,
+        "ScriptType: v4.00+",
+        "",
+        "[Events]",
+        "Format: Layer, Start, End, Style, Text",
+        "Dialogue: 0,0:00:01.00,0:00:02.00,Default,Hello",
+        "",
+      ].join("\n");
+
+      expect(() => runChain({ plan, inputPath: INPUT_PATH, content: malformed })).toThrow(
+        /requires ASS.*SSA content/
+      );
+    }
+  );
 });

--- a/src/features/chain/chain-runtime.ts
+++ b/src/features/chain/chain-runtime.ts
@@ -63,11 +63,10 @@ interface TransformResult {
   /**
    * Optional count of captions whose text exceeded
    * MAX_CAPTION_TEXT_LEN (64 KB) and were emitted as skipped
-   * placeholders during this step's processing. Aggregated by
-   * `runChain` into `ChainResult.skippedCount` for the Rust shell
-   * to surface via `emit_oversized_skipped_warning` (stderr +
-   * FileReport.warnings). Previously a note suffix only, which the
-   * Rust shell didn't parse.
+   * placeholders during this step's processing. `runChain` retains
+   * the largest per-step count for the Rust shell's warning path
+   * (stderr + FileReport.warnings). Previously this was only a note
+   * suffix, which the Rust shell did not parse.
    */
   skippedCount?: number;
 }
@@ -138,10 +137,11 @@ function shiftTransform(ctx: TransformContext, params: ShiftStepParams): Transfo
   });
   const shiftedCount = result.shiftedCount;
   // surface skippedCount as a structured field on
-  // TransformResult (not a note suffix). runChain aggregates it
-  // into ChainResult.skippedCount; the Rust shell reads that field
+  // TransformResult (not a note suffix). runChain promotes it
+  // into ChainResult.skippedCount without recounting preserved cues;
+  // the Rust shell reads that field
   // and routes a stderr warning + FileReport.warnings entry via
-  // emit_oversized_skipped_warning, matching the standalone HDR /
+  // its oversized-caption warning path, matching the standalone HDR /
   // Shift CLI paths. The earlier note-suffix approach was opaque to
   // the Rust shell (notes are unparsed strings) and only printed
   // under --verbose, on stdout — neither surface matched the
@@ -258,12 +258,12 @@ function decodeBase64(b64: string, name: string): Uint8Array {
 export function runChain(request: ChainRunRequest): ChainResult {
   const { plan, inputPath, content } = request;
   const notes: string[] = [];
-  // aggregate skipped-caption counts across every step
-  // so the Rust shell sees a single number it can pass to
-  // `emit_oversized_skipped_warning`. Today only shiftTransform
-  // populates `result.skippedCount`; an embed or HDR step that grew
-  // similar semantics would feed in the same way.
-  let totalSkippedCount = 0;
+  // Keep the largest per-step count rather than summing. A preserved
+  // oversized ASS/WebVTT cue is encountered again by every later shift;
+  // summing would report one source cue as several captions. Current
+  // transforms may preserve or remove these cues, but do not create new
+  // oversized cues, so the maximum is the chain-level source count.
+  let skippedCaptionCount = 0;
   let current = content;
 
   // chain-level preflight for the strictest
@@ -376,12 +376,12 @@ export function runChain(request: ChainRunRequest): ChainResult {
       notes.push(result.note);
     }
     if (result.skippedCount !== undefined && result.skippedCount > 0) {
-      totalSkippedCount += result.skippedCount;
+      skippedCaptionCount = Math.max(skippedCaptionCount, result.skippedCount);
     }
   }
 
   const outputPath = resolveChainOutputPath(inputPath, plan.outputTemplate);
-  return { content: current, outputPath, notes, skippedCount: totalSkippedCount };
+  return { content: current, outputPath, notes, skippedCount: skippedCaptionCount };
 }
 
 /**

--- a/src/features/chain/chain-runtime.ts
+++ b/src/features/chain/chain-runtime.ts
@@ -103,18 +103,11 @@ function hdrTransform(ctx: TransformContext, params: HdrStepParams): TransformRe
   // no `[V4+ Styles]` / `[Events]` sections, producing garbage output
   // that's neither ASS nor SRT. Violates no-silent-action: chain
   // either succeeds with the documented contract or surfaces the
-  // mismatch. The probe is shape-only — any line starting with
-  // `[Script Info]` or `[V4+ Styles]` qualifies; both real ASS files
-  // open with at least one of those headers (allowing leading BOM /
-  // whitespace / comments).
-  // bound the whitespace runs explicitly.
-  // Real ASS headers carry no leading whitespace, and renderers
-  // tolerate at most a tab or two before / inside the bracket. {0,16}
-  // is generous past anything legitimate and keeps the regex out of
-  // catastrophic-backtracking territory for crafted inputs (the
-  // chain `.replace(timingRe)` ReDoS regression class). Same shape applies
-  // to the embed preflight regex above; both share this bound.
-  if (!/^\s{0,16}\[\s{0,16}(Script Info|V4\+? Styles)\s{0,16}\]/im.test(ctx.content)) {
+  // mismatch. Keep the section syntax strict and column-zero, matching
+  // the embed preflight's `assertAssShape` contract: an otherwise
+  // header-looking line with leading or inner whitespace is malformed,
+  // not sufficient evidence that this is ASS / SSA content.
+  if (!/^\[(Script Info|V4\+? Styles)\][ \t]*$/im.test(ctx.content)) {
     throw new Error(
       "hdr step requires ASS / SSA content (no [Script Info] or " +
         "[V4+ Styles] header found). Run `hdr` standalone first to " +

--- a/src/features/chain/chain-types.ts
+++ b/src/features/chain/chain-types.ts
@@ -159,11 +159,11 @@ export interface ChainResult {
    */
   notes: string[];
   /**
-   * Aggregate count of captions whose text exceeded
-   * MAX_CAPTION_TEXT_LEN (64 KB) across every step that parses
-   * subtitle content (today: only `shift`). The
+   * Largest per-step count of source captions whose text exceeded
+   * MAX_CAPTION_TEXT_LEN (64 KB). Using the maximum prevents a cue
+   * preserved by several shift steps from being counted repeatedly. The
    * Rust shell reads this directly and routes it through
-   * `emit_oversized_skipped_warning` (stderr + FileReport.warnings),
+   * oversized-caption warning path (stderr + FileReport.warnings),
    * mirroring the standalone HDR / Shift CLI paths. Previously the
    * count was embedded as a suffix in `notes[]`, which the Rust
    * shell never parsed and which printed to stdout (notes loop),

--- a/src/features/font-embed/FontCacheDriftModal.tsx
+++ b/src/features/font-embed/FontCacheDriftModal.tsx
@@ -52,6 +52,10 @@ export default function FontCacheDriftModal({
   // Single mutex across both async actions. Either both buttons are
   // enabled or both are disabled; never one-but-not-the-other.
   const [working, setWorking] = useState<null | "rescanning" | "clearing">(null);
+  // React state updates become visible on the next render. This ref is the
+  // synchronous gate that closes the same-tick double-click window before
+  // either button has re-rendered as disabled.
+  const busyRef = useRef(false);
   const [error, setError] = useState<string | null>(null);
   // Surface the post-op success message inline rather than auto-closing
   // silently — the i18n strings font_cache_rescan_done /
@@ -68,23 +72,8 @@ export default function FontCacheDriftModal({
   // the in-flight Tauri command. The close button's disabled state
   // matches.
   //
-  // `working` is read via a ref inside the handler instead of being a
-  // dep on the effect : the prior `[open, working,
-  // onClose]` dep array tore down and re-attached the keydown listener
-  // on every working-state flip, matching `useFolderDrop`'s explicit
-  // anti-pattern note. Stable handler now mounts once per `open=true`
-  // cycle and reads the latest `working` via the ref each press.
-  const workingRef = useRef(working);
-  useEffect(() => {
-    workingRef.current = working;
-  }, [working]);
-  // Order matters: the workingRef-update effect above MUST stay declared
-  // before this keydown-handler effect. React runs effects in declaration
-  // order within a single component, so the handler always reads the
-  // freshly-synced `workingRef.current`. Reordering or extracting the
-  // two effects across files would break the invariant silently (no
-  // build error, just a stale-closure race when the user presses Esc
-  // mid-rescan).
+  // Read the synchronous gate inside the stable handler so working-state
+  // flips do not tear down and re-attach the global keydown listener.
   useEffect(() => {
     if (!open) return;
     const handler = (e: KeyboardEvent) => {
@@ -96,7 +85,7 @@ export default function FontCacheDriftModal({
       // disabled close button at the top mirrors this — no path
       // closes mid-op.
       e.stopPropagation();
-      if (workingRef.current === null) {
+      if (!busyRef.current) {
         onClose();
       }
     };
@@ -111,23 +100,25 @@ export default function FontCacheDriftModal({
     if (open) closeButtonRef.current?.focus();
   }, [open]);
 
-  // INVARIANT : `requestClose` MUST NOT call onClose
-  // while `working !== null`. The component's open=false→true effect
+  // INVARIANT: `requestClose` MUST NOT call onClose while an operation is
+  // in flight. The component's open=false→true effect
   // (further down) resets transient state on mount/unmount, but
   // App.tsx currently mounts/unmounts the modal — so a future
   // refactor that keeps it mounted would expose stale state on next
   // open ONLY IF `requestClose` permits mid-op close. This single
-  // gate is the contract; the rest of the modal (Esc handler, close
-  // button disabled state) all funnels through here. Test coverage
+  // gate is the contract; the Esc handler and disabled close button
+  // mirror the same gate. Test coverage
   // for this invariant is deferred until the repo adds React Testing
   // Library + happy-dom — no existing infrastructure to render the
   // modal in vitest.
   const requestClose = useCallback(() => {
-    if (working !== null) return;
+    if (busyRef.current) return;
     onClose();
-  }, [working, onClose]);
+  }, [onClose]);
 
   const handleRescan = useCallback(async () => {
+    if (busyRef.current) return;
+    busyRef.current = true;
     // Reset transient states at entry — a prior op's doneMessage or
     // skipped list would otherwise persist next to the in-progress
     // "Rescanning…" banner until rescan finishes.
@@ -137,7 +128,6 @@ export default function FontCacheDriftModal({
     setWorking("rescanning");
     try {
       const result = await rescanFontCacheDrift();
-      setWorking(null);
       setDoneMessage(t("font_cache_rescan_done", result.modifiedRescanned, result.removedEvicted));
       setSkippedFolders(result.skipped);
       onRescanComplete();
@@ -148,23 +138,28 @@ export default function FontCacheDriftModal({
       // U+202E in a drifted folder path can't reverse the surrounding
       // error banner text.
       setError(sanitizeError(e));
+    } finally {
+      busyRef.current = false;
       setWorking(null);
     }
   }, [onRescanComplete, t]);
 
   const handleClear = useCallback(async () => {
+    if (busyRef.current) return;
+    busyRef.current = true;
     setError(null);
     setDoneMessage(null);
     setSkippedFolders([]);
     setWorking("clearing");
     try {
       await clearFontCache();
-      setWorking(null);
       setDoneMessage(t("font_cache_cleared"));
       onClearComplete();
     } catch (e) {
       // Same BiDi reason as handleRescan above.
       setError(sanitizeError(e));
+    } finally {
+      busyRef.current = false;
       setWorking(null);
     }
   }, [onClearComplete, t]);
@@ -174,7 +169,10 @@ export default function FontCacheDriftModal({
   // refactor that keeps it mounted — without this, a stale doneMessage
   // from a prior open would leak into the next drift report.
   useEffect(() => {
-    if (open) {
+    // Do not let a delayed open-transition effect erase the visual working
+    // state after an unusually fast first click; busyRef is already the
+    // synchronous source of truth for that operation.
+    if (open && !busyRef.current) {
       setError(null);
       setDoneMessage(null);
       setSkippedFolders([]);

--- a/src/features/font-embed/FontEmbed.tsx
+++ b/src/features/font-embed/FontEmbed.tsx
@@ -2,10 +2,11 @@ import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import {
   clearFontSources,
   fileNameFromPath,
+  isInferredUtf16,
   openFontCache,
   pickAssFiles,
   pickOutputDirectory,
-  readText,
+  readTextDetectEncoding,
   removeFontSource,
   writeText,
 } from "../../lib/tauri-api";
@@ -301,8 +302,15 @@ export default function FontEmbed() {
         for (const path of paths) {
           if (gen !== pickGenRef.current) return;
           let content: string;
+          let inferredEncodingId: string | undefined;
           try {
-            content = await readText(path);
+            const read = await readTextDetectEncoding(path);
+            if (gen !== pickGenRef.current) return;
+            content = read.text;
+            if (isInferredUtf16(read)) {
+              inferredEncodingId = read.encodingId;
+              addLog(t("msg_inferred_utf16", safeDisplayFileName(path), read.encodingId), "warn");
+            }
           } catch (e) {
             // BiDi parity: read errors carry the file path
             // (often the user-picked path including filename), and
@@ -332,7 +340,12 @@ export default function FontEmbed() {
             cacheLookupCache
           );
           if (gen !== pickGenRef.current) return;
-          cache.set(path, { content, infos: analyzed.infos, usages: analyzed.usages });
+          cache.set(path, {
+            content,
+            infos: analyzed.infos,
+            usages: analyzed.usages,
+            ...(inferredEncodingId !== undefined && { inferredEncodingId }),
+          });
         }
 
         if (cache.size === 0) {
@@ -466,7 +479,7 @@ export default function FontEmbed() {
         const analyzed = await analyzeFonts(prev.content, null, sysCache, true, cacheLookupCache);
         if (gen !== pickGenRef.current) return;
         newCache.set(path, {
-          content: prev.content,
+          ...prev,
           infos: analyzed.infos,
           usages: analyzed.usages,
         });
@@ -813,6 +826,9 @@ export default function FontEmbed() {
                 fileWarnings.length > 0 ? "warn" : "info"
               );
               continue;
+            }
+            if (cached.inferredEncodingId) {
+              addLog(t("msg_inferred_utf16", safeFileName, cached.inferredEncodingId), "warn");
             }
             await writeText(outputPath, result.content);
             const fileWarnings = [...missingWarnings, ...result.warnings];

--- a/src/features/font-embed/FontEmbed.tsx
+++ b/src/features/font-embed/FontEmbed.tsx
@@ -255,6 +255,10 @@ export default function FontEmbed() {
   // selection — see buildConflictMessage / FileContext for rationale.
   const ingestPaths = useCallback(
     async (paths: string[], gen: number) => {
+      // A font-source scan/mutation changes the resolver underneath this
+      // batch. Keep the two workflows mutually exclusive so one selection is
+      // always analyzed against a single source-index generation.
+      if (sourceLocked) return;
       const conflictMsg = buildConflictMessage(paths, "fonts", isFileInUse, t);
       if (conflictMsg) {
         setDropError(conflictMsg);
@@ -271,6 +275,13 @@ export default function FontEmbed() {
       }
       setDropError(null);
 
+      // The accepted selection is now authoritative. Clear both halves of
+      // the previous batch before any await so an all-read/analyze failure
+      // cannot leave an old file strip or let a later source refresh revive
+      // stale per-file analyses. Rejected conflict/count checks above keep
+      // the previous selection by design; only an accepted ingest resets it.
+      perFileAnalysisRef.current = new Map();
+      setFontsFiles(null);
       setFonts([]);
       setFontUsages([]);
       setSelected(new Set());
@@ -349,8 +360,8 @@ export default function FontEmbed() {
         }
 
         if (cache.size === 0) {
-          // No file made it through (all reads failed). Don't enter a
-          // half-loaded state.
+          // No file made it through. The accepted-ingest reset above already
+          // cleared both the visible strip and the authoritative cache.
           return;
         }
 
@@ -364,11 +375,15 @@ export default function FontEmbed() {
         // FontsFilesState.firstFileContent slot — the field is kept for
         // FileContext compatibility but the cache is the authoritative
         // store from here on.
-        const firstSuccessfulPath = paths.find((p) => cache.has(p)) ?? paths[0]!;
-        const firstContent = cache.get(firstSuccessfulPath)?.content ?? "";
-        const names = paths.map(fileNameFromPath);
+        // Publish exactly the cache-backed subset. Failed reads were already
+        // reported once above; keeping them in filePaths would make Embed hit
+        // an impossible cache miss and report the same failure a second time.
+        const successfulPaths = paths.filter((path) => cache.has(path));
+        const firstSuccessfulPath = successfulPaths[0]!;
+        const firstContent = cache.get(firstSuccessfulPath)!.content;
+        const names = successfulPaths.map(fileNameFromPath);
         setFontsFiles({
-          filePaths: paths,
+          filePaths: successfulPaths,
           fileNames: names,
           firstFileContent: firstContent,
         });
@@ -379,7 +394,7 @@ export default function FontEmbed() {
         if (gen === pickGenRef.current) setAnalyzing(false);
       }
     },
-    [isFileInUse, setFontsFiles, addLog, t]
+    [sourceLocked, isFileInUse, setFontsFiles, addLog, t]
   );
 
   const handlePickFiles = useCallback(async () => {
@@ -439,7 +454,7 @@ export default function FontEmbed() {
     // first analysis pass (gen counter saves correctness but the work
     // is thrown away) and produce a confusing "pick disabled, drop
     // accepted" UX.
-    disabled: embedding || analyzing,
+    disabled: embedding || analyzing || sourceLocked,
     t,
   });
 
@@ -733,7 +748,10 @@ export default function FontEmbed() {
             const cached = perFileAnalysisRef.current.get(filePath);
             if (!cached) {
               issueCount++;
-              addLog(t("msg_fonts_error", safeFileName, "analysis cache miss"), "error");
+              addLog(
+                t("msg_fonts_error", safeFileName, t("msg_fonts_analysis_unavailable")),
+                "error"
+              );
               continue;
             }
             if (abortRef.current?.signal.aborted) break;
@@ -1117,11 +1135,12 @@ export default function FontEmbed() {
         )}
         <button
           onClick={handlePickFiles}
-          disabled={analyzing || embedding}
+          disabled={analyzing || embedding || sourceLocked}
           className="flex-none px-5 rounded-lg font-medium text-sm transition-colors"
           style={{
-            background: analyzing || embedding ? "var(--bg-input)" : "var(--accent)",
-            color: analyzing || embedding ? "var(--text-muted)" : "white",
+            background:
+              analyzing || embedding || sourceLocked ? "var(--bg-input)" : "var(--accent)",
+            color: analyzing || embedding || sourceLocked ? "var(--text-muted)" : "white",
             height: "38px",
           }}
         >
@@ -1217,10 +1236,10 @@ export default function FontEmbed() {
       <div className="flex items-center gap-2">
         <button
           onClick={() => setSourceModalOpen(true)}
-          disabled={embedding}
+          disabled={embedding || analyzing || sourceLocked}
           className="px-5 rounded-lg font-medium text-sm transition-colors"
           style={
-            embedding
+            embedding || analyzing || sourceLocked
               ? {
                   background: "var(--accent-disabled-bg)",
                   color: "var(--accent-disabled-text)",
@@ -1245,18 +1264,28 @@ export default function FontEmbed() {
         {fontSources.length > 0 && (
           <button
             onClick={handleClearFontSources}
-            disabled={embedding || sourceLocked}
+            disabled={embedding || analyzing || sourceLocked}
             className="flex-none px-3 rounded-lg text-lg font-bold transition-colors"
             style={{
-              background: embedding || sourceLocked ? "var(--bg-input)" : "var(--cancel-bg)",
-              color: embedding || sourceLocked ? "var(--text-muted)" : "var(--cancel-text)",
+              background:
+                embedding || analyzing || sourceLocked ? "var(--bg-input)" : "var(--cancel-bg)",
+              color:
+                embedding || analyzing || sourceLocked ? "var(--text-muted)" : "var(--cancel-text)",
               height: "38px",
             }}
             // Mirror the Modal's per-row remove tooltip pattern: when
             // disabled-by-busy, the tooltip should match the disabled
             // state instead of the action label that's not currently
             // available.
-            title={sourceLocked ? t("font_sources_scanning") : t("btn_clear_font_sources")}
+            title={
+              embedding
+                ? t("btn_embedding")
+                : analyzing
+                  ? t("btn_analyzing")
+                  : sourceLocked
+                    ? t("font_sources_scanning")
+                    : t("btn_clear_font_sources")
+            }
           >
             ✕
           </button>
@@ -1369,7 +1398,17 @@ export default function FontEmbed() {
                     ) : (
                       <span />
                     )}
-                    <span className={"badge " + (info.filePath ? "badge-green" : "badge-red")}>
+                    <span
+                      className={"badge " + (info.filePath ? "badge-green" : "badge-red")}
+                      title={info.error ?? undefined}
+                      aria-label={
+                        info.filePath
+                          ? t("fonts_found")
+                          : info.error
+                            ? `${t("fonts_missing")}: ${info.error}`
+                            : t("fonts_missing")
+                      }
+                    >
                       {info.filePath ? t("fonts_found") : t("fonts_missing")}
                     </span>
                   </label>
@@ -1438,6 +1477,7 @@ export default function FontEmbed() {
         usages={fontUsages}
         localCoveredKeys={localCoveredKeys}
         hasSubtitle={fileCount > 0}
+        mutationLocked={analyzing || embedding || sourceBusy}
         onAddSource={handleAddFontSource}
         onRemoveSource={handleRemoveFontSource}
         onScanStateChange={setModalScanning}

--- a/src/features/font-embed/FontEmbed.tsx
+++ b/src/features/font-embed/FontEmbed.tsx
@@ -109,6 +109,10 @@ const MAX_BATCH_AGGREGATE_BYTES = 200 * 1024 * 1024;
 
 export default function FontEmbed() {
   const { t } = useI18n();
+  const fontStyleLabels = useMemo(
+    () => ({ bold: t("font_style_bold"), italic: t("font_style_italic") }),
+    [t]
+  );
   const { fontsFiles, setFontsFiles, clearFile, isFileInUse } = useFileContext();
 
   // Aggregated font state for the unified detection grid and checkbox
@@ -984,7 +988,7 @@ export default function FontEmbed() {
   ]);
   useTabStatus("fonts", tabStatus);
 
-  const formatFontLabel = (info: FontInfo) => fontKeyLabel(info.key);
+  const formatFontLabel = (info: FontInfo) => fontKeyLabel(info.key, fontStyleLabels);
 
   const handleClearFiles = useCallback(() => {
     pickGenRef.current = pickGenRef.current + 1;

--- a/src/features/font-embed/FontSourceModal.tsx
+++ b/src/features/font-embed/FontSourceModal.tsx
@@ -56,6 +56,8 @@ interface Props {
   usages: FontUsage[];
   localCoveredKeys: Set<string>;
   hasSubtitle: boolean;
+  /** Parent-owned analysis/embed work currently requires a stable source index. */
+  mutationLocked: boolean;
   onAddSource: (source: FontSource) => void;
   onRemoveSource: (id: string) => void;
   /**
@@ -156,6 +158,7 @@ export default function FontSourceModal(props: Props) {
     usages,
     localCoveredKeys,
     hasSubtitle,
+    mutationLocked,
     onAddSource,
     onRemoveSource,
     onScanStateChange,
@@ -164,6 +167,7 @@ export default function FontSourceModal(props: Props) {
 
   const [busy, setBusy] = useState(false);
   const busyRef = useRef(false);
+  const controlsLocked = busy || mutationLocked;
   const [scanning, setScanning] = useState(false);
   // Wrap setScanning to also notify the parent. Single source of truth
   // for "is the modal scanning" — every setter now goes through here so
@@ -414,7 +418,7 @@ export default function FontSourceModal(props: Props) {
   }, [t]);
 
   const claimScanFlow = useCallback(() => {
-    if (busyRef.current) return false;
+    if (busyRef.current || mutationLocked) return false;
     busyRef.current = true;
     setBusy(true);
     setCancelRequested(false);
@@ -428,7 +432,7 @@ export default function FontSourceModal(props: Props) {
     // mutate . Mirrored in releaseScanFlow.
     setScanningWithParent(true);
     return true;
-  }, [setScanningWithParent]);
+  }, [mutationLocked, setScanningWithParent]);
 
   const releaseScanFlow = useCallback(() => {
     // Ordering note: clearing busyRef synchronously while setBusy(false)
@@ -774,14 +778,16 @@ export default function FontSourceModal(props: Props) {
                     </span>
                     <button
                       type="button"
-                      onClick={() => onRemoveSource(src.id)}
-                      disabled={busy}
+                      onClick={() => {
+                        if (!mutationLocked && !busyRef.current) onRemoveSource(src.id);
+                      }}
+                      disabled={controlsLocked}
                       className="px-2 py-0.5 rounded text-xs"
                       style={{
                         background: "var(--cancel-bg)",
                         color: "var(--cancel-text)",
-                        filter: busy ? "grayscale(1)" : "none",
-                        cursor: busy ? "not-allowed" : "pointer",
+                        filter: controlsLocked ? "grayscale(1)" : "none",
+                        cursor: controlsLocked ? "not-allowed" : "pointer",
                       }}
                       title={busy ? t("font_sources_scanning") : t("font_sources_remove")}
                     >
@@ -794,7 +800,12 @@ export default function FontSourceModal(props: Props) {
           )}
 
           {/* Option cards — explicit shallow folder, recursive library, or files. */}
-          <button type="button" onClick={handleAddFolder} disabled={busy} className="modal-opt">
+          <button
+            type="button"
+            onClick={handleAddFolder}
+            disabled={controlsLocked}
+            className="modal-opt"
+          >
             <span className="modal-opt-icon" aria-hidden="true">
               <svg
                 width="20"
@@ -819,7 +830,7 @@ export default function FontSourceModal(props: Props) {
           <button
             type="button"
             onClick={handleAddFontLibrary}
-            disabled={busy}
+            disabled={controlsLocked}
             className="modal-opt"
           >
             <span className="modal-opt-icon" aria-hidden="true">
@@ -844,7 +855,12 @@ export default function FontSourceModal(props: Props) {
               <div className="modal-opt-sub">{t("font_sources_add_library_sub")}</div>
             </div>
           </button>
-          <button type="button" onClick={handleAddFiles} disabled={busy} className="modal-opt">
+          <button
+            type="button"
+            onClick={handleAddFiles}
+            disabled={controlsLocked}
+            className="modal-opt"
+          >
             <span className="modal-opt-icon" aria-hidden="true">
               <svg
                 width="20"

--- a/src/features/font-embed/FontSourceModal.tsx
+++ b/src/features/font-embed/FontSourceModal.tsx
@@ -15,7 +15,7 @@ import { ask } from "@tauri-apps/plugin-dialog";
 import { sanitizeError, sanitizeForDialog } from "../../lib/dedup-helpers";
 import { isWindowsRuntime } from "../../lib/platform";
 import { useI18n } from "../../i18n/useI18n";
-import type { FontUsage } from "./font-collector";
+import type { FontStyleLabels, FontUsage } from "./font-collector";
 import { fontKeyLabel } from "./font-collector";
 import { userFontKey } from "./font-embedder";
 import { formatFontScanBytes, shouldWarnLargeFontScan } from "./font-source-warning";
@@ -132,7 +132,8 @@ function newScanId(): number {
 function computeCoverage(
   usages: FontUsage[],
   localCoveredKeys: Set<string>,
-  hasSubtitle: boolean
+  hasSubtitle: boolean,
+  styleLabels: Readonly<FontStyleLabels>
 ): { covered: number; total: number; missing: string[] } {
   if (!hasSubtitle || usages.length === 0) {
     return { covered: 0, total: 0, missing: [] };
@@ -144,7 +145,7 @@ function computeCoverage(
     if (localCoveredKeys.has(k)) {
       covered += 1;
     } else {
-      missing.push(fontKeyLabel(u.key));
+      missing.push(fontKeyLabel(u.key, styleLabels));
     }
   }
   return { covered, total: usages.length, missing };
@@ -164,6 +165,10 @@ export default function FontSourceModal(props: Props) {
     onScanStateChange,
   } = props;
   const { t } = useI18n();
+  const fontStyleLabels = useMemo(
+    () => ({ bold: t("font_style_bold"), italic: t("font_style_italic") }),
+    [t]
+  );
 
   const [busy, setBusy] = useState(false);
   const busyRef = useRef(false);
@@ -676,8 +681,8 @@ export default function FontSourceModal(props: Props) {
   // walk. Only the inputs to computeCoverage actually invalidate the
   // result.
   const { covered, total, missing } = useMemo(
-    () => computeCoverage(usages, localCoveredKeys, hasSubtitle),
-    [usages, localCoveredKeys, hasSubtitle]
+    () => computeCoverage(usages, localCoveredKeys, hasSubtitle, fontStyleLabels),
+    [usages, localCoveredKeys, hasSubtitle, fontStyleLabels]
   );
 
   if (!open) return null;

--- a/src/features/font-embed/font-collector.test.ts
+++ b/src/features/font-embed/font-collector.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, it, expect } from "vitest";
 
-import { collectFonts, ensureLoaded } from "./font-collector";
+import { collectFonts, ensureLoaded, fontKeyLabel } from "./font-collector";
 
 function makeASS(dialogue: string): string {
   return `[Script Info]
@@ -25,6 +25,18 @@ Format: Layer, Start, End, Style, Text
 Dialogue: 0,0:00:00.00,0:00:05.00,Default,${dialogue}
 `;
 }
+
+describe("fontKeyLabel", () => {
+  const boldItalic = { family: "Arial", bold: true, italic: true };
+
+  it("uses English style suffixes by default for non-GUI callers", () => {
+    expect(fontKeyLabel(boldItalic)).toBe("Arial Bold Italic");
+  });
+
+  it("accepts localized style suffixes for GUI callers", () => {
+    expect(fontKeyLabel(boldItalic, { bold: "粗体", italic: "斜体" })).toBe("Arial 粗体 斜体");
+  });
+});
 
 describe("font-collector \\p drawing-tag whitespace handling", () => {
   it("rejects `\\p 1` (space before digit) and continues collecting glyphs", async () => {

--- a/src/features/font-embed/font-collector.ts
+++ b/src/features/font-embed/font-collector.ts
@@ -144,6 +144,16 @@ export interface FontUsage {
   codepoints: Set<number>;
 }
 
+export interface FontStyleLabels {
+  bold: string;
+  italic: string;
+}
+
+const DEFAULT_FONT_STYLE_LABELS: Readonly<FontStyleLabels> = {
+  bold: "Bold",
+  italic: "Italic",
+};
+
 /**
  * Serialize a FontKey to a stable string for Map keys.
  */
@@ -152,10 +162,13 @@ function fontKeyToString(key: FontKey): string {
 }
 
 /** Format a FontKey as a human-readable label (e.g., "Arial Bold Italic"). */
-export function fontKeyLabel(key: FontKey): string {
+export function fontKeyLabel(
+  key: FontKey,
+  styleLabels: Readonly<FontStyleLabels> = DEFAULT_FONT_STYLE_LABELS
+): string {
   let label = key.family;
-  if (key.bold) label += " Bold";
-  if (key.italic) label += " Italic";
+  if (key.bold) label += ` ${styleLabels.bold}`;
+  if (key.italic) label += ` ${styleLabels.italic}`;
   return label;
 }
 

--- a/src/features/font-embed/font-embedder.test.ts
+++ b/src/features/font-embed/font-embedder.test.ts
@@ -626,6 +626,44 @@ describe("analyzeFonts — useRustUserFonts production path", () => {
     expect(resolveUserFontMock).toHaveBeenCalledWith("Arial", true, false);
   });
 
+  it("contains a rejected local lookup to that font and continues analyzing later fonts", async () => {
+    resolveUserFontMock.mockImplementation(async (family: string) => {
+      if (family === "FZLanTingHei") {
+        throw new Error("session index busy\u202E");
+      }
+      return null;
+    });
+    lookupFontFamilyMock.mockResolvedValue({ path: "C:/cache/should-not-win.ttf", index: 0 });
+    findSystemFontMock.mockImplementation(async (family: string, bold: boolean) => {
+      if (family === "Arial" && bold) return { path: "C:/Windows/Fonts/arialbd.ttf", index: 0 };
+      throw new Error("Font not found");
+    });
+
+    const { infos } = await analyzeFonts(MINIMAL_ASS, null, undefined, true);
+    const fz = infos.find((i) => i.key.family === "FZLanTingHei");
+    const arial = infos.find((i) => i.key.family === "Arial" && i.key.bold);
+
+    expect(infos).toHaveLength(2);
+    expect(fz).toMatchObject({
+      filePath: null,
+      fontIndex: 0,
+      source: null,
+      error: "session index busy",
+    });
+    // Local-tier errors fail closed: neither lower tier may silently
+    // substitute a different FZ face after an explicit local source failed.
+    expect(
+      lookupFontFamilyMock.mock.calls.filter((call) => call[0] === "FZLanTingHei")
+    ).toHaveLength(0);
+    expect(findSystemFontMock.mock.calls.filter((call) => call[0] === "FZLanTingHei")).toHaveLength(
+      0
+    );
+    // The next family still completes normally, proving the rejection is
+    // per-font rather than an analyzeFonts/batch abort.
+    expect(arial?.source).toBe("cache");
+    expect(arial?.filePath).toBe("C:/cache/should-not-win.ttf");
+  });
+
   it("userFontMap wins over useRustUserFonts when both are provided", async () => {
     // Production currently never calls analyzeFonts with both arguments
     // truthy; this test pins the priority order anyway so a future
@@ -1137,12 +1175,40 @@ describe("aggregateFonts — cross-file union + cap", () => {
     // each file but NOT their cross-file union; a crafted batch could
     // otherwise grow the in-memory detection-grid Set unbounded. Over-cap
     // input must clamp to exactly the cap.
-    function* overCap(): Generator<number> {
-      for (let i = 0; i <= MAX_AGGREGATE_CODEPOINTS_PER_KEY; i++) yield i;
-    }
-    const perFile = new Map<string, FileAnalysis>([["big.ass", makeAnalysis("Arial", overCap())]]);
-    expect(aggregateFonts(perFile).usages[0]!.codepoints.size).toBe(
-      MAX_AGGREGATE_CODEPOINTS_PER_KEY
-    );
+    expect(MAX_AGGREGATE_CODEPOINTS_PER_KEY).toBe(1_000_000);
+
+    // aggregateFonts only iterates FontUsage.codepoints. A lazy Set-shaped
+    // iterable avoids allocating a second million-entry input Set alongside
+    // the one aggregateFonts necessarily builds for its result.
+    const key: FontKey = { family: "Arial", bold: false, italic: false };
+    const lazyCodepoints = {
+      *[Symbol.iterator](): Generator<number> {
+        for (let i = 0; i <= MAX_AGGREGATE_CODEPOINTS_PER_KEY; i++) yield i;
+      },
+    } as unknown as Set<number>;
+    const perFile = new Map<string, FileAnalysis>([
+      [
+        "big.ass",
+        {
+          content: "",
+          infos: [
+            {
+              key,
+              glyphCount: MAX_AGGREGATE_CODEPOINTS_PER_KEY + 1,
+              filePath: "/fonts/x.ttf",
+              fontIndex: 0,
+              error: null,
+              source: "local",
+            },
+          ],
+          usages: [{ key, codepoints: lazyCodepoints }],
+        },
+      ],
+    ]);
+    const aggregate = aggregateFonts(perFile).usages[0]!.codepoints;
+
+    expect(aggregate.size).toBe(MAX_AGGREGATE_CODEPOINTS_PER_KEY);
+    expect(aggregate.has(MAX_AGGREGATE_CODEPOINTS_PER_KEY - 1)).toBe(true);
+    expect(aggregate.has(MAX_AGGREGATE_CODEPOINTS_PER_KEY)).toBe(false);
   });
 });

--- a/src/features/font-embed/font-embedder.ts
+++ b/src/features/font-embed/font-embedder.ts
@@ -399,6 +399,8 @@ export interface FileAnalysis {
   content: string;
   infos: FontInfo[];
   usages: FontUsage[];
+  /** Encoding inferred without a BOM; retained so every later write warns. */
+  inferredEncodingId?: string;
 }
 
 /**

--- a/src/features/font-embed/font-embedder.ts
+++ b/src/features/font-embed/font-embedder.ts
@@ -665,6 +665,9 @@ export async function embedFonts(
 ): Promise<EmbedFontsResult | null> {
   const fontEntries: string[] = [];
   const warnings: string[] = [];
+  const fontStyleLabels = t
+    ? { bold: t("font_style_bold"), italic: t("font_style_italic") }
+    : undefined;
 
   // Index fontUsages by lookup key once (O(N)) instead of linear-scanning
   // for each selected font (O(N²)). For a 40-font subtitle the scan cost
@@ -730,7 +733,7 @@ export async function embedFonts(
     const info = selectedFonts[preIdx]!;
     if (!info.filePath) continue;
 
-    const label = fontKeyLabel(info.key);
+    const label = fontKeyLabel(info.key, fontStyleLabels);
     const usage = usageByKey.get(userFontKey(info.key.family, info.key.bold, info.key.italic));
     if (!usage) {
       // Selected FontInfo has no matching FontUsage — means analyzeFonts and
@@ -860,7 +863,7 @@ export async function embedFonts(
         if (isCancelled?.()) return null;
         if (!alias.info.filePath) continue;
         const aliasFontName = buildFontFileName(alias.info.key);
-        const aliasLabel = fontKeyLabel(alias.info.key);
+        const aliasLabel = fontKeyLabel(alias.info.key, fontStyleLabels);
         onProgress?.({
           stage: t?.("msg_subsetting", aliasLabel) ?? `Subsetting ${aliasLabel}…`,
           current: i + 1,
@@ -897,7 +900,7 @@ export async function embedFonts(
     }
 
     const fontName = buildFontFileName(template.key);
-    const label = fontKeyLabel(template.key);
+    const label = fontKeyLabel(template.key, fontStyleLabels);
     onProgress?.({
       stage: t?.("msg_subsetting", label) ?? `Subsetting ${label}…`,
       current: i + 1,

--- a/src/features/font-embed/font-embedder.ts
+++ b/src/features/font-embed/font-embedder.ts
@@ -241,7 +241,25 @@ export async function analyzeFonts(
     }
 
     if (useRustUserFonts) {
-      const localResult = await resolveUserFont(usage.key.family, usage.key.bold, usage.key.italic);
+      let localResult: Awaited<ReturnType<typeof resolveUserFont>>;
+      try {
+        localResult = await resolveUserFont(usage.key.family, usage.key.bold, usage.key.italic);
+      } catch (error) {
+        // A session-index failure belongs to this font, not the whole
+        // subtitle batch. Fail this priority tier closed: silently using a
+        // lower-priority cache/system face after an explicitly supplied local
+        // source malfunctioned could embed the wrong font. This mirrors the
+        // CLI resolver's local-tier error policy while allowing later font
+        // families/files to continue analyzing.
+        infos.push({
+          ...base,
+          filePath: null,
+          fontIndex: 0,
+          error: sanitizeError(error),
+          source: null,
+        });
+        continue;
+      }
       if (localResult) {
         if (isDev) console.debug(`[ssaHdrify] '${usage.key.family}' → LOCAL ${localResult.path}`);
         infos.push({

--- a/src/features/hdr-convert/HdrConvert.tsx
+++ b/src/features/hdr-convert/HdrConvert.tsx
@@ -195,13 +195,15 @@ export default function HdrConvert() {
   }, []);
 
   const activeTemplate = template === "custom" ? customTemplate : template;
+  const templateInvalid = template === "custom" && customTemplate.trim().length === 0;
   // Gate Convert on the same visible-input validity shown by the
-  // NumberInput border, so keyboard activation cannot commit a stale
-  // prior brightness value.
+  // controls, so keyboard activation cannot commit a stale prior
+  // brightness value or start a batch with a universally invalid template.
   const convertDisabled = isHdrConvertDisabled({
     hasFiles: !!hdrFiles,
     processing,
     brightnessInvalid,
+    templateInvalid,
   });
 
   // ── File selection (separate from conversion) ──────────
@@ -292,6 +294,7 @@ export default function HdrConvert() {
         hasFiles: !!hdrFiles,
         processing,
         brightnessInvalid,
+        templateInvalid,
       })
     ) {
       return;
@@ -543,7 +546,18 @@ export default function HdrConvert() {
     } finally {
       busyRef.current = false;
     }
-  }, [hdrFiles, processing, brightnessInvalid, brightness, eotf, activeTemplate, style, addLog, t]);
+  }, [
+    hdrFiles,
+    processing,
+    brightnessInvalid,
+    templateInvalid,
+    brightness,
+    eotf,
+    activeTemplate,
+    style,
+    addLog,
+    t,
+  ]);
 
   const handleClearFiles = useCallback(() => {
     clearFile("hdr");
@@ -786,6 +800,7 @@ export default function HdrConvert() {
       {/* Output Template */}
       <div className="space-y-2">
         <label
+          id="hdr-template-label"
           htmlFor="hdr-template-select"
           className="block text-sm font-medium"
           style={{ color: "var(--text-secondary)" }}
@@ -814,20 +829,35 @@ export default function HdrConvert() {
             <option value="custom">{t("template_custom")}</option>
           </select>
           {template === "custom" && (
-            <input
-              type="text"
-              value={customTemplate}
-              onChange={(e) => setCustomTemplate(e.target.value)}
-              placeholder="{name}.hdr.{eotf}.ass"
-              maxLength={200}
-              disabled={processing}
-              className="w-64 px-3 py-2 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
-              style={{
-                background: "var(--bg-input)",
-                border: "1px solid var(--border)",
-                color: "var(--text-primary)",
-              }}
-            />
+            <>
+              <input
+                id="hdr-custom-template-input"
+                type="text"
+                value={customTemplate}
+                onChange={(e) => setCustomTemplate(e.target.value)}
+                placeholder="{name}.hdr.{eotf}.ass"
+                maxLength={200}
+                disabled={processing}
+                aria-labelledby="hdr-template-label"
+                aria-invalid={templateInvalid}
+                aria-describedby={templateInvalid ? "hdr-custom-template-error" : undefined}
+                className="w-64 px-3 py-2 rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                style={{
+                  background: "var(--bg-input)",
+                  border: templateInvalid ? "1px solid var(--error)" : "1px solid var(--border)",
+                  color: "var(--text-primary)",
+                }}
+              />
+              {templateInvalid && (
+                <span
+                  id="hdr-custom-template-error"
+                  className="text-xs"
+                  style={{ color: "var(--error)" }}
+                >
+                  {t("template_required")}
+                </span>
+              )}
+            </>
           )}
         </div>
         <p className="text-xs" style={{ color: "var(--text-muted)" }}>

--- a/src/features/hdr-convert/HdrConvert.tsx
+++ b/src/features/hdr-convert/HdrConvert.tsx
@@ -1,5 +1,11 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from "react";
-import { pickSubtitleFiles, readText, writeText, fileNameFromPath } from "../../lib/tauri-api";
+import {
+  fileNameFromPath,
+  isInferredUtf16,
+  pickSubtitleFiles,
+  readText,
+  writeText,
+} from "../../lib/tauri-api";
 import { processAssContent, parseAssColor, formatAssColor } from "./ass-processor";
 import {
   processSrtUserText,
@@ -433,7 +439,11 @@ export default function HdrConvert() {
             // Read input file
             let content: string;
             try {
-              content = await readText(filePath);
+              content = await readText(filePath, (read) => {
+                if (isInferredUtf16(read)) {
+                  addLog(t("msg_inferred_utf16", fileName, read.encodingId), "warn");
+                }
+              });
             } catch (e) {
               addLog(t("msg_read_error", fileName, sanitizeError(e)), "error");
               continue;

--- a/src/features/hdr-convert/hdr-ui-state.test.ts
+++ b/src/features/hdr-convert/hdr-ui-state.test.ts
@@ -27,6 +27,18 @@ describe("HDR UI state guards", () => {
         hasFiles: true,
         processing: false,
         brightnessInvalid: true,
+        templateInvalid: false,
+      })
+    ).toBe(true);
+  });
+
+  it("disables Convert when the custom output template is empty", () => {
+    expect(
+      isHdrConvertDisabled({
+        hasFiles: true,
+        processing: false,
+        brightnessInvalid: false,
+        templateInvalid: true,
       })
     ).toBe(true);
   });
@@ -37,6 +49,7 @@ describe("HDR UI state guards", () => {
         hasFiles: true,
         processing: false,
         brightnessInvalid: false,
+        templateInvalid: false,
       })
     ).toBe(false);
   });

--- a/src/features/hdr-convert/hdr-ui-state.ts
+++ b/src/features/hdr-convert/hdr-ui-state.ts
@@ -4,6 +4,7 @@ export interface HdrConvertDisabledState {
   hasFiles: boolean;
   processing: boolean;
   brightnessInvalid: boolean;
+  templateInvalid: boolean;
 }
 
 export function isHdrBrightnessInvalid(
@@ -16,5 +17,5 @@ export function isHdrBrightnessInvalid(
 }
 
 export function isHdrConvertDisabled(state: HdrConvertDisabledState): boolean {
-  return !state.hasFiles || state.processing || state.brightnessInvalid;
+  return !state.hasFiles || state.processing || state.brightnessInvalid || state.templateInvalid;
 }

--- a/src/features/hdr-convert/srt-converter.test.ts
+++ b/src/features/hdr-convert/srt-converter.test.ts
@@ -84,25 +84,33 @@ describe("preprocessSrtColors", () => {
     expect(result).toContain("{\\r}");
   });
 
-  it("processes a 100KB pathological near-match payload in linear time", () => {
+  it("does not match color openers beyond the bounded windows in a 100KB payload", () => {
     // ReDoS regression. SRT_COLOR_OPEN_RE has two `[^>]{0,512}` windows
-    // anchored on `>`. JS regex engines are linear on `>`-anchored
-    // character-class repetitions, so the worst case should be O(N).
-    // Build a 100KB payload with crafted near-matches that would
-    // exercise the worst alt-path: many "<font" prefixes that almost
-    // satisfy the color-attribute branch but fail at the closing
-    // delimiter, forcing backtrack-style behavior in a vulnerable
-    // engine. If this hangs the test runner (default 5s vitest
-    // timeout), we have a real ReDoS.
+    // anchored on `>`. Build a 100KB payload with crafted near-matches
+    // that almost satisfy the color-attribute branch but exceed those
+    // windows. Vitest's default timeout remains the hang guard; the
+    // assertion stays deterministic across fast and slow runners.
     const chunk = '<font face="Arial" data-extra="x"'.repeat(40); // ~1300 bytes
     const payload = chunk.repeat(80) + ">Styled</font>"; // ~100KB
-    const start = Date.now();
     const result = preprocessSrtColors(payload);
-    const elapsed = Date.now() - start;
-    // Generous budget — a working linear-time regex finishes in <100ms;
-    // a quadratic backtracker would blow past 5s on this payload.
-    expect(elapsed).toBeLessThan(2000);
-    expect(typeof result).toBe("string");
+    expect(result).toBe(payload.replace("</font>", "{\\r}"));
+  });
+
+  it.each([
+    [
+      "before color=",
+      (padding: number) => `<font${" ".repeat(padding)}color="#FF0000">Styled</font>`,
+    ],
+    [
+      "after color=",
+      (padding: number) => `<font color="#FF0000"${" ".repeat(padding)}>Styled</font>`,
+    ],
+  ])("enforces the exact 512-character window %s", (_label, makeInput) => {
+    const atLimit = makeInput(512);
+    const overLimit = makeInput(513);
+
+    expect(preprocessSrtColors(atLimit)).toBe("{\\1c&H0000FF&}Styled{\\r}");
+    expect(preprocessSrtColors(overLimit)).toBe(overLimit.replace("</font>", "{\\r}"));
   });
 });
 

--- a/src/features/style-edit/StyleEdit.tsx
+++ b/src/features/style-edit/StyleEdit.tsx
@@ -15,6 +15,7 @@ import { PreviewTable, type PreviewTableColumn } from "../../lib/PreviewTable";
 import type { Status } from "../../lib/StatusContext";
 import {
   fileNameFromPath,
+  isInferredUtf16,
   outputPathExists,
   pickAssFiles,
   readTextDetectEncoding,
@@ -50,6 +51,7 @@ interface LoadedStyleFile {
   path: string;
   name: string;
   sourceRevision: string;
+  inferredEncodingId?: string;
   planner: ReturnType<typeof createStyleDocumentPlanner>;
 }
 
@@ -259,6 +261,9 @@ export default function StyleEdit() {
           if (read.lossy) {
             throw new Error(t("msg_style_lossy_encoding", name));
           }
+          if (isInferredUtf16(read)) {
+            addLog(t("msg_inferred_utf16", name, read.encodingId), "warn");
+          }
           aggregateSourceBytes += read.sourceByteLength;
           if (aggregateSourceBytes > STYLE_EDIT_MAX_SOURCE_BYTES) {
             const reachedMb = Math.ceil(aggregateSourceBytes / (1024 * 1024));
@@ -276,7 +281,13 @@ export default function StyleEdit() {
           if (aggregateRows > STYLE_EDIT_MAX_ROWS) {
             throw new Error(t("msg_style_too_many_rows", STYLE_EDIT_MAX_ROWS));
           }
-          nextFiles.push({ path, name, sourceRevision: read.sourceRevision, planner });
+          nextFiles.push({
+            path,
+            name,
+            sourceRevision: read.sourceRevision,
+            ...(isInferredUtf16(read) && { inferredEncodingId: read.encodingId }),
+            planner,
+          });
         }
 
         if (generation !== pickGenerationRef.current) return;
@@ -438,6 +449,12 @@ export default function StyleEdit() {
         const target = writableTargets[index]!;
         try {
           const result = target.file.planner.apply(operations, target.selectedRowIds);
+          if (target.file.inferredEncodingId) {
+            addLog(
+              t("msg_inferred_utf16", target.file.name, target.file.inferredEncodingId),
+              "warn"
+            );
+          }
           await writeStyleEditOutput({
             sourcePath: target.file.path,
             expectedRevision: target.file.sourceRevision,

--- a/src/features/style-edit/style-editor.test.ts
+++ b/src/features/style-edit/style-editor.test.ts
@@ -281,6 +281,9 @@ describe("strict structure and operation errors", () => {
   });
 
   it("bounds and scrubs Format column names without echoing them", () => {
+    const atLimit = `[V4+ Styles]\nFormat: Name, ${"x".repeat(128)}`;
+    expect(() => inspectStyleDocument(atLimit)).not.toThrow();
+
     const longColumn = `[V4+ Styles]\nFormat: Name, ${"x".repeat(129)}`;
     expect(() =>
       planStyleEdit(longColumn, { fontSize: { enabled: true, targetSize: 48 } })
@@ -378,6 +381,9 @@ describe("strict structure and operation errors", () => {
   });
 
   it("bounds and scrubs existing Fontsize before preview or numeric conversion", () => {
+    const atLimit = assDocument([`Style: Default,Arial,${"9".repeat(128)},0,0`]);
+    expect(() => planStyleEdit(atLimit, EDIT_BOTH)).not.toThrow();
+
     const longSize = assDocument([`Style: Default,Arial,${"9".repeat(129)},0,0`]);
     expect(() => planStyleEdit(longSize, EDIT_BOTH)).toThrow(/font size exceeds 128/);
 
@@ -412,14 +418,30 @@ describe("strict structure and operation errors", () => {
 });
 
 describe("resource ceilings", () => {
+  it("accepts a physical line exactly at the 1000000-character ceiling", () => {
+    const input = `[V4+ Styles]\nFormat: Name\n${"x".repeat(1_000_000)}`;
+    expect(inspectStyleDocument(input)).toEqual({ styleCount: 0 });
+  });
+
   it("rejects an overlong physical line before style parsing", () => {
     const input = `[Script Info]\n${"x".repeat(1_000_001)}\n[V4+ Styles]`;
     expect(() => planStyleEdit(input, EDIT_BOTH)).toThrow(/Line 2: Line has 1000001 characters/);
   });
 
+  it("accepts exactly 501024 physical lines", () => {
+    const input = "[V4+ Styles]\nFormat: Name" + "\n".repeat(501_022);
+    expect(inspectStyleDocument(input)).toEqual({ styleCount: 0 });
+  });
+
   it("rejects too many physical lines without materializing the whole split", () => {
     const input = "\n".repeat(501_024);
     expect(() => planStyleEdit(input, EDIT_BOTH)).toThrow(/more than 501024 lines/);
+  });
+
+  it("accepts exactly 1024 Format fields", () => {
+    const fields = ["Name", ...Array.from({ length: 1_023 }, (_, i) => `F${i}`)];
+    const input = `[V4+ Styles]\nFormat: ${fields.join(",")}`;
+    expect(inspectStyleDocument(input)).toEqual({ styleCount: 0 });
   });
 
   it("rejects an excessive Format field vector", () => {
@@ -429,6 +451,12 @@ describe("resource ceilings", () => {
     expect(() => planStyleEdit(input, { fontSize: { enabled: true, targetSize: 48 } })).toThrow(
       /1025 fields \(max 1024\)/
     );
+  });
+
+  it("accepts exactly 50000 style rows", () => {
+    const rows = Array.from({ length: 50_000 }, (_, i) => `Style: S${i}`).join("\n");
+    const input = `[V4+ Styles]\nFormat: Name\n${rows}`;
+    expect(inspectStyleDocument(input)).toEqual({ styleCount: 50_000 });
   });
 
   it("rejects more than 50000 style rows", () => {

--- a/src/features/timing-shift/TimingShift.tsx
+++ b/src/features/timing-shift/TimingShift.tsx
@@ -1,6 +1,12 @@
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
 import { List, type RowComponentProps } from "react-window";
-import { pickSubtitleFiles, readText, writeText, fileNameFromPath } from "../../lib/tauri-api";
+import {
+  fileNameFromPath,
+  isInferredUtf16,
+  pickSubtitleFiles,
+  readText,
+  writeText,
+} from "../../lib/tauri-api";
 import { ask } from "@tauri-apps/plugin-dialog";
 import {
   shiftSubtitles,
@@ -268,7 +274,12 @@ export default function TimingShift() {
         setCaptionCount(result.captionCount);
         setDetectedFormat(result.format.toUpperCase());
       } catch {
-        // Preview update failed — don't crash, just skip
+        // Keep all derived preview state aligned with the current file.
+        // Otherwise a malformed or zero-cue replacement would leave the
+        // previous file's timeline, count, and format visible.
+        setPreview([]);
+        setCaptionCount(0);
+        setDetectedFormat("");
       }
     }, 200);
     return () => {
@@ -510,7 +521,11 @@ export default function TimingShift() {
 
             let content: string;
             try {
-              content = await readText(filePath);
+              content = await readText(filePath, (read) => {
+                if (isInferredUtf16(read)) {
+                  addLog(t("msg_inferred_utf16", fileName, read.encodingId), "warn");
+                }
+              });
             } catch (e) {
               addLog(t("msg_read_error", fileName, sanitizeError(e)), "error");
               continue;
@@ -523,15 +538,15 @@ export default function TimingShift() {
               thresholdMs: thresholdMs ?? undefined,
             });
 
-            // surface oversized-text drop
-            // count to close the no-silent-action gap (parity with
-            // HdrConvert). All four parsers push
-            // skipped placeholders for entries exceeding
-            // MAX_CAPTION_TEXT_LEN; builders filter them out so disk
-            // output stays clean, but without this log the user has no
-            // signal that input was partially dropped.
+            // Surface oversized captions explicitly. Structure-preserving
+            // ASS/WebVTT writers leave them unchanged; SRT/MicroDVD writers
+            // omit them because those formats are rebuilt from parsed cues.
             if (result.skippedCount > 0) {
-              addLog(t("msg_oversized_skipped", result.skippedCount, fileName), "warn");
+              const warningKey =
+                result.format === "ass" || result.format === "vtt"
+                  ? "msg_oversized_unchanged"
+                  : "msg_oversized_skipped";
+              addLog(t(warningKey, result.skippedCount, fileName), "warn");
             }
 
             if (abortRef.current?.signal.aborted) break;

--- a/src/features/timing-shift/TimingShift.tsx
+++ b/src/features/timing-shift/TimingShift.tsx
@@ -9,7 +9,8 @@ import {
 } from "../../lib/tauri-api";
 import { ask } from "@tauri-apps/plugin-dialog";
 import {
-  shiftSubtitles,
+  previewShiftSubtitles,
+  shiftSubtitlesCompact,
   formatDisplayTime,
   parseDisplayTime,
   deriveShiftedPath,
@@ -42,8 +43,9 @@ type Direction = "slower" | "faster";
 /** Cap to ±1 year to prevent integer precision loss for extreme inputs. */
 const MAX_OFFSET_MS = 365 * 24 * 3600 * 1000;
 
-// Preview list virtualization — defends against preview DOM explosion
-// at the parser's 500k-entry ceiling. A naive preview.map(...) would
+// Preview list virtualization — the engine now retains at most 5,000 rows,
+// but rendering even that many DOM nodes eagerly would still be wasteful. A
+// naive preview.map(...) would
 // materialize one DOM node per caption regardless of scroll position,
 // freezing the WebView on large inputs even though only a few rows fit
 // in the 280px viewport at any time. react-window constrains the
@@ -61,6 +63,28 @@ interface PreviewRowData {
   formatTime: (ms: number) => string;
   origLabel: string;
   shiftedLabel: string;
+}
+
+interface TimingPreviewState {
+  preview: PreviewEntry[];
+  captionCount: number;
+  shiftableCount: number;
+  maxCaptionStart: number;
+  detectedFormat: string;
+  previewTruncated: boolean;
+  error: string | null;
+}
+
+function emptyTimingPreviewState(error: string | null = null): TimingPreviewState {
+  return {
+    preview: [],
+    captionCount: 0,
+    shiftableCount: 0,
+    maxCaptionStart: 0,
+    detectedFormat: "",
+    previewTruncated: false,
+    error,
+  };
 }
 
 function PreviewRow({
@@ -90,7 +114,7 @@ function PreviewRow({
       <span className="t-new" title={`${shiftedLabel}: ${formatTime(entry.shiftedStart)}`}>
         {formatTime(entry.shiftedStart)}
       </span>
-      <span className="txt" title={entry.fullText}>
+      <span className="txt" title={entry.tooltipText}>
         {entry.text}
       </span>
     </div>
@@ -101,7 +125,18 @@ export default function TimingShift() {
   const { t } = useI18n();
   const { timingFiles, setTimingFiles, clearFile, isFileInUse } = useFileContext();
 
-  const [detectedFormat, setDetectedFormat] = useState<string>("");
+  const [previewState, setPreviewState] = useState<TimingPreviewState>(() =>
+    emptyTimingPreviewState()
+  );
+  const {
+    preview,
+    captionCount,
+    shiftableCount,
+    maxCaptionStart,
+    detectedFormat,
+    previewTruncated,
+    error: previewError,
+  } = previewState;
   // Two-slot shadow mirroring HdrConvert's `brightness` /
   // `brightnessText`: `offsetValue` is the validated integer used by
   // `effectiveOffsetMs` math; `offsetText` is the raw input string the
@@ -114,8 +149,6 @@ export default function TimingShift() {
   const [direction, setDirection] = useState<Direction>("slower");
   const [useThreshold, setUseThreshold] = useState(false);
   const [thresholdText, setThresholdText] = useState("00:05:00.000");
-  const [preview, setPreview] = useState<PreviewEntry[]>([]);
-  const [captionCount, setCaptionCount] = useState(0);
   const [busy, setBusy] = useState(false);
   // Same shape as HdrConvert — "cancelled" is its own visible state so
   // the footer and log can both acknowledge that the user stepped back
@@ -200,15 +233,12 @@ export default function TimingShift() {
   );
   const thresholdInvalid = useThreshold && thresholdMs === null;
 
-  // Last caption's START time — shiftSubtitle uses `c.start >= threshold`,
-  // so a threshold past the last START produces zero shifts even if it
-  // falls before the last caption's END.
-  const maxCaptionStart = useMemo(
-    () => preview.reduce((max, e) => Math.max(max, e.originalStart), 0),
-    [preview]
-  );
+  // Full-file maximum, returned by the parse-only engine even when the
+  // retained preview rows are capped. shiftSubtitle uses
+  // `c.start >= threshold`, so a threshold past the last START produces
+  // zero shifts even if it falls before the last caption's END.
   const thresholdExceedsFile =
-    useThreshold && thresholdMs !== null && maxCaptionStart > 0 && thresholdMs > maxCaptionStart;
+    useThreshold && thresholdMs !== null && captionCount > 0 && thresholdMs > maxCaptionStart;
 
   const filePaths = useMemo(() => timingFiles?.filePaths ?? [], [timingFiles]);
   const fileNames = useMemo(() => timingFiles?.fileNames ?? [], [timingFiles]);
@@ -247,45 +277,43 @@ export default function TimingShift() {
   // is honest; we don't re-render the timeline as the loop runs.
   useEffect(() => {
     if (!firstFileContent) {
-      setPreview([]);
-      setCaptionCount(0);
-      setDetectedFormat("");
+      setPreviewState(emptyTimingPreviewState());
       return;
     }
-    if (thresholdInvalid) {
+    if (offsetInvalid || thresholdInvalid) {
       if (debounceRef.current) clearTimeout(debounceRef.current);
-      // Clear the derived chips too, not just the preview: leaving
-      // captionCount / detectedFormat set would show a stale count + format
-      // badge over a blank timeline. The empty-content branch above resets
-      // all three for the same consistency reason.
-      setPreview([]);
-      setCaptionCount(0);
-      setDetectedFormat("");
+      // Clear all derived preview state: leaving count/format/max/error from
+      // the prior valid input would contradict the visible invalid input.
+      setPreviewState(emptyTimingPreviewState());
       return;
     }
     if (debounceRef.current) clearTimeout(debounceRef.current);
     debounceRef.current = setTimeout(() => {
       try {
-        const result = shiftSubtitles(firstFileContent, {
+        const result = previewShiftSubtitles(firstFileContent, {
           offsetMs: effectiveOffsetMs,
           thresholdMs: thresholdMs ?? undefined,
         });
-        setPreview(result.preview);
-        setCaptionCount(result.captionCount);
-        setDetectedFormat(result.format.toUpperCase());
-      } catch {
-        // Keep all derived preview state aligned with the current file.
-        // Otherwise a malformed or zero-cue replacement would leave the
-        // previous file's timeline, count, and format visible.
-        setPreview([]);
-        setCaptionCount(0);
-        setDetectedFormat("");
+        setPreviewState({
+          preview: result.preview,
+          captionCount: result.captionCount,
+          shiftableCount: result.shiftableCount,
+          maxCaptionStart: result.maxCaptionStart,
+          detectedFormat: result.format.toUpperCase(),
+          previewTruncated: result.previewTruncated,
+          error: null,
+        });
+      } catch (error) {
+        // Publish failure atomically with cleared derived state. Keeping an
+        // independent error flag let old count/format chips survive a failed
+        // parse for one render; one object makes those states inseparable.
+        setPreviewState(emptyTimingPreviewState(t("timing_preview_error", sanitizeError(error))));
       }
     }, 200);
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  }, [firstFileContent, effectiveOffsetMs, thresholdMs, thresholdInvalid]);
+  }, [firstFileContent, effectiveOffsetMs, offsetInvalid, thresholdMs, thresholdInvalid, t]);
 
   // Reset last-save outcome on selection change so "done" / "cancelled"
   // don't linger after the user picks a brand-new batch.
@@ -414,9 +442,7 @@ export default function TimingShift() {
   const handleClearFiles = useCallback(() => {
     pickGenRef.current = pickGenRef.current + 1;
     clearFile("timing");
-    setPreview([]);
-    setCaptionCount(0);
-    setDetectedFormat("");
+    setPreviewState(emptyTimingPreviewState());
     setDropError(null);
   }, [clearFile]);
 
@@ -533,7 +559,7 @@ export default function TimingShift() {
 
             if (abortRef.current?.signal.aborted) break;
 
-            const result = shiftSubtitles(content, {
+            const result = shiftSubtitlesCompact(content, {
               offsetMs: effectiveOffsetMs,
               thresholdMs: thresholdMs ?? undefined,
             });
@@ -790,6 +816,12 @@ export default function TimingShift() {
       {/* Selection-rejected banner — same UX as HdrConvert. */}
       <DropErrorBanner message={dropError} onDismiss={() => setDropError(null)} />
 
+      {/* Parse/cap failures must stay visible even when the log is collapsed. */}
+      <DropErrorBanner
+        message={previewError}
+        onDismiss={() => setPreviewState((state) => ({ ...state, error: null }))}
+      />
+
       {/* Drop-zone discoverability hint — visible only when idle. */}
       {fileCount === 0 && !dropError && (
         <p className="text-xs ml-1" style={{ color: "var(--text-muted)" }}>
@@ -969,9 +1001,18 @@ export default function TimingShift() {
         <div className="timeline-preview" aria-live="polite">
           <div className="timeline-preview-head">
             <span>
-              {fileCount > 1
-                ? t("preview_title_first", preview.length, primaryFileName)
-                : t("preview_title", preview.length)}
+              {previewTruncated
+                ? fileCount > 1
+                  ? t(
+                      "preview_title_first_truncated",
+                      preview.length,
+                      shiftableCount,
+                      primaryFileName
+                    )
+                  : t("preview_title_truncated", preview.length, shiftableCount)
+                : fileCount > 1
+                  ? t("preview_title_first", shiftableCount, primaryFileName)
+                  : t("preview_title", shiftableCount)}
             </span>
           </div>
           <div className="timeline-row timeline-row-header" aria-hidden="true">

--- a/src/features/timing-shift/timing-engine.test.ts
+++ b/src/features/timing-shift/timing-engine.test.ts
@@ -1,11 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  MAX_TIMING_PREVIEW_ENTRIES,
+  MAX_TIMING_PREVIEW_TOOLTIP_CODEPOINTS,
   MAX_TIMING_OFFSET_MS,
   compileTimingMapRules,
   findTimingMapRule,
   normalizeTimingMapRules,
   parseTimingMapText,
+  previewShiftSubtitles,
   shiftSubtitles,
   shiftSubtitlesCompact,
   shiftSubtitlesWithTimingMap,
@@ -35,6 +38,76 @@ describe("shiftSubtitles", () => {
     expect(result.content).toContain("00:00:01,000 --> 00:00:02,000");
     expect(result.content).toContain("00:00:06,000 --> 00:00:07,000");
     expect(result.content).toContain("00:00:10,000 --> 00:00:11,000");
+  });
+
+  it("uses a parse-only preview that matches full shift timings without returning content", () => {
+    const options = { offsetMs: 1000.9, thresholdMs: 5000 };
+    const preview = previewShiftSubtitles(SRT_SAMPLE, options);
+    const full = shiftSubtitles(SRT_SAMPLE, options);
+
+    expect("content" in preview).toBe(false);
+    expect(preview.format).toBe(full.format);
+    expect(preview.captionCount).toBe(full.captionCount);
+    expect(preview.shiftableCount).toBe(full.captionCount - full.skippedCount);
+    expect(preview.skippedCount).toBe(full.skippedCount);
+    expect(preview.maxCaptionStart).toBe(9000);
+    expect(preview.preview).toEqual(full.preview);
+    expect(preview.previewTruncated).toBe(false);
+  });
+
+  it("caps retained preview rows at the exact boundary while preserving full-file metadata", () => {
+    const makeSrt = (count: number) =>
+      Array.from({ length: count }, (_, index) => {
+        const hours = String(Math.floor(index / 3600)).padStart(2, "0");
+        const minutes = String(Math.floor((index % 3600) / 60)).padStart(2, "0");
+        const seconds = String(index % 60).padStart(2, "0");
+        return `${index + 1}\n${hours}:${minutes}:${seconds},000 --> ${hours}:${minutes}:${seconds},500\ncaption ${index + 1}`;
+      }).join("\n\n");
+
+    const atBoundary = previewShiftSubtitles(makeSrt(MAX_TIMING_PREVIEW_ENTRIES), {
+      offsetMs: 1,
+    });
+    const overBoundary = previewShiftSubtitles(makeSrt(MAX_TIMING_PREVIEW_ENTRIES + 1), {
+      offsetMs: 1,
+    });
+
+    expect(MAX_TIMING_PREVIEW_ENTRIES).toBe(5_000);
+    expect(atBoundary.preview).toHaveLength(MAX_TIMING_PREVIEW_ENTRIES);
+    expect(atBoundary.previewTruncated).toBe(false);
+    expect(overBoundary.captionCount).toBe(MAX_TIMING_PREVIEW_ENTRIES + 1);
+    expect(overBoundary.shiftableCount).toBe(MAX_TIMING_PREVIEW_ENTRIES + 1);
+    expect(overBoundary.preview).toHaveLength(MAX_TIMING_PREVIEW_ENTRIES);
+    expect(overBoundary.preview.at(-1)?.index).toBe(MAX_TIMING_PREVIEW_ENTRIES);
+    expect(overBoundary.previewTruncated).toBe(true);
+    // Metadata scans the full parsed file rather than only retained rows.
+    expect(overBoundary.maxCaptionStart).toBe(MAX_TIMING_PREVIEW_ENTRIES * 1000);
+  });
+
+  it("counts oversized placeholders separately from shiftable preview rows", () => {
+    const input =
+      `1\n00:00:01,000 --> 00:00:02,000\n${"Z".repeat(65_000)}\n\n` +
+      "2\n00:00:03,000 --> 00:00:04,000\nNORMAL\n";
+
+    const result = previewShiftSubtitles(input, { offsetMs: 1000 });
+
+    expect(result.captionCount).toBe(2);
+    expect(result.shiftableCount).toBe(1);
+    expect(result.skippedCount).toBe(1);
+    expect(result.preview).toHaveLength(1);
+    expect(result.previewTruncated).toBe(false);
+  });
+
+  it("caps tooltip text by Unicode code point without splitting surrogate pairs", () => {
+    const longCaption = "🙂".repeat(MAX_TIMING_PREVIEW_TOOLTIP_CODEPOINTS + 5);
+    const input = `1\n00:00:01,000 --> 00:00:02,000\n${longCaption}\n`;
+
+    const result = previewShiftSubtitles(input, { offsetMs: 0 });
+    const tooltip = result.preview[0]!.tooltipText;
+
+    expect(MAX_TIMING_PREVIEW_TOOLTIP_CODEPOINTS).toBe(512);
+    expect(Array.from(tooltip)).toHaveLength(MAX_TIMING_PREVIEW_TOOLTIP_CODEPOINTS);
+    expect(tooltip.endsWith("…")).toBe(true);
+    expect(tooltip.includes("\uFFFD")).toBe(false);
   });
 });
 
@@ -204,6 +277,9 @@ describe("normalizeTimingMapRules", () => {
   it("rejects invalid timing-map rows before output generation", () => {
     expect(() => normalizeTimingMapRules([{ startMs: -1, offsetMs: 0 }])).toThrow(/startMs/);
     expect(() => normalizeTimingMapRules([{ startMs: 1000, endMs: 1000, offsetMs: 0 }])).toThrow(
+      /endMs/
+    );
+    expect(() => normalizeTimingMapRules([{ startMs: 1000, endMs: 999, offsetMs: 0 }])).toThrow(
       /endMs/
     );
     expect(() => normalizeTimingMapRules([{ startMs: 0, offsetMs: NaN }])).toThrow(/offsetMs/);

--- a/src/features/timing-shift/timing-engine.ts
+++ b/src/features/timing-shift/timing-engine.ts
@@ -12,8 +12,10 @@
 import {
   shiftSubtitle,
   transformSubtitleTimings,
+  parseSubtitle,
   formatDisplayTime,
   parseDisplayTime,
+  safeMs,
   type Caption,
   type SubtitleFormat,
 } from "../../lib/subtitle-parser";
@@ -27,6 +29,10 @@ export type { Caption, SubtitleFormat };
 export { formatDisplayTime, parseDisplayTime };
 
 export const MAX_TIMING_OFFSET_MS = 365 * 24 * 3600 * 1000;
+/** Maximum number of caption rows retained by any preview result. */
+export const MAX_TIMING_PREVIEW_ENTRIES = 5_000;
+/** Maximum Unicode code points retained for one preview tooltip. */
+export const MAX_TIMING_PREVIEW_TOOLTIP_CODEPOINTS = 512;
 
 export interface ShiftOptions {
   /** Offset in milliseconds (positive = later/slower, negative = earlier/faster) */
@@ -50,9 +56,9 @@ export function assertFiniteShiftMs(offsetMs: number, thresholdMs?: number | nul
   if (!Number.isFinite(offsetMs)) {
     throw new Error(`Invalid offsetMs: expected a finite number, got ${String(offsetMs)}`);
   }
-  // thresholdMs is OPTIONAL. The CLI wire form (deno_core op JSON) sends
-  // `null` — not `undefined` — when no threshold is set, so both must count
-  // as "not provided"; only a present-but-non-finite value is an error.
+  // thresholdMs is OPTIONAL. Public/runtime callers may still supply either
+  // null or undefined for absence, so both count as "not provided"; only a
+  // present-but-non-finite value is an error.
   if (thresholdMs !== null && thresholdMs !== undefined && !Number.isFinite(thresholdMs)) {
     throw new Error(`Invalid thresholdMs: expected a finite number, got ${String(thresholdMs)}`);
   }
@@ -66,8 +72,8 @@ export interface PreviewEntry {
   shiftedEnd: number;
   /** Truncated text for DOM efficiency (max ~60 codepoints). Keep this for display. */
   text: string;
-  /** Full un-truncated text — used for hover tooltips so long lines remain readable. */
-  fullText: string;
+  /** Bounded text used for hover tooltips (max 512 Unicode code points). */
+  tooltipText: string;
   wasShifted: boolean;
 }
 
@@ -126,6 +132,8 @@ export interface ShiftResult {
   format: SubtitleFormat;
   /** Preview entries: original and shifted timings */
   preview: PreviewEntry[];
+  /** True when preview contains only the first MAX_TIMING_PREVIEW_ENTRIES rows. */
+  previewTruncated: boolean;
   /** Total number of captions (includes skipped placeholders) */
   captionCount: number;
   /**
@@ -143,12 +151,26 @@ export interface TimingMapResult extends Omit<ShiftResult, "preview"> {
   activeRuleCount: number;
 }
 
-export interface CompactShiftResult extends Omit<ShiftResult, "preview"> {
+export interface CompactShiftResult extends Omit<ShiftResult, "preview" | "previewTruncated"> {
   shiftedCount: number;
 }
 
 export interface CompactTimingMapResult extends CompactShiftResult {
   activeRuleCount: number;
+}
+
+/** Parse-only result used by the live GUI preview. It deliberately has no content field. */
+export interface ShiftPreviewResult {
+  format: SubtitleFormat;
+  preview: PreviewEntry[];
+  /** Full parsed caption count, even when the retained preview is capped. */
+  captionCount: number;
+  /** Parsed captions that can be shifted (excludes oversized placeholders). */
+  shiftableCount: number;
+  skippedCount: number;
+  /** Maximum start time across every shiftable caption, including capped rows. */
+  maxCaptionStart: number;
+  previewTruncated: boolean;
 }
 
 function truncateCodepoints(text: string, max: number): string {
@@ -160,6 +182,24 @@ function truncateCodepoints(text: string, max: number): string {
     cp++;
   }
   return out;
+}
+
+/**
+ * Retain at most `max` Unicode code points and reserve the last slot for an
+ * ellipsis when truncation occurs. The bounded array avoids splitting UTF-16
+ * surrogate pairs while never materializing the full caption as `Array.from`.
+ */
+function truncateCodepointsWithEllipsis(text: string, max: number): string {
+  if (max <= 0) return "";
+  const codepoints: string[] = [];
+  for (const ch of text) {
+    if (codepoints.length >= max) {
+      codepoints[max - 1] = "…";
+      return codepoints.join("");
+    }
+    codepoints.push(ch);
+  }
+  return codepoints.join("");
 }
 
 function assertFiniteTimingMapMs(value: number, label: string): void {
@@ -609,27 +649,39 @@ function countShiftedCaptions(captions: Caption[], shifted: Caption[]): number {
   return count;
 }
 
+function makePreviewEntry(caption: Caption, shifted: Caption, index: number): PreviewEntry {
+  return {
+    index: index + 1,
+    originalStart: caption.start,
+    originalEnd: caption.end,
+    shiftedStart: shifted.start,
+    shiftedEnd: shifted.end,
+    text: truncateCodepoints(caption.text, 60),
+    tooltipText: truncateCodepointsWithEllipsis(
+      caption.text,
+      MAX_TIMING_PREVIEW_TOOLTIP_CODEPOINTS
+    ),
+    wasShifted: caption.start !== shifted.start || caption.end !== shifted.end,
+  };
+}
+
 function buildPreview(
   captions: Caption[],
   shifted: Caption[],
   matches?: TimingMapMatch[]
-): PreviewEntry[] | TimingMapPreviewEntry[] {
+): {
+  preview: (PreviewEntry | TimingMapPreviewEntry)[];
+  truncated: boolean;
+} {
   const preview: (PreviewEntry | TimingMapPreviewEntry)[] = [];
   for (let i = 0; i < captions.length; i++) {
     const c = captions[i]!;
     if (c.skipped) continue;
+    if (preview.length >= MAX_TIMING_PREVIEW_ENTRIES) {
+      return { preview, truncated: true };
+    }
     const s = shifted[i]!;
-    const wasShifted = c.start !== s.start || c.end !== s.end;
-    const base: PreviewEntry = {
-      index: i + 1,
-      originalStart: c.start,
-      originalEnd: c.end,
-      shiftedStart: s.start,
-      shiftedEnd: s.end,
-      text: truncateCodepoints(c.text, 60),
-      fullText: c.text,
-      wasShifted,
-    };
+    const base = makePreviewEntry(c, s, i);
     const match = matches?.[i];
     if (match) {
       preview.push({
@@ -642,7 +694,60 @@ function buildPreview(
       preview.push(base);
     }
   }
-  return preview;
+  return { preview, truncated: false };
+}
+
+/**
+ * Parse and calculate a bounded timing preview without rebuilding subtitle
+ * text. Save/export paths use the compact serializers below; live input
+ * changes should never allocate a discarded 50 MiB output string.
+ */
+export function previewShiftSubtitles(content: string, options: ShiftOptions): ShiftPreviewResult {
+  const { offsetMs, thresholdMs, fps } = options;
+  const { format, captions } = parseSubtitle(content, fps);
+  const preview: PreviewEntry[] = [];
+  let foundShiftableCaption = false;
+  let previewTruncated = false;
+  let maxCaptionStart = 0;
+  let skippedCount = 0;
+
+  for (let i = 0; i < captions.length; i++) {
+    const caption = captions[i]!;
+    if (caption.skipped) {
+      skippedCount += 1;
+      continue;
+    }
+    foundShiftableCaption = true;
+    maxCaptionStart = Math.max(maxCaptionStart, caption.start);
+    if (preview.length >= MAX_TIMING_PREVIEW_ENTRIES) {
+      previewTruncated = true;
+      continue;
+    }
+
+    const shouldShift = thresholdMs === undefined || caption.start >= thresholdMs;
+    const shifted = shouldShift
+      ? {
+          ...caption,
+          start: safeMs(caption.start + offsetMs),
+          end: safeMs(caption.end + offsetMs),
+        }
+      : caption;
+    preview.push(makePreviewEntry(caption, shifted, i));
+  }
+
+  if (!foundShiftableCaption) {
+    throw new Error("No shiftable subtitle cues were found");
+  }
+
+  return {
+    format,
+    preview,
+    captionCount: captions.length,
+    shiftableCount: captions.length - skippedCount,
+    skippedCount,
+    maxCaptionStart,
+    previewTruncated,
+  };
 }
 
 /**
@@ -652,15 +757,16 @@ export function shiftSubtitles(content: string, options: ShiftOptions): ShiftRes
   const { offsetMs, thresholdMs, fps } = options;
 
   const { output, format, captions, shifted } = shiftSubtitle(content, offsetMs, thresholdMs, fps);
-  // Build preview for every caption — the UI scroll container decides
-  // how many are visible at a time. `buildPreview` excludes oversized
-  // skipped placeholders and preserves original caption indexes.
-  const preview = buildPreview(captions, shifted) as PreviewEntry[];
+  // Keep preview retention bounded independently of the serializer output.
+  // `buildPreview` excludes oversized skipped placeholders, preserves
+  // original caption indexes, and reports when additional rows were omitted.
+  const builtPreview = buildPreview(captions, shifted);
 
   return {
     content: output,
     format,
-    preview,
+    preview: builtPreview.preview as PreviewEntry[],
+    previewTruncated: builtPreview.truncated,
     captionCount: captions.length,
     skippedCount: captions.filter((c) => c.skipped).length,
   };
@@ -704,12 +810,13 @@ export function shiftSubtitlesWithTimingMap(
     }
   }
 
-  const preview = buildPreview(captions, shifted, matches) as TimingMapPreviewEntry[];
+  const builtPreview = buildPreview(captions, shifted, matches);
 
   return {
     content: output,
     format,
-    preview,
+    preview: builtPreview.preview as TimingMapPreviewEntry[],
+    previewTruncated: builtPreview.truncated,
     captionCount: captions.length,
     skippedCount: countSkippedCaptions(captions),
     shiftedCount: countShiftedCaptions(captions, shifted),

--- a/src/features/timing-shift/timing-engine.ts
+++ b/src/features/timing-shift/timing-engine.ts
@@ -131,7 +131,7 @@ export interface ShiftResult {
   /**
    * Count of captions whose text exceeded MAX_CAPTION_TEXT_LEN (64 KB)
    * and were emitted as skipped placeholders by the parser. TimingShift
-   * surfaces this via msg_oversized_skipped to close the
+   * surfaces this with a format-appropriate warning to close the
    * no-silent-action gap.
    */
   skippedCount: number;

--- a/src/i18n/strings.test.ts
+++ b/src/i18n/strings.test.ts
@@ -1,8 +1,7 @@
 import { describe, expect, it } from "vitest";
-import { strings, type Lang } from "./strings";
+import { LANGS, strings } from "./strings";
 import { translate } from "./useI18n";
 
-const LANGS: Lang[] = ["en", "zh"];
 const PLACEHOLDER_RE = /\{(\d+)\}/g;
 
 /**

--- a/src/i18n/strings.test.ts
+++ b/src/i18n/strings.test.ts
@@ -40,6 +40,13 @@ describe("i18n strings", () => {
     expect(strings["font_sources_loaded_summary"]!.zh).toContain("字体条目");
     expect(strings["font_sources_loaded_summary"]!.zh).toContain("分别计数");
   });
+
+  it("provides localized font-style suffixes", () => {
+    expect(translate("en", "font_style_bold")).toBe("Bold");
+    expect(translate("en", "font_style_italic")).toBe("Italic");
+    expect(translate("zh", "font_style_bold")).toBe("粗体");
+    expect(translate("zh", "font_style_italic")).toBe("斜体");
+  });
 });
 
 describe("translate runtime substitution", () => {

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -216,16 +216,22 @@ export const strings: Record<string, StringEntry> = {
     zh: "已跳过 {0}：输出路径重复",
   },
   msg_read_error: { en: "Error reading {0}: {1}", zh: "读取 {0} 出错：{1}" },
+  msg_inferred_utf16: {
+    en: "{0}: detected BOM-less {1} from its byte pattern. This is a best-effort guess; verify the preview or output.",
+    zh: "已根据字节模式将 {0} 推测为无 BOM 的 {1} 编码。此结果并非完全确定，请核对预览或输出。",
+  },
   msg_unsupported: { en: "Skipped {0}: unsupported format", zh: "已跳过 {0}：不支持的格式" },
   // HDR Convert and Time Shift both surface a per-file count of
-  // oversized captions dropped by the subtitle parser
-  // (MAX_CAPTION_TEXT_LEN = 64 KB). Previously the placeholder Captions
-  // silently emitted empty Dialogue lines (HDR path) or were silently
-  // dropped (SRT/VTT); users had no signal that their input had been
-  // partially dropped.
+  // Rebuilding writers cannot safely transform captions above the
+  // MAX_CAPTION_TEXT_LEN (64 KB) cap. Structure-preserving writers use the
+  // sibling unchanged warning instead of claiming the source cue was dropped.
   msg_oversized_skipped: {
     en: "Dropped {0} oversized caption(s) from {1}: text exceeded 64 KB per-caption cap",
     zh: "{1} 中有 {0} 条超大字幕（单条 64 KB 上限）已丢弃",
+  },
+  msg_oversized_unchanged: {
+    en: "Left {0} oversized caption(s) in {1} unchanged: text exceeded the 64 KB per-caption processing cap",
+    zh: "{1} 中有 {0} 条超大字幕超过单条 64 KB 的处理上限，已保留原内容且未调整时间",
   },
   msg_done: { en: "Done: {0}", zh: "完成：{0}" },
   msg_convert_error: { en: "Error converting {0}: {1}", zh: "转换 {0} 出错：{1}" },

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -182,6 +182,10 @@ export const strings: Record<string, StringEntry> = {
   },
   template_label: { en: "Output Template", zh: "输出模板" },
   template_custom: { en: "Custom…", zh: "自定义…" },
+  template_required: {
+    en: "Enter a custom output template.",
+    zh: "请输入自定义输出模板。",
+  },
   style_settings: { en: "Style Settings", zh: "样式设置" },
   style_hint: { en: "(SRT/SUB/VTT input only)", zh: "（仅 SRT/SUB/VTT 输入）" },
   style_font: { en: "Font", zh: "字体" },
@@ -420,6 +424,8 @@ export const strings: Record<string, StringEntry> = {
     zh: "提示：可将 .ass / .ssa 文件或文件夹拖到上方文件栏（文件夹内其他类型文件会自动忽略）",
   },
   btn_embedding: { en: "Embedding…", zh: "嵌入中…" },
+  font_style_bold: { en: "Bold", zh: "粗体" },
+  font_style_italic: { en: "Italic", zh: "斜体" },
   msg_subsetting: { en: "Subsetting {0}…", zh: "子集化 {0}…" },
   msg_font_skipped: { en: "Skipped {0}: {1}", zh: "跳过 {0}：{1}" },
   msg_no_fonts_for_file: {

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -5,7 +5,8 @@
  * Parametric strings use {0}, {1}, ... placeholders.
  */
 
-export type Lang = "en" | "zh";
+export const LANGS = ["en", "zh"] as const;
+export type Lang = (typeof LANGS)[number];
 
 type StringEntry = Record<Lang, string>;
 
@@ -296,6 +297,10 @@ export const strings: Record<string, StringEntry> = {
   threshold_label: { en: "Apply only after:", zh: "仅在此时间后应用：" },
   threshold_invalid: { en: "Invalid format (HH:MM:SS.mmm)", zh: "格式无效（HH:MM:SS.mmm）" },
   preview_title: { en: "Preview — {0} captions", zh: "预览 — {0} 条字幕" },
+  preview_title_truncated: {
+    en: "Preview — first {0} of {1} captions",
+    zh: "预览 — 共 {1} 条字幕，显示前 {0} 条",
+  },
   col_index: { en: "#", zh: "#" },
   col_original: { en: "Original", zh: "原始" },
   col_shifted: { en: "After Shift", zh: "偏移后" },
@@ -328,6 +333,14 @@ export const strings: Record<string, StringEntry> = {
   preview_title_first: {
     en: "Preview — {0} captions ({1})",
     zh: "预览 — {1} 的 {0} 条字幕",
+  },
+  preview_title_first_truncated: {
+    en: "Preview — first {0} of {1} captions ({2})",
+    zh: "预览 — {2} 共 {1} 条字幕，显示前 {0} 条",
+  },
+  timing_preview_error: {
+    en: "Preview unavailable: {0}",
+    zh: "无法生成预览：{0}",
   },
   timing_drop_hint: {
     en: "Tip: drag subtitle files or a folder onto the file strip above (videos in the folder are skipped automatically)",
@@ -393,6 +406,10 @@ export const strings: Record<string, StringEntry> = {
   },
   msg_fonts_cancelled: { en: "Embed cancelled.", zh: "已取消嵌入。" },
   msg_fonts_error: { en: "Error embedding {0}: {1}", zh: "嵌入 {0} 出错：{1}" },
+  msg_fonts_analysis_unavailable: {
+    en: "Analysis data is unavailable. Select the files again.",
+    zh: "分析数据已不可用，请重新选择文件。",
+  },
   msg_fonts_file_warning: { en: "{0}: {1}", zh: "{0}：{1}" },
   msg_fonts_missing_warning: {
     en: "{0} referenced font(s) were missing and were not embedded",

--- a/src/lib/path-validation.test.ts
+++ b/src/lib/path-validation.test.ts
@@ -21,6 +21,13 @@ describe("assertSafeOutputFilename", () => {
     expect(() => assertSafeOutputFilename("   ")).toThrow(/empty/);
   });
 
+  it("rejects dot-only filenames without rejecting ordinary hidden names", () => {
+    for (const name of [".", "..", "...", " . . "]) {
+      expect(() => assertSafeOutputFilename(name)).toThrow(/dots-only/);
+    }
+    expect(() => assertSafeOutputFilename(".hidden.ass")).not.toThrow();
+  });
+
   it("rejects path separators in the filename", () => {
     expect(() => assertSafeOutputFilename("dir/file.ass")).toThrow(/illegal/);
     expect(() => assertSafeOutputFilename("dir\\file.ass")).toThrow(/illegal/);

--- a/src/lib/path-validation.test.ts
+++ b/src/lib/path-validation.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import {
   WINDOWS_RESERVED_NAMES,
@@ -8,6 +8,33 @@ import {
   decomposeInputPath,
   substituteTemplate,
 } from "./path-validation";
+
+type InjectedPlatform = {
+  isWindows: boolean;
+  isCaseInsensitiveFs: boolean;
+};
+
+async function withInjectedPlatform(
+  platform: InjectedPlatform,
+  run: (mod: typeof import("./path-validation")) => void | Promise<void>
+): Promise<void> {
+  const slot = globalThis as typeof globalThis & {
+    __ssahdrifyPlatform?: InjectedPlatform;
+  };
+  const previous = slot.__ssahdrifyPlatform;
+  slot.__ssahdrifyPlatform = platform;
+  vi.resetModules();
+  try {
+    await run(await import("./path-validation"));
+  } finally {
+    if (previous === undefined) {
+      delete slot.__ssahdrifyPlatform;
+    } else {
+      slot.__ssahdrifyPlatform = previous;
+    }
+    vi.resetModules();
+  }
+}
 
 describe("assertSafeOutputFilename", () => {
   it("accepts ordinary filenames", () => {
@@ -412,37 +439,55 @@ describe("assertSafeOutputPath", () => {
     expect(() => assertSafeOutputPath(overLimit, uncInput)).toThrow(/too long/);
   });
 
-  it("rejects self-overwrite when output basename only differs in case", () => {
-    // Realistic scenario: user template produces an output basename
-    // that case-folds to the input basename. The dir-escape check
-    // (which is case-sensitive) doesn't fire because the directory
-    // portion matches the input's case exactly. Self-overwrite check
-    // is case-insensitive, so the upper-case basename collides.
-    //
-    // Test portability: `pathsEqualOnFs`'s case-fold branch is gated
-    // on `isCaseInsensitiveFs()`, which
-    // returns true only on win32 and darwin. On Linux CI the test
-    // would fail because the case-fold path doesn't trigger. Force
-    // `__ssahdrifyPlatform = "win32"` via the same injection
-    // mechanism `platform.ts` documents for the CLI runtime; restore
-    // in finally so other tests aren't affected. (CLI runtime uses
-    // the same hook to declare its host platform without depending
-    // on `process.platform`.)
-    type PlatformSlot = { __ssahdrifyPlatform?: unknown };
-    const slot = globalThis as PlatformSlot;
-    const previous = slot.__ssahdrifyPlatform;
-    slot.__ssahdrifyPlatform = "win32";
-    try {
-      expect(() => assertSafeOutputPath("C:/subs/EPISODE01.ass", inputBackslash)).toThrow(
-        /same as input/
-      );
-    } finally {
-      if (previous === undefined) {
-        delete slot.__ssahdrifyPlatform;
-      } else {
-        slot.__ssahdrifyPlatform = previous;
+  it("rejects case-only self-overwrite on an injected case-insensitive Windows runtime", async () => {
+    await withInjectedPlatform(
+      { isWindows: true, isCaseInsensitiveFs: true },
+      ({ assertSafeOutputPath: assertInjectedSafeOutputPath }) => {
+        expect(() => assertInjectedSafeOutputPath("C:/subs/EPISODE01.ass", inputBackslash)).toThrow(
+          /same as input/
+        );
       }
-    }
+    );
+  });
+
+  it("keeps case-only paths distinct on an injected case-sensitive POSIX runtime", async () => {
+    await withInjectedPlatform(
+      { isWindows: false, isCaseInsensitiveFs: false },
+      ({ assertSafeOutputPath: assertInjectedSafeOutputPath }) => {
+        expect(() =>
+          assertInjectedSafeOutputPath("/subs/EPISODE01.ass", "/subs/episode01.ass")
+        ).not.toThrow();
+      }
+    );
+  });
+
+  it("preserves POSIX backslashes and applies the 4096-character path boundary", async () => {
+    await withInjectedPlatform(
+      { isWindows: false, isCaseInsensitiveFs: false },
+      ({
+        assertSafeOutputPath: assertInjectedSafeOutputPath,
+        decomposeInputPath: decomposeInjectedInputPath,
+      }) => {
+        expect(decomposeInjectedInputPath("/tmp/ep\\01.srt")).toEqual({
+          dir: "/tmp",
+          baseName: "ep\\01",
+          ext: ".srt",
+          normalized: "/tmp/ep\\01.srt",
+          usedBackslash: false,
+        });
+
+        const prefix = "/tmp/";
+        const suffix = ".ass";
+        const atLimit = `${prefix}${"a".repeat(4096 - prefix.length - suffix.length)}${suffix}`;
+        const overLimit = `${prefix}${"a".repeat(4097 - prefix.length - suffix.length)}${suffix}`;
+        expect(atLimit).toHaveLength(4096);
+        expect(overLimit).toHaveLength(4097);
+        expect(() => assertInjectedSafeOutputPath(atLimit, "/tmp/source.ass")).not.toThrow();
+        expect(() => assertInjectedSafeOutputPath(overLimit, "/tmp/source.ass")).toThrow(
+          /too long.*4096/i
+        );
+      }
+    );
   });
 });
 

--- a/src/lib/path-validation.ts
+++ b/src/lib/path-validation.ts
@@ -21,13 +21,14 @@ import { ASCII_CONTROL_CHARS, hasUnicodeControls, stripUnicodeControls } from ".
  */
 
 // ── Windows reserved names ─────────────────────────────────
-// Forbidden on Windows regardless of extension (NT object-namespace
-// reservations: legacy device names that the kernel routes specially).
+// Names this project rejects for Windows-safe output. The documented
+// device names are forbidden regardless of extension (NT object-namespace
+// reservations that the kernel routes specially).
 //
 // Source: https://learn.microsoft.com/en-us/windows/win32/fileio/naming-a-file
-// Includes COM0–COM9, LPT0–LPT9, plus the ISO 8859-1 superscript-digit
-// variants (COM¹/²/³ and LPT¹/²/³) that current Windows recognizes as
-// device aliases.
+// Microsoft documents COM1–COM9, LPT1–LPT9, plus the ISO 8859-1
+// superscript-digit variants (COM¹/²/³ and LPT¹/²/³). This project also
+// rejects COM0 / LPT0 defensively as device-like names for portable output.
 //
 // CONIN$ / CONOUT$ are runtime Win32 console aliases (Global?? namespace)
 // rather than always-reserved device names; included defensively because

--- a/src/lib/path-validation.ts
+++ b/src/lib/path-validation.ts
@@ -528,6 +528,9 @@ export function assertSafeOutputFilename(
   if (!filename.trim()) {
     throw new Error("Template resolves to empty filename");
   }
+  if (!filename.replace(/\./g, "").trim()) {
+    throw new Error("Template resolves to a dots-only filename");
+  }
   const illegalRe = options?.allowBraces
     ? ILLEGAL_FILENAME_CHARS_BRACES_OK
     : ILLEGAL_FILENAME_CHARS;

--- a/src/lib/strict-number.test.ts
+++ b/src/lib/strict-number.test.ts
@@ -19,6 +19,11 @@ describe("parseFiniteNumberText", () => {
     expect(parseFiniteNumberText(`${"1".repeat(120)}e123456789`)).toBeNull();
   });
 
+  it("accepts numeric text exactly at the 128-character limit", () => {
+    const atLimit = "1".repeat(128);
+    expect(parseFiniteNumberText(atLimit)).toBe(Number(atLimit));
+  });
+
   it("accepts complete finite decimal text", () => {
     expect(parseFiniteNumberText("1")).toBe(1);
     expect(parseFiniteNumberText("-1.5")).toBe(-1.5);

--- a/src/lib/subtitle-parser.test.ts
+++ b/src/lib/subtitle-parser.test.ts
@@ -587,7 +587,7 @@ describe("parseSubtitle / shiftSubtitle — oversized-ASS-Dialogue placeholder a
 
   // ── Parser boundary pins ──
 
-  it("parses single-digit-hour VTT timing as zero (bounded-hour regex)", () => {
+  it("rejects a single-digit-hour VTT timing line as non-shiftable", () => {
     // The VTT hour group is bounded `\d{2,12}`, so a stray
     // single-digit hour like "1:00:00.000" doesn't satisfy the
     // HH:MM:SS form. The MM:SS arm still matches ("1:00.000" is
@@ -599,6 +599,7 @@ describe("parseSubtitle / shiftSubtitle — oversized-ASS-Dialogue placeholder a
     expect(result.format).toBe("vtt");
     // The cue's timing line failed to match → block skipped → zero captions.
     expect(result.captions).toHaveLength(0);
+    expect(() => shiftSubtitle(content, 1000)).toThrow(/No shiftable subtitle cues/);
   });
 
   it("round-trips the largest whole-hour VTT value within the safe-integer boundary", () => {

--- a/src/lib/subtitle-parser.test.ts
+++ b/src/lib/subtitle-parser.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
+  formatDisplayTime,
   parseDisplayTime,
   parseSubtitle,
+  safeMs,
   shiftSubtitle,
   transformSubtitleTimings,
 } from "./subtitle-parser";
@@ -59,22 +61,25 @@ describe("parseSubtitle", () => {
     expect(result.captions[0]!.text).toBe("real cue");
   });
 
-  it("accepts NOTE as a standards-valid WebVTT cue identifier", () => {
-    const content = [
-      "WEBVTT",
-      "",
-      "NOTE",
-      "00:00:01.000 --> 00:00:02.000 align:start",
-      "this is a cue, not a comment block",
-      "",
-    ].join("\n");
+  it.each(["NOTE", "STYLE", "REGION"])(
+    "accepts %s as a standards-valid WebVTT cue identifier",
+    (cueId) => {
+      const content = [
+        "WEBVTT",
+        "",
+        cueId,
+        "00:00:01.000 --> 00:00:02.000 align:start",
+        "this is a cue, not a comment block",
+        "",
+      ].join("\n");
 
-    const result = parseSubtitle(content);
+      const result = parseSubtitle(content);
 
-    expect(result.captions).toHaveLength(1);
-    expect(result.captions[0]!.cueId).toBe("NOTE");
-    expect(result.captions[0]!.text).toBe("this is a cue, not a comment block");
-  });
+      expect(result.captions).toHaveLength(1);
+      expect(result.captions[0]!.cueId).toBe(cueId);
+      expect(result.captions[0]!.text).toBe("this is a cue, not a comment block");
+    }
+  );
 
   it("parses ASS Dialogue lines and reports format=ass", () => {
     const content =
@@ -308,16 +313,61 @@ describe("parseSubtitle", () => {
   });
 });
 
+describe("safeMs / formatDisplayTime", () => {
+  it.each([
+    [1234.9, 1234, "00:00:01.234"],
+    [-1234.9, 0, "00:00:00.000"],
+    [Number.MAX_SAFE_INTEGER + 1, Number.MAX_SAFE_INTEGER, "2501999792:59:00.991"],
+    [NaN, 0, "00:00:00.000"],
+    [Infinity, 0, "00:00:00.000"],
+    [-Infinity, 0, "00:00:00.000"],
+  ])("canonicalizes %s to integer milliseconds", (input, expectedMs, expectedDisplay) => {
+    expect(safeMs(input)).toBe(expectedMs);
+    expect(formatDisplayTime(input)).toBe(expectedDisplay);
+  });
+});
+
 describe("transformSubtitleTimings", () => {
-  it("rejects non-finite transformed timestamps before formatting output", () => {
+  it.each(["start", "end"] as const)(
+    "rejects a non-finite transformed %s before formatting output",
+    (field) => {
+      const srt = ["1", "00:00:01,000 --> 00:00:02,000", "hello", ""].join("\n");
+
+      expect(() =>
+        transformSubtitleTimings(srt, (caption) => ({
+          ...caption,
+          [field]: NaN,
+        }))
+      ).toThrow(/non-finite timestamp/);
+    }
+  );
+
+  it("canonicalizes fractional transformed timestamps in data, preview, and serialization", () => {
     const srt = ["1", "00:00:01,000 --> 00:00:02,000", "hello", ""].join("\n");
 
-    expect(() =>
-      transformSubtitleTimings(srt, (caption) => ({
-        ...caption,
-        start: NaN,
-      }))
-    ).toThrow(/non-finite timestamp/);
+    const result = transformSubtitleTimings(srt, (caption) => ({
+      ...caption,
+      start: 1234.9,
+      end: 2345.9,
+    }));
+
+    expect(result.shifted[0]).toMatchObject({ start: 1234, end: 2345 });
+    expect(formatDisplayTime(result.shifted[0]!.start)).toBe("00:00:01.234");
+    expect(formatDisplayTime(result.shifted[0]!.end)).toBe("00:00:02.345");
+    expect(result.output).toBe("1\n00:00:01,234 --> 00:00:02,345\nhello\n");
+  });
+
+  it("clamps large finite negative transformed timestamps consistently", () => {
+    const srt = ["1", "00:00:01,000 --> 00:00:02,000", "hello", ""].join("\n");
+
+    const result = transformSubtitleTimings(srt, (caption) => ({
+      ...caption,
+      start: -Number.MAX_SAFE_INTEGER,
+      end: -1_000_000_000_000.5,
+    }));
+
+    expect(result.shifted[0]).toMatchObject({ start: 0, end: 0 });
+    expect(result.output).toBe("1\n00:00:00,000 --> 00:00:00,000\nhello\n");
   });
 
   it("rewrites only WebVTT cue timestamps and preserves the exact surrounding structure", () => {
@@ -533,19 +583,18 @@ describe("parseSubtitle / shiftSubtitle — oversized-ASS-Dialogue placeholder a
     expect(result.captions).toHaveLength(0);
   });
 
-  it("parses 12-digit-hour VTT timing (upper bound)", () => {
-    // Use a 12-digit fixture so the at-limit test pins the boundary
-    // from the inside. An earlier attempt used a 9-digit fixture and
-    // called it "upper bound"; a regression lowering the bound to
-    // `\d{2,11}` would have left both tests green (9 digits passes,
-    // 13 fails) without exercising the actual 12-digit edge. The
-    // 12-digit fixture + the 13-digit over-bound counter-test (below)
-    // pin the boundary from both sides: at-limit must pass and
-    // over-limit must fail.
-    const longHour = "999999999999"; // 12 digits, exactly at {2,12} upper bound
-    const content = `WEBVTT\r\n\r\n${longHour}:00:01.000 --> ${longHour}:00:02.000\r\nLine\r\n`;
+  it("round-trips the largest whole-hour VTT value within the safe-integer boundary", () => {
+    const longHour = "2501999792";
+    const content = `WEBVTT\n\n${longHour}:00:01.000 --> ${longHour}:00:02.000\nLine\n`;
     const result = parseSubtitle(content);
     expect(result.captions).toHaveLength(1);
+    expect(shiftSubtitle(content, 0).output).toBe(content);
+  });
+
+  it("rejects a syntactically bounded VTT timestamp beyond the safe-integer boundary", () => {
+    const unsafeHour = "999999999999";
+    const content = `WEBVTT\n\n${unsafeHour}:00:01.000 --> ${unsafeHour}:00:02.000\nLine\n`;
+    expect(() => parseSubtitle(content)).toThrow(/safe integer range/);
   });
 
   it("rejects 13-digit-hour VTT timing (upper bound enforced)", () => {
@@ -565,12 +614,19 @@ describe("parseSubtitle / shiftSubtitle — oversized-ASS-Dialogue placeholder a
   // a refactor that loosens the cap (`\d{1,13}`) or tightens it
   // (`\d{1,11}`) trips a test.
 
-  it("parses 12-digit-hour SRT timing (upper bound)", () => {
-    const longHour = "999999999999"; // 12 digits
+  it("round-trips the largest whole-hour SRT value within the safe-integer boundary", () => {
+    const longHour = "2501999792";
     const content = `1\n${longHour}:00:01,000 --> ${longHour}:00:02,000\nLine\n`;
     const result = parseSubtitle(content);
     expect(result.format).toBe("srt");
     expect(result.captions).toHaveLength(1);
+    expect(shiftSubtitle(content, 0).output).toBe(content);
+  });
+
+  it("rejects a syntactically bounded SRT timestamp beyond the safe-integer boundary", () => {
+    const unsafeHour = "999999999999";
+    const content = `1\n${unsafeHour}:00:01,000 --> ${unsafeHour}:00:02,000\nLine\n`;
+    expect(() => parseSubtitle(content)).toThrow(/safe integer range/);
   });
 
   it("rejects 13-digit-hour SRT timing (upper bound enforced)", () => {
@@ -589,8 +645,8 @@ describe("parseSubtitle / shiftSubtitle — oversized-ASS-Dialogue placeholder a
     expect(() => parseSubtitle(content)).toThrow("Could not detect subtitle format");
   });
 
-  it("parses 12-digit-hour ASS Dialogue (upper bound)", () => {
-    const longHour = "999999999999"; // 12 digits
+  it("round-trips the largest whole-hour ASS value within the safe-integer boundary", () => {
+    const longHour = "2501999792";
     const ass =
       "[Script Info]\n\n[V4+ Styles]\nFormat: Name\nStyle: Default\n\n" +
       "[Events]\nFormat: Layer, Start, End, Style, Text\n" +
@@ -599,6 +655,16 @@ describe("parseSubtitle / shiftSubtitle — oversized-ASS-Dialogue placeholder a
     expect(result.format).toBe("ass");
     expect(result.captions).toHaveLength(1);
     expect(result.captions[0]!.text).toContain("Hello");
+    expect(shiftSubtitle(ass, 0).output).toBe(ass);
+  });
+
+  it("rejects a syntactically bounded ASS timestamp beyond the safe-integer boundary", () => {
+    const unsafeHour = "999999999999";
+    const ass =
+      "[Script Info]\n\n[V4+ Styles]\nFormat: Name\nStyle: Default\n\n" +
+      "[Events]\nFormat: Layer, Start, End, Style, Text\n" +
+      `Dialogue: 0,${unsafeHour}:00:01.00,${unsafeHour}:00:02.00,Default,Hello\n`;
+    expect(() => parseSubtitle(ass)).toThrow(/safe integer range/);
   });
 
   it("rejects 13-digit-hour ASS Dialogue (upper bound enforced)", () => {

--- a/src/lib/subtitle-parser.test.ts
+++ b/src/lib/subtitle-parser.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { parseSubtitle, shiftSubtitle, transformSubtitleTimings } from "./subtitle-parser";
+import {
+  parseDisplayTime,
+  parseSubtitle,
+  shiftSubtitle,
+  transformSubtitleTimings,
+} from "./subtitle-parser";
 
 describe("parseSubtitle", () => {
   it("splits SRT cue blocks with mixed CRLF and LF endings", () => {
@@ -29,6 +34,7 @@ describe("parseSubtitle", () => {
       "WEBVTT",
       "",
       "NOTE exported by a tool",
+      "comment text before an invalid timing-shaped line",
       "00:00:01.000 --> 00:00:02.000",
       "comment text must not become a cue",
       "",
@@ -53,6 +59,23 @@ describe("parseSubtitle", () => {
     expect(result.captions[0]!.text).toBe("real cue");
   });
 
+  it("accepts NOTE as a standards-valid WebVTT cue identifier", () => {
+    const content = [
+      "WEBVTT",
+      "",
+      "NOTE",
+      "00:00:01.000 --> 00:00:02.000 align:start",
+      "this is a cue, not a comment block",
+      "",
+    ].join("\n");
+
+    const result = parseSubtitle(content);
+
+    expect(result.captions).toHaveLength(1);
+    expect(result.captions[0]!.cueId).toBe("NOTE");
+    expect(result.captions[0]!.text).toBe("this is a cue, not a comment block");
+  });
+
   it("parses ASS Dialogue lines and reports format=ass", () => {
     const content =
       "[Script Info]\nScriptType: v4.00+\n\n" +
@@ -71,6 +94,49 @@ describe("parseSubtitle", () => {
     expect(result.captions[0]!.end).toBe(2500);
     expect(result.captions[1]!.start).toBe(3000);
     expect(result.captions[1]!.end).toBe(4500);
+  });
+
+  it("parses and shifts classic SSA Marked dialogue prefixes", () => {
+    const content =
+      "[Script Info]\nScriptType: v4.00\n\n" +
+      "[Events]\nFormat: Marked, Start, End, Style, Text\n" +
+      "Dialogue: Marked=0,0:00:01.00,0:00:02.50,Default,Hello\n" +
+      "Dialogue: Marked = 1,0:00:03.00,0:00:04.50,Default,World\n";
+
+    const parsed = parseSubtitle(content);
+    expect(parsed.captions).toHaveLength(2);
+
+    const { output } = shiftSubtitle(content, 1000);
+    expect(output).toContain("Dialogue: Marked=0,0:00:02.00,0:00:03.50,Default,Hello");
+    expect(output).toContain("Dialogue: Marked = 1,0:00:04.00,0:00:05.50,Default,World");
+  });
+
+  it.each([
+    ["SRT minutes", "1\n00:60:00,000 --> 00:60:01,000\nline\n"],
+    ["SRT seconds", "1\n00:00:60,000 --> 00:01:01,000\nline\n"],
+    ["full WebVTT minutes", "WEBVTT\n\n00:60:00.000 --> 00:60:01.000\nline\n"],
+    ["full WebVTT seconds", "WEBVTT\n\n00:00:60.000 --> 00:01:01.000\nline\n"],
+    ["short WebVTT minutes", "WEBVTT\n\n60:00.000 --> 60:01.000\nline\n"],
+    ["short WebVTT seconds", "WEBVTT\n\n00:60.000 --> 01:01.000\nline\n"],
+    ["ASS minutes", "[Script Info]\n\n[Events]\nDialogue: 0,0:60:00.00,0:60:01.00,Default,line\n"],
+    ["ASS seconds", "[Script Info]\n\n[Events]\nDialogue: 0,0:00:60.00,0:01:01.00,Default,line\n"],
+  ])("rejects %s fields at 60", (_label, content) => {
+    expect(() => parseSubtitle(content)).toThrow(/below 60/);
+  });
+
+  it.each([
+    "1\n00:59:59,000 --> 01:00:00,000\nline\n",
+    "WEBVTT\n\n00:59:59.000 --> 01:00:00.000\nline\n",
+    "WEBVTT\n\n59:59.000 --> 01:00:00.000\nline\n",
+    "[Script Info]\n\n[Events]\nDialogue: 0,0:59:59.00,1:00:00.00,Default,line\n",
+  ])("accepts minute and second fields at 59: %s", (content) => {
+    expect(parseSubtitle(content).captions).toHaveLength(1);
+  });
+
+  it("keeps display-time validation aligned with subtitle timestamp bounds", () => {
+    expect(parseDisplayTime("00:59:59.999")).toBe(3_599_999);
+    expect(parseDisplayTime("00:60:00.000")).toBeNull();
+    expect(parseDisplayTime("00:00:60.000")).toBeNull();
   });
 
   it("parses MicroDVD SUB frame ranges and reports format=sub", () => {
@@ -252,6 +318,72 @@ describe("transformSubtitleTimings", () => {
         start: NaN,
       }))
     ).toThrow(/non-finite timestamp/);
+  });
+
+  it("rewrites only WebVTT cue timestamps and preserves the exact surrounding structure", () => {
+    const input =
+      "WEBVTT - exported\r\n" +
+      "X-TIMESTAMP-MAP=LOCAL:00:00:00.000,MPEGTS:900000\r\n" +
+      "\r\n" +
+      "STYLE\r\n" +
+      "::cue { color: white }\r\n" +
+      "\r\n" +
+      "NOTE export comment\r\n" +
+      "leave this block alone\r\n" +
+      "\r\n" +
+      "REGION\r\n" +
+      "id:bottom\r\n" +
+      "width:40%\r\n" +
+      "\r\n" +
+      "cue-a\r\n" +
+      "00:00:01.000  -->\t00:00:02.500 line:20% position:30% align:start\r\n" +
+      "Hello\r\n";
+
+    const expected = input.replace(
+      "00:00:01.000  -->\t00:00:02.500",
+      "00:00:02.000  -->\t00:00:03.500"
+    );
+
+    expect(shiftSubtitle(input, 1000).output).toBe(expected);
+  });
+
+  it("preserves multiple blank separator lines before an identified WebVTT cue", () => {
+    const input = "WEBVTT\n\n\ncue-a\n00:00:01.000 --> 00:00:02.000 align:start\nHello\n";
+    const expected = input.replace(
+      "00:00:01.000 --> 00:00:02.000",
+      "00:00:02.000 --> 00:00:03.000"
+    );
+
+    expect(shiftSubtitle(input, 1000).output).toBe(expected);
+  });
+
+  it("rejects a comment-only WebVTT file instead of rebuilding it as an empty header", () => {
+    const input = "WEBVTT\n\nNOTE no shiftable cues\ncomment body\n";
+
+    expect(() => shiftSubtitle(input, 1000)).toThrow(/No shiftable subtitle cues/);
+  });
+
+  it("rejects WebVTT whose only timing line is malformed", () => {
+    const input = "WEBVTT\n\n00:00:01,000 --> 00:00:02,000\nwrong separator\n";
+
+    expect(() => shiftSubtitle(input, 1000)).toThrow(/No shiftable subtitle cues/);
+  });
+
+  it("rejects files whose only parsed cue is an oversized placeholder", () => {
+    const input = `WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n${"X".repeat(65_000)}\n`;
+
+    expect(() => shiftSubtitle(input, 1000)).toThrow(/No shiftable subtitle cues/);
+  });
+
+  it("preserves an oversized WebVTT cue while shifting later normal cues", () => {
+    const oversized = "X".repeat(65_000);
+    const input =
+      `WEBVTT\n\n00:00:01.000 --> 00:00:02.000 align:start\n${oversized}\n\n` +
+      "00:00:03.000 --> 00:00:04.000\nnormal\n";
+
+    const { output } = shiftSubtitle(input, 1000);
+    expect(output).toContain(`00:00:01.000 --> 00:00:02.000 align:start\n${oversized}`);
+    expect(output).toContain("00:00:04.000 --> 00:00:05.000\nnormal");
   });
 });
 

--- a/src/lib/subtitle-parser.test.ts
+++ b/src/lib/subtitle-parser.test.ts
@@ -101,6 +101,17 @@ describe("parseSubtitle", () => {
     expect(result.captions[1]!.end).toBe(4500);
   });
 
+  it("does not retain a CRLF terminator in ASS caption text", () => {
+    const content =
+      "[Script Info]\r\nScriptType: v4.00+\r\n\r\n" +
+      "[Events]\r\nFormat: Layer, Start, End, Style, Text\r\n" +
+      "Dialogue: 0,0:00:01.00,0:00:02.00,Default,Hello\r\n";
+
+    const result = parseSubtitle(content);
+    expect(result.captions[0]!.text).toBe("Default,Hello");
+    expect(result.captions[0]!.text).not.toContain("\r");
+  });
+
   it("parses and shifts classic SSA Marked dialogue prefixes", () => {
     const content =
       "[Script Info]\nScriptType: v4.00\n\n" +
@@ -164,6 +175,13 @@ describe("parseSubtitle", () => {
     expect(result.captions[0]!.end).toBe(2002);
     expect(result.captions[1]!.start).toBe(3003);
     expect(result.captions[1]!.end).toBe(4004);
+  });
+
+  it("does not retain a CRLF terminator in MicroDVD SUB caption text", () => {
+    const result = parseSubtitle("{24}{48}Hello\r\n");
+
+    expect(result.captions[0]!.text).toBe("Hello");
+    expect(result.captions[0]!.text).not.toContain("\r");
   });
 
   it("throws when the content has no recognized header or timing", () => {

--- a/src/lib/subtitle-parser.ts
+++ b/src/lib/subtitle-parser.ts
@@ -389,6 +389,14 @@ export const MAX_PARSED_ENTRIES = 500_000;
 // separate payloads of 1.5M blocks each are both accepted.
 const MAX_RAW_BLOCKS = 2_000_000;
 
+// Per-caption text cap shared by SRT, VTT, ASS, and MicroDVD SUB.
+// Real-world caption text is normally well under 1 KB; 64 KB remains
+// generous while bounding a crafted multi-megabyte text body. Each parser
+// emits a skipped placeholder for an oversized caption so feature layers can
+// report the omission. ASS additionally relies on the placeholder to keep
+// buildAss's positional walk aligned with the original Dialogue line order.
+const MAX_CAPTION_TEXT_LEN = 64_000;
+
 function parseSrt(content: string): Caption[] {
   const captions: Caption[] = [];
   // Normalize first so mixed CRLF/LF files still split into cue blocks.
@@ -644,19 +652,6 @@ const DIALOGUE_FLAGS = "gim";
 function createDialogueRe(): RegExp {
   return new RegExp(DIALOGUE_PATTERN, DIALOGUE_FLAGS);
 }
-
-// per-caption text cap. Real-world ASS
-// dialogue lines are < 1 KB even for elaborate styled karaoke. 64 KB
-// is generous — guards against a crafted file with a single dialogue
-// containing a multi-MB attacker-influenced text body.
-// Captions exceeding the cap are skipped (text dropped), but for ASS
-// parseAss still emits a placeholder Caption with `skipped: true` so
-// that buildAss's positional consumption stays aligned with the
-// original Dialogue line order (see parseAss / buildAss WHY below).
-// Matches parseSub's per-text guard added alongside (parseSub doesn't
-// need the placeholder dance because buildSub rebuilds from the
-// captions array, not by walking original content).
-const MAX_CAPTION_TEXT_LEN = 64_000;
 
 function parseAss(content: string): Caption[] {
   const captions: Caption[] = [];

--- a/src/lib/subtitle-parser.ts
+++ b/src/lib/subtitle-parser.ts
@@ -29,9 +29,9 @@ export interface Caption {
    * The placeholder counts
    * toward MAX_PARSED_ENTRIES on every parser. buildAss returns the
    * original Dialogue line untouched (so its positional alignment with
-   * the regex-walk over original content holds); buildSrt / buildVtt /
-   * buildSub filter placeholders out before serialization so disk
-   * output is unchanged.
+   * the regex-walk over original content holds); buildVtt likewise keeps
+   * the original cue in place. buildSrt / buildSub filter placeholders
+   * before serialization and the feature layer surfaces the skipped count.
    */
   skipped?: boolean;
 }
@@ -221,12 +221,12 @@ function parseSrtTime(ts: string): number {
   // structurally impossible.
   const m = ts.match(/(\d{1,12}):(\d{2}):(\d{2})[,.](\d{3})/);
   if (!m) return 0;
-  return (
-    parseInt(m[1]!, 10) * 3600000 +
-    parseInt(m[2]!, 10) * 60000 +
-    parseInt(m[3]!, 10) * 1000 +
-    parseInt(m[4]!, 10)
-  );
+  const minutes = parseInt(m[2]!, 10);
+  const seconds = parseInt(m[3]!, 10);
+  if (minutes >= 60 || seconds >= 60) {
+    throw new Error(`Invalid SRT timestamp (minutes and seconds must be below 60): ${ts}`);
+  }
+  return parseInt(m[1]!, 10) * 3600000 + minutes * 60000 + seconds * 1000 + parseInt(m[4]!, 10);
 }
 
 /** Parse VTT timestamps — supports both "HH:MM:SS.mmm" and "MM:SS.mmm" (no hours) */
@@ -240,19 +240,24 @@ function parseVttTime(ts: string): number {
   // same shape.
   const full = ts.match(/^(\d{2,12}):(\d{2}):(\d{2})\.(\d{3})$/);
   if (full) {
+    const minutes = parseInt(full[2]!, 10);
+    const seconds = parseInt(full[3]!, 10);
+    if (minutes >= 60 || seconds >= 60) {
+      throw new Error(`Invalid WebVTT timestamp (minutes and seconds must be below 60): ${ts}`);
+    }
     return (
-      parseInt(full[1]!, 10) * 3600000 +
-      parseInt(full[2]!, 10) * 60000 +
-      parseInt(full[3]!, 10) * 1000 +
-      parseInt(full[4]!, 10)
+      parseInt(full[1]!, 10) * 3600000 + minutes * 60000 + seconds * 1000 + parseInt(full[4]!, 10)
     );
   }
   // MM:SS.mmm (no hours — valid per WebVTT spec)
   const short = ts.match(/^(\d{2}):(\d{2})\.(\d{3})$/);
   if (short) {
-    return (
-      parseInt(short[1]!, 10) * 60000 + parseInt(short[2]!, 10) * 1000 + parseInt(short[3]!, 10)
-    );
+    const minutes = parseInt(short[1]!, 10);
+    const seconds = parseInt(short[2]!, 10);
+    if (minutes >= 60 || seconds >= 60) {
+      throw new Error(`Invalid WebVTT timestamp (minutes and seconds must be below 60): ${ts}`);
+    }
+    return minutes * 60000 + seconds * 1000 + parseInt(short[3]!, 10);
   }
   return 0;
 }
@@ -261,11 +266,13 @@ function parseVttTime(ts: string): number {
 function parseAssTime(ts: string): number {
   const m = ts.match(/(\d{1,12}):(\d{2}):(\d{2})\.(\d{2})/);
   if (!m) return 0;
+  const minutes = parseInt(m[2]!, 10);
+  const seconds = parseInt(m[3]!, 10);
+  if (minutes >= 60 || seconds >= 60) {
+    throw new Error(`Invalid ASS/SSA timestamp (minutes and seconds must be below 60): ${ts}`);
+  }
   return (
-    parseInt(m[1]!, 10) * 3600000 +
-    parseInt(m[2]!, 10) * 60000 +
-    parseInt(m[3]!, 10) * 1000 +
-    parseInt(m[4]!, 10) * 10
+    parseInt(m[1]!, 10) * 3600000 + minutes * 60000 + seconds * 1000 + parseInt(m[4]!, 10) * 10
   );
 }
 
@@ -320,10 +327,13 @@ export function formatDisplayTime(ms: number): string {
 export function parseDisplayTime(ts: string): number | null {
   const m = ts.match(/^(\d{1,12}):(\d{2}):(\d{2})\.(\d{1,3})$/);
   if (!m) return null;
+  const minutes = parseInt(m[2]!, 10);
+  const seconds = parseInt(m[3]!, 10);
+  if (minutes >= 60 || seconds >= 60) return null;
   return (
     parseInt(m[1]!, 10) * 3600000 +
-    parseInt(m[2]!, 10) * 60000 +
-    parseInt(m[3]!, 10) * 1000 +
+    minutes * 60000 +
+    seconds * 1000 +
     parseInt(m[4]!.padEnd(3, "0"), 10)
   );
 }
@@ -455,6 +465,53 @@ function buildSrt(captions: Caption[]): string {
 
 // ── VTT Parser ────────────────────────────────────────────
 
+const VTT_TIMESTAMP_SHAPE = String.raw`(?:\d{2,12}:\d{2}:\d{2}\.\d{3}|\d{2}:\d{2}\.\d{3})`;
+const VTT_TIMING_LINE = new RegExp(
+  String.raw`^(${VTT_TIMESTAMP_SHAPE})([\t ]*-->[\t ]*)(${VTT_TIMESTAMP_SHAPE})(.*)$`
+);
+
+type VttCueTiming = {
+  timingIdx: number;
+  match: RegExpMatchArray;
+};
+
+type LineSpan = {
+  text: string;
+  start: number;
+  end: number;
+};
+
+function lineSpans(content: string): LineSpan[] {
+  const spans: LineSpan[] = [];
+  let start = 0;
+  while (start < content.length) {
+    let end = start;
+    while (end < content.length && content[end] !== "\r" && content[end] !== "\n") {
+      end += 1;
+    }
+    spans.push({ text: content.slice(start, end), start, end });
+    if (end >= content.length) break;
+    start = content[end] === "\r" && content[end + 1] === "\n" ? end + 2 : end + 1;
+  }
+  return spans;
+}
+
+/**
+ * WebVTT recognizes a cue timing line only as the first or second line
+ * of a block. Checking the second line before classifying NOTE / STYLE /
+ * REGION preserves the standards-valid case where one of those words is
+ * the cue identifier; real metadata blocks have no timing line there.
+ */
+function findVttCueTiming(lines: string[]): VttCueTiming | undefined {
+  const first = lines[0]?.match(VTT_TIMING_LINE);
+  if (first) return { timingIdx: 0, match: first };
+
+  const second = lines[1]?.match(VTT_TIMING_LINE);
+  if (second) return { timingIdx: 1, match: second };
+
+  return undefined;
+}
+
 function parseVtt(content: string): Caption[] {
   const captions: Caption[] = [];
   const body = normalizeLineEndings(content).replace(/^WEBVTT[^\n]*\n/, "");
@@ -467,38 +524,13 @@ function parseVtt(content: string): Caption[] {
         `Per-caption parse cap is ${MAX_PARSED_ENTRIES}; raw-block ceiling guards iteration cost.`
     );
   }
-  // VTT timing: supports both HH:MM:SS.mmm and MM:SS.mmm.
-  // Hour group bounded `\d{2,12}` for parity with parseSrt + parseAss
-  // — an unbounded `\d{2,}` form let a crafted single-line input scan
-  // O(N) before silent-fallback to zero, and diverged from the rest
-  // of the parser family. 12 digits caps the
-  // hours at ~1e12, well past any plausible timecode and aligned with
-  // ASS DIALOGUE_PATTERN's `\d{1,12}` bound.
-  const timingRe =
-    /^(\d{2,12}:\d{2}:\d{2}\.\d{3}|\d{2}:\d{2}\.\d{3})\s*-->\s*(\d{2,12}:\d{2}:\d{2}\.\d{3}|\d{2}:\d{2}\.\d{3})/;
-
   // Per-entry cap — see parseSrt for the
   // block-vs-entry rationale.
   for (const block of blocks) {
     const lines = block.replace(/^\n/, "").split("\n");
-    const firstLine = lines[0]?.trimStart() ?? "";
-    // WebVTT NOTE / STYLE / REGION blocks are metadata, not cues. A
-    // timing-looking line inside them must not become ASS dialogue.
-    if (/^(?:NOTE|STYLE|REGION)(?:\s|$)/.test(firstLine)) {
-      continue;
-    }
-    // Find the timing line — a cue ID is any line that does NOT contain "-->"
-    let timingIdx = -1;
-    for (let i = 0; i < lines.length; i++) {
-      if (timingRe.test(lines[i]!)) {
-        timingIdx = i;
-        break;
-      }
-    }
-    if (timingIdx === -1) continue;
-
-    const timingMatch = lines[timingIdx]!.match(timingRe);
-    if (!timingMatch) continue;
+    const timing = findVttCueTiming(lines);
+    if (!timing) continue;
+    const { timingIdx, match: timingMatch } = timing;
 
     if (captions.length >= MAX_PARSED_ENTRIES) {
       throw new Error(`Too many subtitle entries: ${captions.length}+ (max ${MAX_PARSED_ENTRIES})`);
@@ -511,13 +543,13 @@ function parseVtt(content: string): Caption[] {
       .trim();
     // oversized text → skipped placeholder
     // (same rationale as parseSrt; see WHY block there). The
-    // placeholder retains cueId because buildVtt's filter respects the
-    // skipped flag, not the cueId presence.
+    // The placeholder retains cueId for preview/accounting; buildVtt uses
+    // source spans and deliberately leaves this entire cue unchanged.
     if (text.length > MAX_CAPTION_TEXT_LEN) {
       captions.push({
         raw: block.trim(),
         start: parseVttTime(timingMatch[1]!),
-        end: parseVttTime(timingMatch[2]!),
+        end: parseVttTime(timingMatch[3]!),
         text: "",
         ...(cueId !== undefined && { cueId }),
         skipped: true,
@@ -527,7 +559,7 @@ function parseVtt(content: string): Caption[] {
     captions.push({
       raw: block.trim(),
       start: parseVttTime(timingMatch[1]!),
-      end: parseVttTime(timingMatch[2]!),
+      end: parseVttTime(timingMatch[3]!),
       text,
       ...(cueId !== undefined && { cueId }),
     });
@@ -535,21 +567,38 @@ function parseVtt(content: string): Caption[] {
   return captions;
 }
 
-function buildVtt(captions: Caption[], header: string = "WEBVTT"): string {
-  const lines = [header, ""];
-  for (const c of captions) {
-    // skip placeholders left by parseVtt
-    // for oversized text. The feature layer surfaces the drop via
-    // msg_oversized_skipped; disk output stays clean.
-    if (c.skipped) continue;
-    if (c.cueId) {
-      lines.push(c.cueId);
+function buildVtt(content: string, captions: Caption[]): string {
+  const parts = content.split(/((?:\r\n|\r|\n)(?:[ \t]*(?:\r\n|\r|\n))+)/);
+  let captionIndex = 0;
+
+  // parts[0] is the WEBVTT header block, including header metadata such
+  // as X-TIMESTAMP-MAP. Every even part after it is a cue or metadata
+  // block; odd parts are the original blank-line separators.
+  for (let partIndex = 2; partIndex < parts.length; partIndex += 2) {
+    const block = parts[partIndex]!;
+    const spans = lineSpans(block);
+    const timing = findVttCueTiming(spans.map((span) => span.text));
+    if (!timing) continue;
+
+    const caption = captions[captionIndex++];
+    if (!caption) {
+      throw new Error("WebVTT parse/rebuild drift: output contains an unparsed cue");
     }
-    lines.push(`${formatVttTime(c.start)} --> ${formatVttTime(c.end)}`);
-    lines.push(c.text);
-    lines.push("");
+    // Oversized placeholders remain byte-for-byte structurally present.
+    // Their text was intentionally not retained in Caption, so rewriting
+    // only other cues avoids turning a partial warning into data loss.
+    if (caption.skipped) continue;
+
+    const { timingIdx, match } = timing;
+    const timingSpan = spans[timingIdx]!;
+    const replacement = `${formatVttTime(caption.start)}${match[2]}${formatVttTime(caption.end)}${match[4]}`;
+    parts[partIndex] = block.slice(0, timingSpan.start) + replacement + block.slice(timingSpan.end);
   }
-  return lines.join("\n");
+
+  if (captionIndex !== captions.length) {
+    throw new Error("WebVTT parse/rebuild drift: not every parsed cue was rebuilt");
+  }
+  return parts.join("");
 }
 
 // ── ASS/SSA Parser (timing only) ─────────────────────────
@@ -572,7 +621,7 @@ function buildVtt(captions: Caption[], header: string = "WEBVTT"): string {
 // `999…9:00:00.00` (100+ hour digits) saturate parseInt to Infinity
 // before the time-math even runs. 12 digits is identical to the SRT /
 // VTT / display-time bound used elsewhere in this file.
-const DIALOGUE_PATTERN = String.raw`^([\t ]*Dialogue:[\t ]*\d+,)(\d{1,12}:\d{2}:\d{2}\.\d{2}),( *)(\d{1,12}:\d{2}:\d{2}\.\d{2}),(.*)$`;
+const DIALOGUE_PATTERN = String.raw`^([\t ]*Dialogue:[\t ]*(?:\d{1,12}|Marked[\t ]*=[\t ]*-?\d{1,12}),)(\d{1,12}:\d{2}:\d{2}\.\d{2}),( *)(\d{1,12}:\d{2}:\d{2}\.\d{2}),(.*)$`;
 const DIALOGUE_FLAGS = "gim";
 
 function createDialogueRe(): RegExp {
@@ -852,13 +901,8 @@ function rebuildSubtitle(
   switch (format) {
     case "srt":
       return buildSrt(captions);
-    case "vtt": {
-      // Preserve the original VTT header (may contain X-TIMESTAMP-MAP for HLS).
-      // Extracted here and passed to buildVtt as a local — no module-level state.
-      const headerMatch = content.match(/^(WEBVTT[^\r\n]*)\r?\n/);
-      const vttHeader = headerMatch?.[1] ?? "WEBVTT";
-      return buildVtt(captions, vttHeader);
-    }
+    case "vtt":
+      return buildVtt(content, captions);
     case "ass":
       return buildAss(content, captions);
     case "sub":
@@ -880,12 +924,14 @@ export function transformSubtitleTimings(
   fps?: number
 ): { output: string; format: SubtitleFormat; captions: Caption[]; shifted: Caption[] } {
   const { format, captions } = parseSubtitle(content, fps);
+  if (!captions.some((caption) => !caption.skipped)) {
+    throw new Error("No shiftable subtitle cues were found");
+  }
 
   const shifted = captions.map((c, index) => {
-    // Skipped placeholders (all four parsers emit them for oversized
-    // text) pass through unchanged — buildAss returns the original
-    // line, buildSrt / buildVtt / buildSub filter them out. Shifting
-    // their timestamps would be wasted work.
+    // Skipped placeholders pass through unchanged. In-place builders
+    // preserve their original entries; reconstruction-based builders
+    // deliberately omit them and the feature layer surfaces that count.
     if (c.skipped) return c;
     const next = transform(c, index);
     if (!Number.isFinite(next.start) || !Number.isFinite(next.end)) {

--- a/src/lib/subtitle-parser.ts
+++ b/src/lib/subtitle-parser.ts
@@ -214,19 +214,31 @@ export function detectFormat(content: string): SubtitleFormat {
 
 // ── Timestamp Parsing ─────────────────────────────────────
 
+function requireSafeTimestampMs(totalMs: number, label: string, source: string): number {
+  if (!Number.isSafeInteger(totalMs)) {
+    throw new Error(`${label} timestamp exceeds JavaScript's safe integer range: ${source}`);
+  }
+  return totalMs;
+}
+
 /** Parse "HH:MM:SS,mmm" (SRT) or "HH:MM:SS.mmm" to ms */
 function parseSrtTime(ts: string): number {
   // Hours capped at 12 digits — far past any legitimate timestamp,
   // bounded so a 400-digit `\d+` saturating parseInt to Infinity is
-  // structurally impossible.
-  const m = ts.match(/(\d{1,12}):(\d{2}):(\d{2})[,.](\d{3})/);
+  // structurally impossible. The exact millisecond total is checked below
+  // because even a bounded 12-digit hour can exceed Number.MAX_SAFE_INTEGER.
+  const m = ts.match(/^(\d{1,12}):(\d{2}):(\d{2})[,.](\d{3})$/);
   if (!m) return 0;
   const minutes = parseInt(m[2]!, 10);
   const seconds = parseInt(m[3]!, 10);
   if (minutes >= 60 || seconds >= 60) {
     throw new Error(`Invalid SRT timestamp (minutes and seconds must be below 60): ${ts}`);
   }
-  return parseInt(m[1]!, 10) * 3600000 + minutes * 60000 + seconds * 1000 + parseInt(m[4]!, 10);
+  return requireSafeTimestampMs(
+    parseInt(m[1]!, 10) * 3600000 + minutes * 60000 + seconds * 1000 + parseInt(m[4]!, 10),
+    "SRT",
+    ts
+  );
 }
 
 /** Parse VTT timestamps — supports both "HH:MM:SS.mmm" and "MM:SS.mmm" (no hours) */
@@ -245,8 +257,10 @@ function parseVttTime(ts: string): number {
     if (minutes >= 60 || seconds >= 60) {
       throw new Error(`Invalid WebVTT timestamp (minutes and seconds must be below 60): ${ts}`);
     }
-    return (
-      parseInt(full[1]!, 10) * 3600000 + minutes * 60000 + seconds * 1000 + parseInt(full[4]!, 10)
+    return requireSafeTimestampMs(
+      parseInt(full[1]!, 10) * 3600000 + minutes * 60000 + seconds * 1000 + parseInt(full[4]!, 10),
+      "WebVTT",
+      ts
     );
   }
   // MM:SS.mmm (no hours — valid per WebVTT spec)
@@ -264,22 +278,25 @@ function parseVttTime(ts: string): number {
 
 /** Parse "H:MM:SS.cc" (ASS centiseconds) to ms */
 function parseAssTime(ts: string): number {
-  const m = ts.match(/(\d{1,12}):(\d{2}):(\d{2})\.(\d{2})/);
+  const m = ts.match(/^(\d{1,12}):(\d{2}):(\d{2})\.(\d{2})$/);
   if (!m) return 0;
   const minutes = parseInt(m[2]!, 10);
   const seconds = parseInt(m[3]!, 10);
   if (minutes >= 60 || seconds >= 60) {
     throw new Error(`Invalid ASS/SSA timestamp (minutes and seconds must be below 60): ${ts}`);
   }
-  return (
-    parseInt(m[1]!, 10) * 3600000 + minutes * 60000 + seconds * 1000 + parseInt(m[4]!, 10) * 10
+  return requireSafeTimestampMs(
+    parseInt(m[1]!, 10) * 3600000 + minutes * 60000 + seconds * 1000 + parseInt(m[4]!, 10) * 10,
+    "ASS/SSA",
+    ts
   );
 }
 
 /**
  * Floor a millisecond value to a safe non-negative finite integer.
  *
- * NaN / Infinity collapse to 0; negatives clamp to 0. Without this,
+ * NaN / Infinity collapse to 0; negatives clamp to 0; larger values clamp
+ * to Number.MAX_SAFE_INTEGER. Without this,
  * a malformed upstream caption (NaN start / end) would produce a
  * literal "NaN:NaN:NaN.NaN" timestamp and corrupt the whole file.
  * Extracted from formatSrtTime / formatAssTime / srt-converter
@@ -288,7 +305,7 @@ function parseAssTime(ts: string): number {
 export function safeMs(ms: number): number {
   if (!Number.isFinite(ms)) return 0;
   if (ms < 0) return 0;
-  return ms;
+  return Math.min(Math.floor(ms), Number.MAX_SAFE_INTEGER);
 }
 
 /** Format ms → "HH:MM:SS,mmm" (SRT) */
@@ -330,12 +347,12 @@ export function parseDisplayTime(ts: string): number | null {
   const minutes = parseInt(m[2]!, 10);
   const seconds = parseInt(m[3]!, 10);
   if (minutes >= 60 || seconds >= 60) return null;
-  return (
+  const totalMs =
     parseInt(m[1]!, 10) * 3600000 +
     minutes * 60000 +
     seconds * 1000 +
-    parseInt(m[4]!.padEnd(3, "0"), 10)
-  );
+    parseInt(m[4]!.padEnd(3, "0"), 10);
+  return Number.isSafeInteger(totalMs) ? totalMs : null;
 }
 
 // ── SRT Parser ────────────────────────────────────────────
@@ -425,9 +442,9 @@ function parseSrt(content: string): Caption[] {
     // count via msg_oversized_skipped — closes the no-silent-action
     // gap (an earlier `continue` lost a 64 KB+ caption without any
     // user signal). The placeholder counts toward MAX_PARSED_ENTRIES
-    // (same as parseAss / parseSub), and buildSrt filters them out
-    // before serialization so disk output is unchanged. Iteration
-    // cost is still bounded by MAX_RAW_BLOCKS (above).
+    // (same as parseAss / parseSub), and buildSrt omits them from the
+    // rebuilt output. The feature layer reports that intentional drop;
+    // iteration cost is still bounded by MAX_RAW_BLOCKS (above).
     if (text.length > MAX_CAPTION_TEXT_LEN) {
       captions.push({
         raw: block.trim(),
@@ -452,8 +469,8 @@ function buildSrt(captions: Caption[]): string {
   // filter skipped placeholders before
   // serialization. parseSrt now pushes them for oversized text so the
   // feature layer can count and surface the drop; buildSrt rebuilds
-  // from the captions array, so filtering here keeps disk output
-  // pristine (no numbered cues with empty bodies). Cue numbering
+  // from the captions array, so filtering here leaves only legitimate
+  // cues (no numbered cues with empty bodies). Cue numbering
   // reflects legitimate captions only because we filter before map.
   return (
     captions
@@ -801,8 +818,8 @@ function parseSub(content: string, fps: number = DEFAULT_FPS): Caption[] {
     // was unbounded by the per-caption cap; a crafted 50 MB MicroDVD
     // file with millions of oversized entries could spin the
     // `subLineRe.exec` loop without tripping any ceiling (the 50 MB
-    // upstream file cap was the only backstop). buildSub filters
-    // skipped placeholders out, so disk output is unchanged.
+    // upstream file cap was the only backstop). buildSub omits skipped
+    // placeholders, while the feature layer reports that intentional drop.
     const text = match[3]!;
     if (text.length > MAX_CAPTION_TEXT_LEN) {
       count += 1;
@@ -939,8 +956,8 @@ export function transformSubtitleTimings(
     }
     return {
       ...next,
-      start: Math.max(0, next.start),
-      end: Math.max(0, next.end),
+      start: safeMs(next.start),
+      end: safeMs(next.end),
     };
   });
 

--- a/src/lib/tauri-api.test.ts
+++ b/src/lib/tauri-api.test.ts
@@ -55,6 +55,7 @@ import {
   removeFontSource,
   scanFontDirectory,
   scanFontFiles,
+  subsetFont,
   writeStyleEditOutput,
 } from "./tauri-api";
 
@@ -91,6 +92,28 @@ describe("writeStyleEditOutput", () => {
       outputPath: "D:/Anime/episode.styled.ass",
       content: "[V4+ Styles]",
     });
+  });
+});
+
+describe("subsetFont", () => {
+  it("accepts Tauri's raw Windows/Linux byte response", async () => {
+    const rawBytes = new Uint8Array([0, 1, 127, 255]);
+    invokeMock.mockResolvedValueOnce(rawBytes.buffer);
+
+    await expect(subsetFont("D:/Fonts/example.ttf", 2, [65, 0x4e2d])).resolves.toEqual(rawBytes);
+    expect(invokeMock).toHaveBeenCalledWith("subset_font_bytes", {
+      fontPath: "D:/Fonts/example.ttf",
+      fontIndex: 2,
+      codepoints: [65, 0x4e2d],
+    });
+  });
+
+  it("accepts the compact base64 fallback used on Apple targets", async () => {
+    invokeMock.mockResolvedValueOnce("AAH//g==");
+
+    await expect(subsetFont("/Library/Fonts/example.ttf", 0, [65])).resolves.toEqual(
+      new Uint8Array([0, 1, 255, 254])
+    );
   });
 });
 

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -173,6 +173,8 @@ export interface ReadTextResult {
   hadBom: boolean;
   /** True when malformed source bytes had to be replaced during decoding. */
   lossy: boolean;
+  /** True only when UTF-16LE/BE was inferred conservatively without a BOM. */
+  inferredWithoutBom: boolean;
   /** SHA-256 of the exact source bytes used for this read. */
   sourceRevision: string;
   /** Exact source byte length for bounded batch planning. */
@@ -186,8 +188,16 @@ export interface ReadTextResult {
  * and other encodings via the Rust backend (chardetng + encoding_rs).
  * Returns clean UTF-8 text regardless of original encoding.
  */
-export async function readText(path: string): Promise<string> {
+export function isInferredUtf16(result: Pick<ReadTextResult, "inferredWithoutBom">): boolean {
+  return result.inferredWithoutBom;
+}
+
+export async function readText(
+  path: string,
+  onRead?: (result: ReadTextResult) => void
+): Promise<string> {
   const result = await readTextDetectEncoding(path);
+  onRead?.(result);
   return result.text;
 }
 

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -604,9 +604,12 @@ export async function lookupFontFamily(
  *  has the inline Cancel button (cancelFontScan) to abort. Adding a
  *  timeout here would race legitimate slow scans (XL font collection
  *  on a slow disk can take 30+ seconds) and produce false-cancel
- *  signals the Rust side never sent. If a future stuck-IPC failure
- *  mode emerges, a watchdog should live in the Tauri command layer
- *  (Rust-side timeout on spawn_blocking), not here. */
+ *  signals the Rust side never sent. Tauri, not React, owns the Channel
+ *  callback registration until Rust drops the sender; hiding/remounting
+ *  this modal does not unregister it, and a full reload destroys the old
+ *  promise realm. If a future stuck-IPC failure mode emerges, a watchdog
+ *  should live in the Tauri command layer (Rust-side timeout on
+ *  spawn_blocking), not here. */
 async function runStreamingScan(
   command: "scan_font_directory" | "scan_font_files",
   args: Record<string, unknown>,

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -314,17 +314,20 @@ export async function findSystemFont(
 
 /** Subset a font file to only include the specified codepoints.
  *
- *  Wire format: Rust returns the bytes base64-encoded (`subset_font_b64`)
- *  to dodge the JSON `[byte, byte, ...]` form's ~4–5× expansion. The
- *  worst-case 10 MB subset would otherwise produce a ~50 MB IPC payload
- *  + main-thread JSON parse pass; base64 is ~1.33×. */
+ *  Wire format: `subset_font_bytes` returns raw bytes on Windows/Linux. Tauri
+ *  2.11 serializes raw responses as numeric JSON arrays on Apple WebViews, so
+ *  those targets retain the smaller base64 form. */
 export async function subsetFont(
   fontPath: string,
   fontIndex: number,
   codepoints: number[]
 ): Promise<Uint8Array> {
-  const b64: string = await invoke("subset_font_b64", { fontPath, fontIndex, codepoints });
-  return decodeBase64Bytes(b64);
+  const payload = await invoke<ArrayBuffer | string>("subset_font_bytes", {
+    fontPath,
+    fontIndex,
+    codepoints,
+  });
+  return typeof payload === "string" ? decodeBase64Bytes(payload) : new Uint8Array(payload);
 }
 
 /** One font face discovered in a user-picked directory or file list.

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -743,9 +743,9 @@ export interface ExpandedPaths {
 /**
  * Expand a list of paths from a drag-drop event into a flat list of file
  * paths. Folders are walked one level deep; files pass through unchanged.
- * Hidden entries, symlinks, and reparse points are skipped on the Rust
- * side. Returns `{ files: [], truncated: false }` when nothing usable
- * was dropped.
+ * Filesystem-scope-denied paths, hidden entries, symlinks, and reparse
+ * points are skipped on the Rust side. Returns
+ * `{ files: [], truncated: false }` when nothing usable was dropped.
  */
 export async function expandDroppedPaths(paths: string[]): Promise<ExpandedPaths> {
   return invoke<ExpandedPaths>("expand_dropped_paths", { paths });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,17 +6,20 @@ import I18nProvider from "./i18n/I18nProvider";
 import ThemeProvider from "./theme/ThemeProvider";
 import { FileProvider } from "./lib/FileContext";
 import StatusProvider from "./lib/StatusProvider";
+import AppErrorBoundary from "./AppErrorBoundary";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <ThemeProvider>
-      <I18nProvider>
-        <FileProvider>
-          <StatusProvider>
-            <App />
-          </StatusProvider>
-        </FileProvider>
-      </I18nProvider>
-    </ThemeProvider>
+    <AppErrorBoundary>
+      <ThemeProvider>
+        <I18nProvider>
+          <FileProvider>
+            <StatusProvider>
+              <App />
+            </StatusProvider>
+          </FileProvider>
+        </I18nProvider>
+      </ThemeProvider>
+    </AppErrorBoundary>
   </StrictMode>
 );

--- a/src/shell.css
+++ b/src/shell.css
@@ -8,6 +8,63 @@
    Tauri window (the stage now fills the OS window — no inset gutter).
    ======================================================================== */
 
+/* Last-resort render fallback. This deliberately does not depend on any
+   provider state: the error boundary also covers Theme/I18n/File providers,
+   so their context may be unavailable when this surface renders. */
+.app-error-boundary {
+  width: 100vw;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  background: var(--bg-app);
+  color: var(--text-primary);
+}
+
+.app-error-panel {
+  width: min(520px, 100%);
+  padding: 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  background: var(--bg-panel);
+  box-shadow: var(--shadow-popover);
+}
+
+.app-error-panel h1 {
+  margin: 0 0 12px;
+  font-size: 20px;
+  font-weight: 650;
+}
+
+.app-error-panel p {
+  margin: 8px 0;
+  color: var(--text-secondary);
+  font-size: 14px;
+  line-height: 1.55;
+}
+
+.app-error-panel button {
+  margin-top: 16px;
+  padding: 9px 14px;
+  border: 1px solid var(--accent);
+  border-radius: var(--radius-sm);
+  background: var(--accent);
+  color: var(--bg-app);
+  cursor: pointer;
+  font: inherit;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.app-error-panel button:hover {
+  background: var(--accent-hover);
+}
+
+.app-error-panel button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
 /* ── Stage — full-window backdrop for the frosted glass ───
    The stage fills the OS window (no inset frame) and hosts the
    animated bloom layer behind the frosted pane. Prior versions


### PR DESCRIPTION
## Summary

This PR strengthens subtitle round-tripping, file-operation safety, font handling, and desktop responsiveness. It also closes parser and frontend error-handling gaps, adds build-time safeguards, and improves the bilingual README.

## Main changes

- Preserve WebVTT cue settings during Timing Shift and refuse files that cannot be safely rebuilt instead of writing an empty or header-only output.
- Conservatively detect BOM-less UTF-16 subtitles, distinguish inferred decoding from BOM-confirmed decoding, and surface a warning before affected content is written.
- Normalize ordinary `.` and `..` components for CLI input and output paths while keeping GUI IPC path validation strict.
- Release output-path reservations after failures or skips while retaining duplicate detection for outputs genuinely planned or written by the current batch.
- Move filesystem, SQLite, and font-processing command bodies to blocking workers so they do not execute on the desktop UI thread.
- Bound font name decoding, poll cancellation during long name-table walks, fall through stale cache candidates, and report skipped font files with useful reasons.
- Preserve an existing rename destination when the platform rejects the move, cap plain-text writes, enforce filesystem scope for dropped folders, and handle dangling output links consistently.
- Make timing preview work parse-only and bounded, surface preview failures, contain font-resolution errors per item, publish ingest state atomically, and guard late directory-picker results.
- Tighten SSA, SRT, WebVTT, timestamp, filename, and runtime-null handling, with additional boundary and rebuild regression coverage.
- Add single-instance startup protection, a top-level UI error boundary, development CSP/HMR configuration, a debug Tauri build in CI, an exact tested Rust toolchain, and stronger embedded-engine sanity checks.
- Document recursive font diagnostics and Batch Rename modes, and refine Chinese README terminology without changing the paired English explanations.

## Deliberate boundaries

- Blocking command bodies now run away from the UI thread; this does not claim that Tauri's surrounding JSON request and response transport is itself moved to those workers.
- Copy and rename remain uncapped by the decoded-text read limit because they stream or move opaque files, including `.sup`, without loading them as subtitle text.
- Direct Cargo invocation still relies on a freshly generated complete `dist-engine` bundle. The supported npm and CI entry points rebuild it first; the build-time marker rejects missing or truncated bundles but cannot prove that every complete bundle is current.
- No release executables or installer artifacts are included in this PR.

## Verification

Validated at the exact branch head `3247f41`:

- `npm run test:run` — 34 files and 720 tests passed
- Rust test suite — 442 passed and 8 fixture-dependent tests ignored
- `npm run typecheck:all` — TypeScript 7 release checks and TypeScript 6 compatibility checks
- ESLint, Prettier, and Stylelint
- Rust 1.91 `fmt`, Clippy with warnings denied, and all-target checking
- production GUI build
- CLI engine build
- `git diff --check`
