### PR TITLE
Update js-base64 to 3.9.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.4",
         "globals": "^17.11.0",
-        "js-base64": "^3.9.2",
+        "js-base64": "^3.9.3",
         "prettier": "3.9.6",
         "stylelint": "^17.14.1",
         "stylelint-config-standard": "^40.0.0",
@@ -4299,9 +4299,9 @@
       }
     },
     "node_modules/js-base64": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.2.tgz",
-      "integrity": "sha512-6zayE8QlUdiweYI6cETD/XBSqFcoCUlufn/29PJR99r82x1yDnIprRca0YvAYpAW+ez0GuQkVBC6xG5QkD7OjA==",
+      "version": "3.9.3",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.9.3.tgz",
+      "integrity": "sha512-uwYQp+VJ38FVvtim6qNbit6e9uT6dwWQ4Y1+H9TxhW5hcHjpHwoxlR0nMpqUmIFOmu4VqMxwdJA88gIVuZJQ/g==",
       "dev": true,
       "license": "BSD-3-Clause"
     },

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.4",
     "globals": "^17.11.0",
-    "js-base64": "^3.9.2",
+    "js-base64": "^3.9.3",
     "prettier": "3.9.6",
     "stylelint": "^17.14.1",
     "stylelint-config-standard": "^40.0.0",


### PR DESCRIPTION
## What changed

- Update the test-only `js-base64` development dependency from 3.9.2 to 3.9.3.
- Refresh the npm lockfile metadata for the new package release.

## Why

Dependency Watch reported the 3.9.3 patch release. Upstream fixes Unicode surrogate handling in the pure-JavaScript fallback without changing the API used by this project.

## Impact

`js-base64` is used only by the wire-format tests. Production base64 decoding does not import this package, so no packaged runtime or user-visible behavior is expected to change.

## Validation

- Targeted wire-format tests: 5 passed
- Full frontend test suite: 720 passed
- TypeScript 7 release and TypeScript 6 compatibility checks
- ESLint and Prettier checks
- Production frontend build
- npm audit: 0 vulnerabilities
- Dependency Watch: 0 actionable updates and 0 monitor errors