### PR TITLE
Harden subtitle workflows, font handling, and runtime safety

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -83,6 +83,7 @@ fn missing_engine_stub() -> String {
         "resolveHdrOutputPath",
         "convertShift",
         "resolveShiftOutputPath",
+        "parseTimingMap",
         "planRename",
         "planFontEmbed",
         "planFontDiagnostics",

--- a/src-tauri/src/bin/cli/engine.rs
+++ b/src-tauri/src/bin/cli/engine.rs
@@ -146,7 +146,9 @@ pub struct RenamePlanRow {
     pub input_path: String,
     pub output_path: String,
     pub video_path: String,
+    pub source: String,
     pub no_op: bool,
+    pub input_conflict: bool,
 }
 
 #[derive(Debug, Serialize)]

--- a/src-tauri/src/bin/cli/main.rs
+++ b/src-tauri/src/bin/cli/main.rs
@@ -234,7 +234,11 @@ pub(crate) struct HdrArgs {
     eotf: EotfArg,
 
     /// Target subtitle brightness in nits. 字幕目标亮度（nits）。
-    #[arg(long, default_value_t = 203)]
+    #[arg(
+        long,
+        default_value_t = 203,
+        value_parser = clap::value_parser!(u16).range(1..=10_000)
+    )]
     nits: u16,
 
     /// Output filename template. 输出文件名模板。
@@ -1260,6 +1264,41 @@ fn validate_cache_file_arg(globals: &GlobalOptions) -> Result<(), String> {
     Ok(())
 }
 
+fn format_refresh_cache_schema_error(cache_path: &Path, found: i32, expected: i32) -> String {
+    let cache_path_disp = sanitize_for_display(&cache_path.to_string_lossy());
+    let schema_detail = match found {
+        -1 => "has no readable schema-version record".to_string(),
+        -2 => "has an unparseable schema-version record".to_string(),
+        version => format!("has schema version {version}"),
+    };
+    format!(
+        "Cache at {} {schema_detail}, but this CLI requires schema version {expected}.\n\
+         The cache is incompatible with this release and must be rebuilt.\n\
+         Delete the cache file at {}, then rerun the same `refresh-fonts` command.",
+        cache_path_disp, cache_path_disp,
+    )
+}
+
+fn format_refresh_cache_access_error(
+    cache_path: &Path,
+    action: &str,
+    error: app_lib::font_cache::CacheError,
+) -> String {
+    let cache_path_disp = sanitize_for_display(&cache_path.to_string_lossy());
+    match error {
+        app_lib::font_cache::CacheError::InvalidDatabase(detail) => format!(
+            "The font cache at {} is invalid or corrupt: {detail}.\n\
+             Delete the cache file at {}, then rerun the same `refresh-fonts` command to rebuild it.",
+            cache_path_disp,
+            cache_path_disp,
+        ),
+        other => format!(
+            "{action} the font cache at {} failed: {other}. Check the cache path and file permissions; the cache was not deleted.",
+            cache_path_disp,
+        ),
+    }
+}
+
 fn run_refresh_fonts(globals: &GlobalOptions, args: RefreshFontsArgs) -> Result<ExitCode, String> {
     // refresh-fonts's whole purpose is to write to the cache. Running
     // with --no-cache is contradictory; surface as a clear error
@@ -1271,7 +1310,18 @@ fn run_refresh_fonts(globals: &GlobalOptions, args: RefreshFontsArgs) -> Result<
             .to_string());
     }
 
-    // --output-dir / --overwrite / --fail-fast affect OUTPUT-file writing;
+    // This subcommand has no JSON report contract. Hard-fail even under
+    // --quiet so a machine consumer never receives an exit-0 empty/plain-text
+    // response after explicitly asking for JSON.
+    if globals.json {
+        return Err(
+            "refresh-fonts does not implement --json output; remove --json and use its stderr status report"
+                .to_string(),
+        );
+    }
+
+    // --output-dir / --overwrite / --fail-fast affect output-file writing,
+    // while --verbose has no additional refresh detail to enable;
     // refresh-fonts writes only to the cache, so they're inert here. Surface
     // a notice rather than ignoring them silently (no-silent-action). Unlike
     // --no-cache (contradictory → hard error) these are harmless, so a
@@ -1287,6 +1337,9 @@ fn run_refresh_fonts(globals: &GlobalOptions, args: RefreshFontsArgs) -> Result<
         }
         if globals.fail_fast {
             inert.push("--fail-fast");
+        }
+        if globals.verbose {
+            inert.push("--verbose");
         }
         if !inert.is_empty() {
             let flags = inert.join(", ");
@@ -1387,24 +1440,26 @@ fn run_refresh_fonts(globals: &GlobalOptions, args: RefreshFontsArgs) -> Result<
         if cache_path.exists() {
             match app_lib::font_cache::FontCache::open_existing_read_only(&cache_path) {
                 Ok(existing) => {
-                    for source in existing
-                        .list_sources()
-                        .map_err(|e| format!("reading existing cache sources: {e}"))?
-                    {
+                    for source in existing.list_sources().map_err(|error| {
+                        format_refresh_cache_access_error(&cache_path, "Reading", error)
+                    })? {
                         final_source_keys.insert(source.key());
                     }
                 }
                 Err(app_lib::font_cache::CacheError::SchemaVersionMismatch { found, expected }) => {
-                    return Err(format!(
-                        "Cache at {} has schema version {found} but this CLI uses version {expected}.\n\
-                         The cache is from a different release and must be rebuilt.\n\
-                         Delete the file manually and re-run refresh-fonts:\n  \
-                         (file: {})",
-                        cache_path.display(),
-                        cache_path.display(),
+                    return Err(format_refresh_cache_schema_error(
+                        &cache_path,
+                        found,
+                        expected,
                     ));
                 }
-                Err(e) => return Err(format!("opening cache: {e}")),
+                Err(error) => {
+                    return Err(format_refresh_cache_access_error(
+                        &cache_path,
+                        "Opening",
+                        error,
+                    ));
+                }
             }
         }
         if final_source_keys.len() > app_lib::font_cache::MAX_CACHED_SOURCES {
@@ -1478,21 +1533,24 @@ fn run_refresh_fonts(globals: &GlobalOptions, args: RefreshFontsArgs) -> Result<
     let mut cache = match app_lib::font_cache::FontCache::open_or_create(&cache_path) {
         Ok(c) => c,
         Err(app_lib::font_cache::CacheError::SchemaVersionMismatch { found, expected }) => {
-            return Err(format!(
-                "Cache at {} has schema version {found} but this CLI uses version {expected}.\n\
-                 The cache is from a different release and must be rebuilt.\n\
-                 Delete the file manually and re-run refresh-fonts:\n  \
-                 (file: {})",
-                cache_path.display(),
-                cache_path.display(),
+            return Err(format_refresh_cache_schema_error(
+                &cache_path,
+                found,
+                expected,
             ));
         }
-        Err(e) => return Err(format!("opening cache: {e}")),
+        Err(error) => {
+            return Err(format_refresh_cache_access_error(
+                &cache_path,
+                "Opening",
+                error,
+            ));
+        }
     };
 
     for source in cache
         .list_sources()
-        .map_err(|e| format!("reading existing cache sources: {e}"))?
+        .map_err(|error| format_refresh_cache_access_error(&cache_path, "Reading", error))?
     {
         final_source_keys.insert(source.key());
     }
@@ -1921,6 +1979,8 @@ fn run_chain(globals: &GlobalOptions, args: ChainArgs) -> Result<ExitCode, Strin
     let mut written = 0usize;
     let mut failed = 0usize;
     let mut skipped = 0usize;
+    let mut written_with_warnings = 0usize;
+    let mut written_warning_count = 0usize;
     // First-input-wins dedup, mirroring run_hdr / run_shift / run_embed
     // . Without this, `chain hdr ... cat.ass cat.ass`
     // runs the chain twice and `--overwrite=true` silently clobbers
@@ -1954,6 +2014,10 @@ fn run_chain(globals: &GlobalOptions, args: ChainArgs) -> Result<ExitCode, Strin
             &mut seen_outputs,
         ) {
             ChainFileOutcome::Written(out, warnings) => {
+                if !warnings.is_empty() {
+                    written_with_warnings += 1;
+                }
+                written_warning_count += warnings.len();
                 if !globals.quiet {
                     // `input` / `out` are raw PathBufs from clap
                     // argv + Rust shell output resolution. Sanitize
@@ -2000,21 +2064,39 @@ fn run_chain(globals: &GlobalOptions, args: ChainArgs) -> Result<ExitCode, Strin
         // chain Summary line + fail-fast suffix go through `localize`,
         // for sibling-parity with the refresh-fonts sweep and the
         // standalone subcommands' `emit_report_summary`.
+        let warning_suffix_en = if written_with_warnings > 0 {
+            format!(
+                ", {written_with_warnings} written with warnings / incomplete ({written_warning_count} warning(s))"
+            )
+        } else {
+            String::new()
+        };
+        let warning_suffix_zh = if written_with_warnings > 0 {
+            format!(
+                "，{written_with_warnings} 个已写入但带警告/不完整（{written_warning_count} 条警告）"
+            )
+        } else {
+            String::new()
+        };
         let summary = if chain_aborted {
             localize(
                 globals,
                 format!(
-                    "Summary: {written} written, {skipped} skipped, {failed} failed (aborted by --fail-fast)"
+                    "Summary: {written} written, {skipped} skipped, {failed} failed{warning_suffix_en} (aborted by --fail-fast)"
                 ),
                 format!(
-                    "汇总：{written} 个已写入，{skipped} 个已跳过，{failed} 个失败（已被 --fail-fast 中止）"
+                    "汇总：{written} 个已写入，{skipped} 个已跳过，{failed} 个失败{warning_suffix_zh}（已被 --fail-fast 中止）"
                 ),
             )
         } else {
             localize(
                 globals,
-                format!("Summary: {written} written, {skipped} skipped, {failed} failed"),
-                format!("汇总：{written} 个已写入，{skipped} 个已跳过，{failed} 个失败"),
+                format!(
+                    "Summary: {written} written, {skipped} skipped, {failed} failed{warning_suffix_en}"
+                ),
+                format!(
+                    "汇总：{written} 个已写入，{skipped} 个已跳过，{failed} 个失败{warning_suffix_zh}"
+                ),
             )
         };
         println!("{summary}");
@@ -2478,6 +2560,13 @@ fn process_one_chain_input(
         globals.output_dir.as_deref(),
     ) {
         let key = normalize_output_key(&predicted);
+        let input_key = normalize_output_key(&input_abs);
+        if key == input_key {
+            return builder.into_failed(format!(
+                "refusing self-overwrite: predicted output path {} is the input file; choose a different --output-template or --output-dir",
+                predicted.display()
+            ));
+        }
         if !seen_outputs.insert(key.clone()) {
             // `predicted.display()` is interpolated
             // raw here; sanitization happens at the chain print boundary
@@ -2760,6 +2849,9 @@ fn process_one_chain_input(
 }
 
 fn emit_chain_dry_run(plan: &chain::ChainPlan, globals: &GlobalOptions) {
+    if globals.quiet {
+        return;
+    }
     println!("Plan (no files written):");
     println!();
     // Every emit_chain_dry_run print site sanitizes interpolated
@@ -3245,7 +3337,7 @@ fn reserve_output<'a>(
         key,
         keep: false,
     };
-    if output_path_exists(globals, output_path) && !globals.overwrite {
+    if !globals.overwrite && output_path_exists(globals, output_path) {
         return Err(Box::new(skipped_report(
             input_path,
             Some(output.to_string()),
@@ -4269,6 +4361,41 @@ fn prepare_embed_cache(
                 diagnostic,
             };
         }
+        Err(app_lib::font_cache::CacheError::InvalidDatabase(detail)) => {
+            if !globals.quiet {
+                let detail_disp = sanitize_for_display(&detail);
+                eprintln!(
+                    "{}",
+                    localize(
+                        globals,
+                        format!(
+                            "⚠ Font cache at {cache_path_disp} is invalid or corrupt: {detail_disp}"
+                        ),
+                        format!("⚠ 位于 {cache_path_disp} 的字体缓存无效或已损坏：{detail_disp}"),
+                    )
+                );
+                eprintln!(
+                    "{}",
+                    localize(
+                        globals,
+                        format!(
+                            "  Delete {cache_path_disp}, then run `refresh-fonts` to rebuild it. Skipping cache for this run."
+                        ),
+                        format!(
+                            "  删除 {cache_path_disp}，然后运行 `refresh-fonts` 以重建缓存。本次运行将跳过缓存。"
+                        ),
+                    )
+                );
+            }
+            return PreparedFontCache {
+                cache: None,
+                diagnostic: CacheDiagnostic::new(
+                    Some(cache_path_json),
+                    CacheDiagnosticStatus::OpenError,
+                    Some(format!("font cache is invalid or corrupt: {detail}")),
+                ),
+            };
+        }
         Err(e) => {
             if !globals.quiet {
                 let e_disp = sanitize_for_display(&e.to_string());
@@ -4276,8 +4403,8 @@ fn prepare_embed_cache(
                     "{}",
                     localize(
                         globals,
-                        format!("⚠ Cannot open font cache: {e_disp}"),
-                        format!("⚠ 无法打开字体缓存：{e_disp}"),
+                        format!("⚠ Cannot open font cache at {cache_path_disp}: {e_disp}"),
+                        format!("⚠ 无法打开位于 {cache_path_disp} 的字体缓存：{e_disp}"),
                     )
                 );
                 eprintln!(
@@ -4294,7 +4421,7 @@ fn prepare_embed_cache(
                 diagnostic: CacheDiagnostic::new(
                     Some(cache_path_json),
                     CacheDiagnosticStatus::OpenError,
-                    Some(format!("cannot open font cache: {e}")),
+                    Some(format!("cannot open font cache at {cache_path_disp}: {e}")),
                 ),
             };
         }
@@ -5899,7 +6026,7 @@ fn process_rename_pair(
         );
     }
 
-    if output_path_exists(globals, &output_path) && !globals.overwrite {
+    if !globals.overwrite && output_path_exists(globals, &output_path) {
         return attach_rename_pairing_warning(
             globals,
             row,
@@ -6062,7 +6189,7 @@ fn build_command_diagnostics(
         );
     }
     let qa = if report.command == "diagnose-fonts" || !fonts.is_empty() {
-        Some(build_font_qa_summary(report, &fonts, warning_count))
+        Some(build_font_qa_summary(report, &fonts))
     } else {
         None
     };
@@ -6090,11 +6217,7 @@ fn build_command_diagnostics(
     }
 }
 
-fn build_font_qa_summary(
-    report: &CommandReport,
-    fonts: &[FontDiagnostic],
-    warning_count: usize,
-) -> FontQaSummary {
+fn build_font_qa_summary(report: &CommandReport, fonts: &[FontDiagnostic]) -> FontQaSummary {
     let failed_file_count = report
         .results
         .iter()
@@ -6126,7 +6249,7 @@ fn build_font_qa_summary(
 
     let status = if failed_file_count > 0 || error_count > 0 || subset_failed_count > 0 {
         FontQaStatus::Blocked
-    } else if missing_count > 0 || warning_count > 0 || subset_skipped_count > 0 {
+    } else if missing_count > 0 || subset_skipped_count > 0 {
         FontQaStatus::Incomplete
     } else {
         FontQaStatus::Complete
@@ -7316,7 +7439,8 @@ mod tests {
         absolute_path, apply_effective_embedded_font_names, apply_subset_checks_to_diagnostics,
         build_font_qa_summary, check_cache_drift, classify_locale, copy_file_output,
         create_cli_font_db_dir, diagnostic_next_actions, display_path,
-        duplicate_rename_output_keys, engine, group_resolved_fonts_by_face, normalize_output_key,
+        duplicate_rename_output_keys, engine, format_refresh_cache_access_error,
+        format_refresh_cache_schema_error, group_resolved_fonts_by_face, normalize_output_key,
         parse_duration_ms, parse_timestamp_ms, predict_chain_output_path,
         refresh_font_directory_sources, relocate_output_path, require_complete_cli_font_source,
         resolve_embed_fonts, sanitize_for_display, substitute_template, write_output,
@@ -7506,6 +7630,43 @@ mod tests {
     }
 
     #[test]
+    fn hdr_nits_accepts_documented_boundaries_and_rejects_values_outside_them() {
+        for value in ["1", "10000"] {
+            let cli = Cli::try_parse_from([
+                "ssahdrify-cli",
+                "hdr",
+                "--eotf",
+                "pq",
+                "--nits",
+                value,
+                "input.ass",
+            ])
+            .unwrap_or_else(|error| panic!("--nits {value} should parse: {error}"));
+            let Command::Hdr(args) = cli.command else {
+                panic!("expected hdr command");
+            };
+            assert_eq!(args.args.nits.to_string(), value);
+        }
+
+        for value in ["0", "10001"] {
+            let error = Cli::try_parse_from([
+                "ssahdrify-cli",
+                "hdr",
+                "--eotf",
+                "pq",
+                "--nits",
+                value,
+                "input.ass",
+            ])
+            .expect_err("out-of-range --nits must fail at parse time");
+            assert!(
+                error.to_string().contains("1..=10000"),
+                "range error should name the accepted boundary: {error}"
+            );
+        }
+    }
+
+    #[test]
     fn refresh_fonts_rejects_diagnose_option() {
         let err = Cli::try_parse_from([
             "ssahdrify-cli",
@@ -7651,6 +7812,35 @@ mod tests {
             .expect_err("refresh-fonts requires one directory-source flag");
 
         assert_eq!(err.kind(), ErrorKind::MissingRequiredArgument);
+    }
+
+    #[test]
+    fn refresh_cache_errors_sanitize_paths_and_limit_delete_guidance() {
+        let hostile = Path::new("cache\u{202e}\u{001b}[2J.sqlite3");
+
+        let schema = format_refresh_cache_schema_error(hostile, 4, 6);
+        assert!(!schema.contains('\u{202e}') && !schema.contains('\u{001b}'));
+        assert!(schema.contains("cache[2J.sqlite3"));
+        assert!(schema.contains("rerun the same `refresh-fonts` command"));
+
+        let invalid = format_refresh_cache_access_error(
+            hostile,
+            "Opening",
+            app_lib::font_cache::CacheError::InvalidDatabase("file is not a database".to_string()),
+        );
+        assert!(!invalid.contains('\u{202e}') && !invalid.contains('\u{001b}'));
+        assert!(invalid.contains("Delete the cache file"));
+        assert!(invalid.contains("rerun the same `refresh-fonts` command"));
+
+        let ordinary = format_refresh_cache_access_error(
+            hostile,
+            "Opening",
+            app_lib::font_cache::CacheError::Io("permission denied".to_string()),
+        );
+        assert!(!ordinary.contains('\u{202e}') && !ordinary.contains('\u{001b}'));
+        assert!(ordinary.contains("Check the cache path and file permissions"));
+        assert!(!ordinary.contains("Delete the cache file"));
+        assert!(!ordinary.contains("rerun the same `refresh-fonts` command"));
     }
 
     /// Construct a default GlobalOptions for tests that need to call
@@ -7878,7 +8068,7 @@ mod tests {
         let mut resolved = FontDiagnostic::new(&qa_usage("Resolved"));
         resolved.mark_resolved("/fonts/resolved.ttf".to_string(), 0);
 
-        let qa = build_font_qa_summary(&qa_report(FileStatus::Diagnosed), &[resolved], 0);
+        let qa = build_font_qa_summary(&qa_report(FileStatus::Diagnosed), &[resolved]);
 
         assert_eq!(qa.status, FontQaStatus::Complete);
         assert_eq!(qa.resolved_count, 1);
@@ -7889,7 +8079,7 @@ mod tests {
     fn font_qa_summary_marks_incomplete_for_missing_fonts() {
         let missing = FontDiagnostic::new(&qa_usage("Missing"));
 
-        let qa = build_font_qa_summary(&qa_report(FileStatus::Diagnosed), &[missing], 0);
+        let qa = build_font_qa_summary(&qa_report(FileStatus::Diagnosed), &[missing]);
 
         assert_eq!(qa.status, FontQaStatus::Incomplete);
         assert_eq!(qa.missing_count, 1);
@@ -7905,10 +8095,28 @@ mod tests {
             error: Some("subset failed".to_string()),
         });
 
-        let qa = build_font_qa_summary(&qa_report(FileStatus::Diagnosed), &[resolved], 0);
+        let qa = build_font_qa_summary(&qa_report(FileStatus::Diagnosed), &[resolved]);
 
         assert_eq!(qa.status, FontQaStatus::Blocked);
         assert_eq!(qa.subset_failed_count, 1);
+    }
+
+    #[test]
+    fn font_qa_summary_ignores_non_font_warnings() {
+        let mut resolved = FontDiagnostic::new(&qa_usage("Resolved"));
+        resolved.mark_resolved("/fonts/resolved.ttf".to_string(), 0);
+        let mut report = qa_report(FileStatus::Diagnosed);
+        report.results[0].warnings = Some(vec![
+            "BOM-less UTF-16 encoding was inferred; verify the output".to_string(),
+        ]);
+
+        let qa = build_font_qa_summary(&report, &[resolved]);
+
+        assert_eq!(
+            qa.status,
+            FontQaStatus::Complete,
+            "encoding and other file warnings must not downgrade font QA"
+        );
     }
 
     #[test]

--- a/src-tauri/src/bin/cli/main.rs
+++ b/src-tauri/src/bin/cli/main.rs
@@ -5854,31 +5854,61 @@ fn process_rename_pair(
     let input = display_path(&input_path);
     let output = display_path(&output_path);
 
+    // planRename computes this flag against every loaded subtitle path (not
+    // only executable rows) before the Rust shell enters this loop. Keep this
+    // guard before no-op, duplicate, exists, dry-run, and overwrite handling:
+    // every participant in a swap/chain must fail without touching the disk.
+    if row.input_conflict {
+        return attach_rename_pairing_warning(
+            globals,
+            row,
+            failed_report(
+                &input_path,
+                Some(output),
+                None,
+                "subtitle is part of a planned conflict where an output targets a loaded subtitle input; no files in that conflicting chain were changed"
+                    .to_string(),
+            ),
+        );
+    }
+
     if row.no_op {
-        return skipped_report(
-            &input_path,
-            Some(output),
-            None,
-            "subtitle already matches the target path".to_string(),
+        return attach_rename_pairing_warning(
+            globals,
+            row,
+            skipped_report(
+                &input_path,
+                Some(output),
+                None,
+                "subtitle already matches the target path".to_string(),
+            ),
         );
     }
 
     let output_key = normalize_output_key(&output_path);
     if duplicate_outputs.contains(&output_key) {
-        return failed_report(
-            &input_path,
-            Some(output),
-            None,
-            "duplicate output path in planned batch".to_string(),
+        return attach_rename_pairing_warning(
+            globals,
+            row,
+            failed_report(
+                &input_path,
+                Some(output),
+                None,
+                "duplicate output path in planned batch".to_string(),
+            ),
         );
     }
 
     if output_path_exists(globals, &output_path) && !globals.overwrite {
-        return skipped_report(
-            &input_path,
-            Some(output),
-            None,
-            "output exists; pass --overwrite to replace it".to_string(),
+        return attach_rename_pairing_warning(
+            globals,
+            row,
+            skipped_report(
+                &input_path,
+                Some(output),
+                None,
+                "output exists; pass --overwrite to replace it".to_string(),
+            ),
         );
     }
 
@@ -5895,7 +5925,11 @@ fn process_rename_pair(
     );
 
     if globals.dry_run {
-        return planned_report(&input_path, Some(output), None);
+        return attach_rename_pairing_warning(
+            globals,
+            row,
+            planned_report(&input_path, Some(output), None),
+        );
     }
 
     let operation_result = if args.mode.is_copy() {
@@ -5905,17 +5939,41 @@ fn process_rename_pair(
     };
 
     if let Err(error) = operation_result {
-        return failed_report(&input_path, Some(output), None, error);
+        return attach_rename_pairing_warning(
+            globals,
+            row,
+            failed_report(&input_path, Some(output), None, error),
+        );
     }
 
-    FileReport {
-        input,
-        output: Some(output),
-        encoding: None,
-        status: FileStatus::Written,
-        error: None,
-        warnings: None,
+    attach_rename_pairing_warning(
+        globals,
+        row,
+        FileReport {
+            input,
+            output: Some(output),
+            encoding: None,
+            status: FileStatus::Written,
+            error: None,
+            warnings: None,
+        },
+    )
+}
+
+fn attach_rename_pairing_warning(
+    globals: &GlobalOptions,
+    row: &engine::RenamePlanRow,
+    mut report: FileReport,
+) -> FileReport {
+    if row.source == "warning" {
+        report.warnings = Some(vec![localize(
+            globals,
+            "pairing is ambiguous because multiple videos share the same season and episode; verify the selected subtitle"
+                .to_string(),
+            "多个视频具有相同的季与集编号，配对存在歧义；请核对所选字幕".to_string(),
+        )]);
     }
+    report
 }
 
 fn duplicate_rename_output_keys(rows: &[engine::RenamePlanRow]) -> HashSet<String> {
@@ -5923,6 +5981,10 @@ fn duplicate_rename_output_keys(rows: &[engine::RenamePlanRow]) -> HashSet<Strin
     // so picking a "winner" among duplicates risks moving the wrong
     // file into a stable name. Every participant in a duplicate set is
     // flagged here and refuses to act in process_rename_pair.
+    //
+    // Rows already blocked by the stronger input-conflict preflight do not
+    // claim outputs: they cannot write, and excluding them keeps GUI/CLI
+    // behavior aligned when an otherwise-safe row shares their target.
     //
     // No-op rows DO claim their output key — a no-op row's output is a
     // real file already on disk, so a non-no-op row targeting the same
@@ -5933,7 +5995,7 @@ fn duplicate_rename_output_keys(rows: &[engine::RenamePlanRow]) -> HashSet<Strin
     let mut seen = HashSet::new();
     let mut duplicates = HashSet::new();
 
-    for row in rows {
+    for row in rows.iter().filter(|row| !row.input_conflict) {
         let key = normalize_output_key(Path::new(&row.output_path));
         if !seen.insert(key.clone()) {
             duplicates.insert(key);
@@ -8054,13 +8116,17 @@ mod tests {
                 input_path: "C:\\Subs\\Episode.ass".to_string(),
                 output_path: "C:\\Subs\\Episode.ass".to_string(),
                 video_path: "C:\\Subs\\Episode.mkv".to_string(),
+                source: "regex".to_string(),
                 no_op: true,
+                input_conflict: false,
             },
             engine::RenamePlanRow {
                 input_path: "C:\\Subs\\episode.tc.ass".to_string(),
                 output_path: "C:\\Subs\\Episode.ass".to_string(),
                 video_path: "C:\\Subs\\Episode.mkv".to_string(),
+                source: "regex".to_string(),
                 no_op: false,
+                input_conflict: false,
             },
         ];
 
@@ -8086,13 +8152,17 @@ mod tests {
                 input_path: "C:\\Subs\\episode.sc.ass".to_string(),
                 output_path: "C:\\Subs\\Episode.sc.ass".to_string(),
                 video_path: "C:\\Subs\\Episode.mkv".to_string(),
+                source: "regex".to_string(),
                 no_op: false,
+                input_conflict: false,
             },
             engine::RenamePlanRow {
                 input_path: "C:\\Subs\\episode.tc.ass".to_string(),
                 output_path: "C:\\Subs\\Episode.tc.ass".to_string(),
                 video_path: "C:\\Subs\\Episode.mkv".to_string(),
+                source: "regex".to_string(),
                 no_op: false,
+                input_conflict: false,
             },
         ];
 
@@ -8110,13 +8180,17 @@ mod tests {
                 input_path: "C:\\Subs\\episode.sc.ass".to_string(),
                 output_path: "C:\\Subs\\Episode.sc.ass".to_string(),
                 video_path: "C:\\Subs\\Episode.mkv".to_string(),
+                source: "regex".to_string(),
                 no_op: false,
+                input_conflict: false,
             },
             engine::RenamePlanRow {
                 input_path: "C:\\Subs\\episode.zh-CN.ass".to_string(),
                 output_path: "C:\\Subs\\Episode.sc.ass".to_string(),
                 video_path: "C:\\Subs\\Episode.mkv".to_string(),
+                source: "regex".to_string(),
                 no_op: false,
+                input_conflict: false,
             },
         ];
 
@@ -8139,19 +8213,25 @@ mod tests {
                 input_path: "C:\\Subs\\episode.sc.ass".to_string(),
                 output_path: "C:\\Subs\\Episode.ass".to_string(),
                 video_path: "C:\\Subs\\Episode.mkv".to_string(),
+                source: "regex".to_string(),
                 no_op: false,
+                input_conflict: false,
             },
             engine::RenamePlanRow {
                 input_path: "C:\\Subs\\episode.tc.ass".to_string(),
                 output_path: "C:\\Subs\\Episode.ass".to_string(),
                 video_path: "C:\\Subs\\Episode.mkv".to_string(),
+                source: "regex".to_string(),
                 no_op: false,
+                input_conflict: false,
             },
             engine::RenamePlanRow {
                 input_path: "C:\\Subs\\already.ass".to_string(),
                 output_path: "C:\\Subs\\Episode.ass".to_string(),
                 video_path: "C:\\Subs\\Episode.mkv".to_string(),
+                source: "regex".to_string(),
                 no_op: true,
+                input_conflict: false,
             },
         ];
 
@@ -8163,6 +8243,30 @@ mod tests {
             "C:/Subs/Episode.ass"
         };
         assert!(duplicates.contains(expected_key));
+    }
+
+    #[test]
+    fn rename_dedup_excludes_rows_already_blocked_by_input_conflicts() {
+        let rows = vec![
+            engine::RenamePlanRow {
+                input_path: "C:\\Subs\\unsafe.ass".to_string(),
+                output_path: "C:\\Subs\\shared.ass".to_string(),
+                video_path: "C:\\Subs\\Unsafe.mkv".to_string(),
+                source: "regex".to_string(),
+                no_op: false,
+                input_conflict: true,
+            },
+            engine::RenamePlanRow {
+                input_path: "C:\\Subs\\safe.ass".to_string(),
+                output_path: "C:\\Subs\\shared.ass".to_string(),
+                video_path: "C:\\Subs\\Safe.mkv".to_string(),
+                source: "regex".to_string(),
+                no_op: false,
+                input_conflict: false,
+            },
+        ];
+
+        assert!(duplicate_rename_output_keys(&rows).is_empty());
     }
 
     #[test]

--- a/src-tauri/src/bin/cli/main.rs
+++ b/src-tauri/src/bin/cli/main.rs
@@ -3182,10 +3182,7 @@ fn append_warning(warnings: &mut Option<Vec<String>>, warning: Option<String>) {
     }
 }
 
-fn load_timing_map_rules(
-    engine: &mut engine::CliEngine,
-    map_path: &Path,
-) -> Result<Vec<engine::TimingMapRule>, String> {
+fn read_timing_map_text(map_path: &Path) -> Result<String, String> {
     let absolute = absolute_path(map_path)?;
     let display = display_path(&absolute);
     let metadata = fs::metadata(&absolute)
@@ -3199,16 +3196,29 @@ fn load_timing_map_rules(
             metadata.len()
         ));
     }
-    let content = fs::read_to_string(&absolute)
-        .map_err(|err| format!("failed to read timing map as UTF-8 text from {display}: {err}"))?;
-    let parsed = engine.parse_timing_map(&engine::TimingMapParseRequest { content })?;
-    if parsed.rules.is_empty() {
+    fs::read_to_string(&absolute)
+        .map_err(|err| format!("failed to read timing map as UTF-8 text from {display}: {err}"))
+}
+
+fn require_enabled_timing_map_rules(
+    rules: Vec<engine::TimingMapRule>,
+) -> Result<Vec<engine::TimingMapRule>, String> {
+    if rules.is_empty() {
         return Err("timing map contains no rules".to_string());
     }
-    if !parsed.rules.iter().any(|rule| rule.enabled.unwrap_or(true)) {
+    if !rules.iter().any(|rule| rule.enabled.unwrap_or(true)) {
         return Err("timing map contains no enabled rules".to_string());
     }
-    Ok(parsed.rules)
+    Ok(rules)
+}
+
+fn load_timing_map_rules(
+    engine: &mut engine::CliEngine,
+    map_path: &Path,
+) -> Result<Vec<engine::TimingMapRule>, String> {
+    let content = read_timing_map_text(map_path)?;
+    let parsed = engine.parse_timing_map(&engine::TimingMapParseRequest { content })?;
+    require_enabled_timing_map_rules(parsed.rules)
 }
 
 fn run_shift(
@@ -7441,15 +7451,17 @@ mod tests {
         create_cli_font_db_dir, diagnostic_next_actions, display_path,
         duplicate_rename_output_keys, engine, format_refresh_cache_access_error,
         format_refresh_cache_schema_error, group_resolved_fonts_by_face, normalize_output_key,
-        parse_duration_ms, parse_timestamp_ms, predict_chain_output_path,
+        parse_duration_ms, parse_timestamp_ms, predict_chain_output_path, read_timing_map_text,
         refresh_font_directory_sources, relocate_output_path, require_complete_cli_font_source,
-        resolve_embed_fonts, sanitize_for_display, substitute_template, write_output,
-        CacheDiagnostic, CacheDiagnosticStatus, Cli, Command, CommandDiagnostics, CommandReport,
-        DiagnoseMode, DiagnosticSubsetBudget, EmbedArgs, FileDiagnostic, FileReport, FileStatus,
-        FontDiagnostic, FontQaStatus, FontSubsetCheckDiagnostic, FontSubsetCheckStatus,
-        GlobalOptions, MissingFontAction, OutputLang, RefreshFontsArgs, ResolvedEmbedFont,
-        TempFontDbDir, MAX_DIAGNOSTIC_SUBSET_CALLS, MAX_DIAGNOSTIC_SUBSET_TOTAL_BYTES,
+        require_enabled_timing_map_rules, resolve_embed_fonts, sanitize_for_display,
+        substitute_template, write_output, CacheDiagnostic, CacheDiagnosticStatus, Cli, Command,
+        CommandDiagnostics, CommandReport, DiagnoseMode, DiagnosticSubsetBudget, EmbedArgs,
+        FileDiagnostic, FileReport, FileStatus, FontDiagnostic, FontQaStatus,
+        FontSubsetCheckDiagnostic, FontSubsetCheckStatus, GlobalOptions, MissingFontAction,
+        OutputLang, RefreshFontsArgs, ResolvedEmbedFont, TempFontDbDir,
+        MAX_DIAGNOSTIC_SUBSET_CALLS, MAX_DIAGNOSTIC_SUBSET_TOTAL_BYTES,
         MAX_RESOLVED_FONT_CODEPOINTS, MAX_SHIFT_OFFSET_MS, MAX_SUBSET_CODEPOINTS_FOR_DEDUP,
+        MAX_TIMING_MAP_BYTES,
     };
     // Import the canonical filename literal directly from app_lib so the
     // test pins the same name `TempFontDbDir::drop`'s remove_dir_all
@@ -7462,6 +7474,63 @@ mod tests {
     use clap::{CommandFactory, Parser};
     use std::fs;
     use std::path::{Path, PathBuf};
+
+    fn timing_map_rule(enabled: Option<bool>) -> engine::TimingMapRule {
+        engine::TimingMapRule {
+            start_ms: 0,
+            end_ms: None,
+            offset_ms: 1,
+            enabled,
+            label: None,
+        }
+    }
+
+    #[test]
+    fn timing_map_file_accepts_one_mib_and_rejects_one_byte_over() {
+        let root = create_cli_font_db_dir().expect("temporary test directory");
+        let map_path = root.join("boundary-map.csv");
+
+        fs::write(&map_path, vec![b' '; MAX_TIMING_MAP_BYTES as usize])
+            .expect("write at-limit timing map");
+        let at_limit = read_timing_map_text(&map_path).expect("one MiB should be accepted");
+        assert_eq!(at_limit.len(), MAX_TIMING_MAP_BYTES as usize);
+
+        fs::write(&map_path, vec![b' '; MAX_TIMING_MAP_BYTES as usize + 1])
+            .expect("write over-limit timing map");
+        let error = read_timing_map_text(&map_path).expect_err("one MiB plus one must be refused");
+        assert!(
+            error.contains("timing map file is too large")
+                && error.contains(&(MAX_TIMING_MAP_BYTES + 1).to_string())
+                && error.contains(&format!("max {MAX_TIMING_MAP_BYTES}")),
+            "size refusal should report the actual and accepted byte counts: {error}"
+        );
+
+        fs::remove_dir_all(root).expect("remove timing-map test directory");
+    }
+
+    #[test]
+    fn timing_map_rules_require_at_least_one_rule() {
+        let error = require_enabled_timing_map_rules(Vec::new())
+            .expect_err("an empty parsed map must be refused");
+
+        assert_eq!(error, "timing map contains no rules");
+    }
+
+    #[test]
+    fn timing_map_rules_require_at_least_one_enabled_rule() {
+        let error = require_enabled_timing_map_rules(vec![
+            timing_map_rule(Some(false)),
+            timing_map_rule(Some(false)),
+        ])
+        .expect_err("an all-disabled parsed map must be refused");
+        assert_eq!(error, "timing map contains no enabled rules");
+
+        for enabled in [None, Some(true)] {
+            let rules = require_enabled_timing_map_rules(vec![timing_map_rule(enabled)])
+                .expect("omitted and explicit true both mean enabled");
+            assert_eq!(rules.len(), 1);
+        }
+    }
 
     #[test]
     fn absolute_path_folds_cli_dot_and_parent_components_without_touching_names() {

--- a/src-tauri/src/encoding.rs
+++ b/src-tauri/src/encoding.rs
@@ -446,36 +446,147 @@ fn looks_like_subtitle_text(text: &str) -> bool {
     })
 }
 
+const UTF32_PROBE_BUDGET_BYTES: usize = 64 * 1024;
+const UTF32_PROBE_WINDOW_COUNT: usize = 3;
+
+fn utf32_probe_windows(bytes: &[u8]) -> Vec<&[u8]> {
+    if bytes.len() <= UTF32_PROBE_BUDGET_BYTES {
+        return vec![bytes];
+    }
+
+    // Spread the existing 64 KiB probe budget across the beginning, middle,
+    // and end. Subtitle files can have a long CJK preamble before the first
+    // timing/header marker; probing only the prefix misses UTF-32 in that
+    // case because BMP CJK text naturally has just two NUL-heavy byte lanes.
+    // Every boundary remains four-byte aligned so decoding never starts in
+    // the middle of a UTF-32 scalar.
+    let window_len = (UTF32_PROBE_BUDGET_BYTES / UTF32_PROBE_WINDOW_COUNT) & !3;
+    let middle_start = ((bytes.len() - window_len) / 2) & !3;
+    let suffix_start = bytes.len() - window_len;
+
+    vec![
+        &bytes[..window_len],
+        &bytes[middle_start..middle_start + window_len],
+        &bytes[suffix_start..],
+    ]
+}
+
+fn utf32_lane_meets_nul_ratio(
+    probes: &[&[u8]],
+    lane: usize,
+    units: usize,
+    minimum_tenths: usize,
+) -> bool {
+    probes
+        .iter()
+        .map(|probe| {
+            probe
+                .iter()
+                .skip(lane)
+                .step_by(4)
+                .filter(|byte| **byte == 0)
+                .count()
+        })
+        .sum::<usize>()
+        * 10
+        >= units * minimum_tenths
+}
+
+fn is_cjk_scalar(ch: char) -> bool {
+    matches!(
+        ch as u32,
+        0x1100..=0x11FF
+            | 0x2E80..=0x2FFF
+            | 0x3040..=0x30FF
+            | 0x31F0..=0x31FF
+            | 0x3400..=0x4DBF
+            | 0x4E00..=0x9FFF
+            | 0xAC00..=0xD7AF
+            | 0xF900..=0xFAFF
+    )
+}
+
+fn is_plausible_text_scalar(ch: char) -> bool {
+    ch.is_alphanumeric()
+        || ch.is_whitespace()
+        || ch.is_ascii_graphic()
+        || matches!(
+            ch as u32,
+            0x0300..=0x036F | 0x2000..=0x206F | 0x3000..=0x303F | 0xFF01..=0xFF65
+        )
+}
+
+fn looks_like_cjk_utf32_scalar_text(probes: &[&[u8]], little_endian: bool) -> bool {
+    let units = probes.iter().map(|probe| probe.len() / 4).sum::<usize>();
+    if units < 32 {
+        return false;
+    }
+
+    // Normal UTF-16 has alternating NUL lanes for ASCII and no NUL-heavy
+    // lanes for CJK. It can satisfy this adjacent high-lane pair only when
+    // almost every other UTF-16 code unit is NUL; that byte stream is also
+    // the exact BMP UTF-32 representation, while its UTF-16 interpretation
+    // contains control characters and is not acceptable subtitle text.
+    let high_lanes = if little_endian { [2, 3] } else { [0, 1] };
+    if !high_lanes
+        .into_iter()
+        .all(|lane| utf32_lane_meets_nul_ratio(probes, lane, units, 9))
+    {
+        return false;
+    }
+
+    let mut plausible = 0usize;
+    let mut visible = 0usize;
+    let mut cjk = 0usize;
+    let mut line_breaks = 0usize;
+
+    for unit in probes.iter().flat_map(|probe| probe.chunks_exact(4)) {
+        let value = if little_endian {
+            u32::from_le_bytes([unit[0], unit[1], unit[2], unit[3]])
+        } else {
+            u32::from_be_bytes([unit[0], unit[1], unit[2], unit[3]])
+        };
+        let Some(ch) = char::from_u32(value) else {
+            return false;
+        };
+        if ch.is_control() && !matches!(ch, '\t' | '\r' | '\n') {
+            return false;
+        }
+
+        plausible += usize::from(is_plausible_text_scalar(ch));
+        if !ch.is_whitespace() {
+            visible += 1;
+            cjk += usize::from(is_cjk_scalar(ch));
+        }
+        line_breaks += usize::from(matches!(ch, '\r' | '\n'));
+    }
+
+    // This fallback is intentionally narrower than generic Unicode-text
+    // detection. It covers the reported two-NUL-lane, CJK-heavy UTF-32 case
+    // while leaving arbitrary four-byte binary and ordinary UTF-16 to their
+    // existing paths. ASCII-heavy UTF-32 is handled by the three-lane check.
+    line_breaks > 0 && visible >= 16 && plausible * 100 >= units * 95 && cjk * 4 >= visible
+}
+
 fn looks_like_bomless_utf32(bytes: &[u8]) -> bool {
     if bytes.len() < 16 || !bytes.len().is_multiple_of(4) {
         return false;
     }
 
-    const STRUCTURE_PROBE_BYTES: usize = 64 * 1024;
-    let probe_len = bytes.len().min(STRUCTURE_PROBE_BYTES) & !3;
-    let probe = &bytes[..probe_len];
-    if decode_utf32_probe(probe, true)
-        .as_deref()
-        .is_some_and(looks_like_subtitle_text)
-        || decode_utf32_probe(probe, false)
-            .as_deref()
-            .is_some_and(looks_like_subtitle_text)
-    {
+    let probes = utf32_probe_windows(bytes);
+    if [true, false].into_iter().any(|little_endian| {
+        probes.iter().any(|probe| {
+            decode_utf32_probe(probe, little_endian)
+                .as_deref()
+                .is_some_and(looks_like_subtitle_text)
+        }) || looks_like_cjk_utf32_scalar_text(&probes, little_endian)
+    }) {
         return true;
     }
 
-    let units = probe.len() / 4;
+    let units = probes.iter().map(|probe| probe.len() / 4).sum::<usize>();
     let high_nul_lanes = (0..4)
-        .filter(|lane| {
-            probe
-                .iter()
-                .skip(*lane)
-                .step_by(4)
-                .filter(|byte| **byte == 0)
-                .count()
-                * 10
-                >= units * 8
-        })
+        .filter(|lane| utf32_lane_meets_nul_ratio(&probes, *lane, units, 8))
         .count();
     // ASCII-heavy UTF-32 has at least three nearly-empty byte lanes. UTF-16
     // has two, so requiring three avoids classifying ordinary UTF-16 text as
@@ -731,6 +842,18 @@ mod tests {
             .collect()
     }
 
+    fn encode_utf32_without_bom(text: &str, little_endian: bool) -> Vec<u8> {
+        text.chars()
+            .flat_map(|ch| {
+                if little_endian {
+                    (ch as u32).to_le_bytes()
+                } else {
+                    (ch as u32).to_be_bytes()
+                }
+            })
+            .collect()
+    }
+
     #[test]
     fn utf8_no_bom() {
         let result = decode_fixture("utf8.ass");
@@ -890,16 +1013,7 @@ mod tests {
     fn bomless_utf32_is_not_misclassified_as_utf16() {
         let source = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nHello\n";
         for little_endian in [true, false] {
-            let bytes: Vec<u8> = source
-                .chars()
-                .flat_map(|ch| {
-                    if little_endian {
-                        (ch as u32).to_le_bytes()
-                    } else {
-                        (ch as u32).to_be_bytes()
-                    }
-                })
-                .collect();
+            let bytes = encode_utf32_without_bom(source, little_endian);
             let decoded = decode_bytes(&bytes);
             assert!(
                 decoded
@@ -908,6 +1022,123 @@ mod tests {
                 "unexpected UTF-32 result: {decoded:?}"
             );
         }
+    }
+
+    #[test]
+    fn rejects_bomless_utf32_when_structure_starts_after_prefix_probe_budget() {
+        // The first subtitle marker starts immediately after the old 64 KiB
+        // prefix-only probe. BMP CJK scalars have only two NUL-heavy lanes,
+        // so the legacy three-NUL-lane fallback cannot identify it by itself.
+        let source = format!(
+            "{}\nWEBVTT\n\n00:00:01.000 --> 00:00:02.000\n正文\n",
+            "中".repeat(UTF32_PROBE_BUDGET_BYTES / 4)
+        );
+
+        for little_endian in [true, false] {
+            let bytes = encode_utf32_without_bom(&source, little_endian);
+            assert!(looks_like_bomless_utf32(&bytes));
+
+            let error = decode_bytes(&bytes).unwrap_err();
+            assert!(error.contains("UTF-32"), "got: {error}");
+        }
+    }
+
+    #[test]
+    fn rejects_cjk_utf32_when_the_only_structure_is_between_probe_windows() {
+        // About 1 MiB after UTF-32 encoding, with WEBVTT around byte 256 KiB.
+        // None of the bounded head/middle/tail windows contains the marker;
+        // the conservative scalar/lane check must identify the surrounding
+        // CJK text without expanding the probe budget.
+        let source = format!(
+            "{}WEBVTT\n{}",
+            "中\n".repeat(32 * 1024),
+            "文\n".repeat(96 * 1024)
+        );
+
+        for little_endian in [true, false] {
+            let bytes = encode_utf32_without_bom(&source, little_endian);
+            let probes = utf32_probe_windows(&bytes);
+            assert!(probes.iter().all(|probe| {
+                !decode_utf32_probe(probe, little_endian)
+                    .as_deref()
+                    .is_some_and(looks_like_subtitle_text)
+            }));
+            assert!(looks_like_bomless_utf32(&bytes));
+
+            let error = decode_bytes(&bytes).unwrap_err();
+            assert!(error.contains("UTF-32"), "got: {error}");
+        }
+    }
+
+    #[test]
+    fn utf32_probe_windows_are_aligned_and_stay_within_the_existing_budget() {
+        for len in [
+            UTF32_PROBE_BUDGET_BYTES,
+            UTF32_PROBE_BUDGET_BYTES + 4,
+            UTF32_PROBE_BUDGET_BYTES * 4,
+        ] {
+            let bytes = vec![0; len];
+            let probes = utf32_probe_windows(&bytes);
+
+            assert!(probes.len() <= UTF32_PROBE_WINDOW_COUNT);
+            assert!(
+                probes.iter().map(|probe| probe.len()).sum::<usize>() <= UTF32_PROBE_BUDGET_BYTES
+            );
+            assert!(probe_alignment_is_valid(&bytes, &probes));
+        }
+    }
+
+    fn probe_alignment_is_valid(source: &[u8], probes: &[&[u8]]) -> bool {
+        probes.iter().all(|probe| {
+            let offset = probe.as_ptr() as usize - source.as_ptr() as usize;
+            offset.is_multiple_of(4) && probe.len().is_multiple_of(4)
+        })
+    }
+
+    #[test]
+    fn utf32_probe_rejects_utf8_utf16_binary_and_truncated_counterexamples() {
+        let mut utf8_source = "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nText".to_string();
+        while !utf8_source.len().is_multiple_of(4) {
+            utf8_source.push(' ');
+        }
+        assert!(utf8_source.len().is_multiple_of(4));
+        assert!(!looks_like_bomless_utf32(utf8_source.as_bytes()));
+        assert_eq!(
+            decode_bytes(utf8_source.as_bytes()).unwrap().encoding_id,
+            "UTF-8"
+        );
+
+        let utf16_source = format!(
+            "WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n{}",
+            "正文\n".repeat(12 * 1024)
+        );
+        for little_endian in [true, false] {
+            let bytes = encode_utf16_without_bom(&utf16_source, little_endian);
+            let probes = utf32_probe_windows(&bytes);
+            assert!(!looks_like_cjk_utf32_scalar_text(&probes, true));
+            assert!(!looks_like_cjk_utf32_scalar_text(&probes, false));
+            assert!(!looks_like_bomless_utf32(&bytes));
+            let result = decode_bytes(&bytes).unwrap();
+            assert_eq!(result.text, utf16_source);
+            assert!(result.inferred_without_bom);
+        }
+
+        // Four-byte records with two adjacent zero lanes can resemble BMP
+        // UTF-32 at the byte level. Without subtitle structure, they remain
+        // an ordinary binary counterexample and must not be rejected as
+        // unsupported UTF-32.
+        let binary: Vec<u8> = [[0xB1, 0x03, 0, 0], [0xB2, 0x03, 0, 0], [b'\n', 0, 0, 0]]
+            .into_iter()
+            .cycle()
+            .take(1024)
+            .flatten()
+            .collect();
+        assert!(!looks_like_bomless_utf32(&binary));
+
+        let mut truncated =
+            encode_utf32_without_bom("WEBVTT\n\n00:00:01.000 --> 00:00:02.000\nText\n", true);
+        truncated.pop();
+        assert!(!looks_like_bomless_utf32(&truncated));
     }
 
     #[test]

--- a/src-tauri/src/font_cache.rs
+++ b/src-tauri/src/font_cache.rs
@@ -1167,14 +1167,23 @@ impl std::fmt::Debug for FontCache {
 /// to react: CLI falls back to no-cache and warns; GUI prompts the user.
 ///
 /// Unified across open/read/write to keep the public API simple — the
-/// caller mostly cares about "did it work" + a message; specific
-/// variant only matters for `SchemaVersionMismatch` which has its own
-/// recovery path.
+/// caller mostly cares about "did it work" + a message. The two
+/// structured variants are deliberately narrow: callers may recommend
+/// deleting/rebuilding a schema-mismatched or invalid SQLite cache, but
+/// must not give that destructive advice for an ordinary permission,
+/// lock, or path error.
 #[derive(Debug)]
 pub enum CacheError {
     /// Filesystem or SQLite-level failure. Includes a human-readable
-    /// message embedding the underlying error.
+    /// message embedding the underlying error. During connection setup
+    /// and schema verification, SQLite corruption and not-a-database
+    /// errors use `InvalidDatabase` instead.
     Io(String),
+    /// While opening or verifying the cache, SQLite positively identified
+    /// it as corrupt or not a database. This is narrower than `Io`, allowing
+    /// callers to offer rebuild guidance without misdiagnosing
+    /// permission/open failures.
+    InvalidDatabase(String),
     /// Existing cache file was opened, but its schema_version row
     /// either doesn't match `SCHEMA_VERSION` (different release) or is
     /// missing entirely (corrupt or pre-versioned cache). Both cases
@@ -1189,6 +1198,9 @@ impl std::fmt::Display for CacheError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::Io(msg) => write!(f, "cache I/O error: {msg}"),
+            Self::InvalidDatabase(msg) => {
+                write!(f, "cache database is corrupt or not SQLite: {msg}")
+            }
             Self::SchemaVersionMismatch { found, expected } if *found == -1 => write!(
                 f,
                 "cache schema_version row missing (cache predates version tracking \
@@ -1205,6 +1217,23 @@ impl std::fmt::Display for CacheError {
                  cache is from a different release and must be rebuilt"
             ),
         }
+    }
+}
+
+/// Preserve the only SQLite error-code distinction during open/schema
+/// validation that changes safe recovery advice at the caller boundary.
+/// All other SQLite failures — including permission denied, cannot-open,
+/// read-only, busy, and locked — remain ordinary `Io` errors and must not
+/// prompt automatic deletion.
+fn cache_sqlite_error(context: impl Into<String>, error: rusqlite::Error) -> CacheError {
+    let message = format!("{}: {error}", context.into());
+    if matches!(
+        error.sqlite_error_code(),
+        Some(rusqlite::ErrorCode::DatabaseCorrupt | rusqlite::ErrorCode::NotADatabase)
+    ) {
+        CacheError::InvalidDatabase(message)
+    } else {
+        CacheError::Io(message)
     }
 }
 
@@ -1250,7 +1279,7 @@ impl FontCache {
         // rusqlite doesn't expose.
         let already_existed = cache_path.exists();
         let conn = Connection::open(cache_path)
-            .map_err(|e| CacheError::Io(format!("opening {}: {e}", cache_path.display())))?;
+            .map_err(|e| cache_sqlite_error(format!("opening {}", cache_path.display()), e))?;
 
         // Keep the cross-run persistent cache in rollback-journal mode.
         // `diagnose-fonts` has a read-only contract, and a read-only WAL
@@ -1260,15 +1289,15 @@ impl FontCache {
         // cache correctness. The session DB in fonts.rs still uses WAL
         // because it is temp/run-local and write-heavy.
         conn.pragma_update(None, "journal_mode", "DELETE")
-            .map_err(|e| CacheError::Io(format!("setting DELETE journal mode: {e}")))?;
+            .map_err(|e| cache_sqlite_error("setting DELETE journal mode", e))?;
         conn.busy_timeout(std::time::Duration::from_secs(5))
-            .map_err(|e| CacheError::Io(format!("setting busy_timeout: {e}")))?;
+            .map_err(|e| cache_sqlite_error("setting busy_timeout", e))?;
         // Per-connection: SQLite ships with foreign_keys=OFF by default,
         // so the FOREIGN KEY clauses in SCHEMA_SQL would be decorative
         // unless turned on here. The session DB `open_user_font_db`
         // mirrors this PRAGMA for the same reason.
         conn.pragma_update(None, "foreign_keys", "ON")
-            .map_err(|e| CacheError::Io(format!("enabling foreign_keys: {e}")))?;
+            .map_err(|e| cache_sqlite_error("enabling foreign_keys", e))?;
 
         let cache = Self { conn };
         if already_existed {
@@ -1288,12 +1317,12 @@ impl FontCache {
         reject_cache_reparse_paths(cache_path)?;
         let conn = Connection::open_with_flags(cache_path, OpenFlags::SQLITE_OPEN_READ_ONLY)
             .map_err(|e| {
-                CacheError::Io(format!("opening {} read-only: {e}", cache_path.display()))
+                cache_sqlite_error(format!("opening {} read-only", cache_path.display()), e)
             })?;
         conn.busy_timeout(std::time::Duration::from_secs(5))
-            .map_err(|e| CacheError::Io(format!("setting busy_timeout: {e}")))?;
+            .map_err(|e| cache_sqlite_error("setting busy_timeout", e))?;
         conn.pragma_update(None, "foreign_keys", "ON")
-            .map_err(|e| CacheError::Io(format!("enabling foreign_keys: {e}")))?;
+            .map_err(|e| cache_sqlite_error("enabling foreign_keys", e))?;
 
         let cache = Self { conn };
         cache.verify_schema_version()?;
@@ -1307,13 +1336,13 @@ impl FontCache {
     fn init_schema(&self) -> Result<(), CacheError> {
         self.conn
             .execute_batch(SCHEMA_SQL)
-            .map_err(|e| CacheError::Io(format!("initializing schema: {e}")))?;
+            .map_err(|e| cache_sqlite_error("initializing schema", e))?;
         self.conn
             .execute(
                 "INSERT INTO cache_meta(key, value) VALUES('schema_version', ?1)",
                 params![SCHEMA_VERSION.to_string()],
             )
-            .map_err(|e| CacheError::Io(format!("writing schema_version: {e}")))?;
+            .map_err(|e| cache_sqlite_error("writing schema_version", e))?;
         Ok(())
     }
 
@@ -1324,7 +1353,7 @@ impl FontCache {
         let has_cache_meta = self
             .conn
             .table_exists(None::<&str>, "cache_meta")
-            .map_err(|e| CacheError::Io(format!("checking cache_meta table: {e}")))?;
+            .map_err(|e| cache_sqlite_error("checking cache_meta table", e))?;
         if !has_cache_meta {
             return Err(CacheError::SchemaVersionMismatch {
                 found: -1,
@@ -1357,7 +1386,7 @@ impl FontCache {
                 found: -1,
                 expected: SCHEMA_VERSION,
             }),
-            Err(e) => Err(CacheError::Io(format!("reading schema_version: {e}"))),
+            Err(e) => Err(cache_sqlite_error("reading schema_version", e)),
         }
     }
 
@@ -2221,6 +2250,52 @@ mod tests {
         let mut sidecar = path.as_os_str().to_os_string();
         sidecar.push(suffix);
         std::path::PathBuf::from(sidecar)
+    }
+
+    fn sqlite_failure(code: i32) -> rusqlite::Error {
+        rusqlite::Error::SqliteFailure(rusqlite::ffi::Error::new(code), None)
+    }
+
+    #[test]
+    fn sqlite_error_classifier_only_marks_invalid_database_codes_for_rebuild() {
+        for code in [rusqlite::ffi::SQLITE_CORRUPT, rusqlite::ffi::SQLITE_NOTADB] {
+            let error = cache_sqlite_error("opening cache", sqlite_failure(code));
+            assert!(
+                matches!(&error, CacheError::InvalidDatabase(_)),
+                "SQLite code {code} must permit invalid-database recovery advice, got {error}"
+            );
+        }
+
+        for code in [rusqlite::ffi::SQLITE_PERM, rusqlite::ffi::SQLITE_CANTOPEN] {
+            let error = cache_sqlite_error("opening cache", sqlite_failure(code));
+            assert!(
+                matches!(&error, CacheError::Io(_)),
+                "SQLite code {code} must remain an ordinary I/O error, got {error}"
+            );
+        }
+    }
+
+    #[test]
+    fn non_sqlite_cache_is_invalid_database_in_both_open_modes() {
+        let guard = TempCacheDir::new();
+        let read_write_path = guard.0.join("invalid-read-write.sqlite3");
+        let read_only_path = guard.0.join("invalid-read-only.sqlite3");
+        let invalid_bytes = b"this is deliberately not a SQLite database";
+        fs::write(&read_write_path, invalid_bytes).expect("write read-write fixture");
+        fs::write(&read_only_path, invalid_bytes).expect("write read-only fixture");
+
+        for (mode, result) in [
+            ("read-write", FontCache::open_or_create(&read_write_path)),
+            (
+                "read-only",
+                FontCache::open_existing_read_only(&read_only_path),
+            ),
+        ] {
+            assert!(
+                matches!(&result, Err(CacheError::InvalidDatabase(_))),
+                "non-SQLite cache must be classified as InvalidDatabase in {mode} mode, got {result:?}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/font_cache.rs
+++ b/src-tauri/src/font_cache.rs
@@ -234,8 +234,8 @@ const FAMILY_LOOKUP_SQL: &str =
 /// (untrusted-input via `--cache-file`) populated with hundreds of fabricated
 /// source rows — especially UNC paths to dead servers — would otherwise
 /// spin every detect call through a per-row stat loop, bounded only by
-/// per-stat OS timeout. The cap fires inside `list_folders` and refuses
-/// to return the result; downstream `diff_against` /
+/// per-stat OS timeout. The cap fires inside `list_sources` and refuses
+/// to return the result; downstream `diff_sources` /
 /// `detect_font_cache_drift` surface the error and the user is pointed
 /// at rebuilding the cache. Realistic working caches hold a handful to
 /// dozens of folders, so 256 stays generous without being a practical
@@ -624,8 +624,9 @@ pub struct CacheSourceRecord {
     pub files: Vec<FileSnapshot>,
 }
 
-/// Transitional root-only view used by older shallow-only callers. New code
-/// should use [`CacheSourceRecord`] so scope and nested snapshots are retained.
+/// Test-only root view for legacy shallow fixtures. Production code must use
+/// [`CacheSourceRecord`] so source scope and nested snapshots cannot be lost.
+#[cfg(test)]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FolderRecord {
     pub folder_path: String,
@@ -1618,8 +1619,10 @@ impl FontCache {
         Ok(removed)
     }
 
-    /// Compatibility wrapper for shallow-only call sites while the CLI moves
-    /// to source snapshots. New code should call [`Self::replace_source`].
+    /// Test-only adapter for legacy shallow fixtures. It deliberately cannot
+    /// represent recursive sources; production code must call
+    /// [`Self::replace_source`] with a complete snapshot.
+    #[cfg(test)]
     pub fn replace_folder(
         &mut self,
         folder_path: &str,
@@ -1650,14 +1653,16 @@ impl FontCache {
         )
     }
 
-    /// Compatibility wrapper for legacy shallow-only callers.
+    /// Test-only adapter for legacy shallow fixtures. Production code must use
+    /// [`Self::remove_source`] and preserve the source scope.
+    #[cfg(test)]
     pub fn remove_folder(&mut self, folder_path: &str) -> Result<(), CacheError> {
         self.remove_source(folder_path, FontDirectoryScope::Shallow)
     }
 
-    /// Compatibility comparison for legacy shallow-only callers. New code uses
-    /// [`FontCache::diff_sources`] with complete directory and candidate-file
-    /// snapshots.
+    /// Test-only comparison for legacy shallow fixtures. It intentionally drops
+    /// recursive scope and nested snapshots; production code must use
+    /// [`FontCache::diff_sources`].
     ///
     /// The drift categories follow the locked design:
     /// - **added**: in the filesystem snapshot but not in the cache.
@@ -1670,6 +1675,7 @@ impl FontCache {
     ///
     /// Folders unchanged (in both with matching mtime) are silently
     /// OK and don't appear in any report list.
+    #[cfg(test)]
     pub fn diff_against(
         &self,
         current_folders: &[(String, i64)],
@@ -1735,7 +1741,7 @@ impl FontCache {
     ///
     /// Match semantics: NFC-normalize + full Unicode lowercase via
     /// `family_lookup_key` on BOTH the query (here) and the storage
-    /// path (`replace_folder`). Exact family-name rows must match
+    /// path (`replace_source`). Exact family-name rows must match
     /// bold/italic exactly; full-face/PostScript alias rows are
     /// style-insensitive because the alias already names a concrete
     /// face. Exact family rows sort before alias rows so an alias can
@@ -2037,7 +2043,9 @@ impl FontCache {
         Ok(report)
     }
 
-    /// Transitional shallow-root view. New code should call `list_sources`.
+    /// Test-only shallow-root view for legacy fixtures. Production code must
+    /// call [`Self::list_sources`] so scope and nested snapshots are retained.
+    #[cfg(test)]
     pub fn list_folders(&self) -> Result<Vec<FolderRecord>, CacheError> {
         self.list_sources()?
             .into_iter()

--- a/src-tauri/src/font_cache_commands.rs
+++ b/src-tauri/src/font_cache_commands.rs
@@ -72,16 +72,24 @@ impl Drop for CacheMutationGuard {
 const GUI_CACHE_FILE_NAME: &str = "gui_font_cache.sqlite3";
 
 /// Live cache handle, populated by `init_gui_font_cache` during Tauri
-/// setup and consumed by the five commands. `None` when init hit a
-/// schema mismatch or other recoverable error — in that state the
-/// frontend's drift modal renders the "rebuild required" path so the
-/// user can clear and re-init explicitly.
+/// setup and consumed by the five commands. `None` after a schema mismatch or
+/// another non-fatal initialization error. Only schema mismatch is represented
+/// as rebuild-required status; ordinary failures are returned from
+/// `open_font_cache` through the separate stored-error slot below.
 static GUI_FONT_CACHE: Lazy<Mutex<Option<FontCache>>> = Lazy::new(|| Mutex::new(None));
 
 /// Cache file path published separately from the live handle so
 /// `clear_font_cache` can drop the connection AND wipe the file even
 /// when `GUI_FONT_CACHE` is `None` (schema-mismatch recovery path).
 static GUI_FONT_CACHE_PATH: Lazy<Mutex<Option<PathBuf>>> = Lazy::new(|| Mutex::new(None));
+
+/// User-safe reason for the most recent non-schema initialization failure.
+/// The path slot deliberately remains empty for those failures so an ordinary
+/// permission or open error cannot be mistaken for a rebuildable schema
+/// mismatch. `open_font_cache` reads this slot before inferring status.
+static GUI_FONT_CACHE_INIT_FAILURE: Lazy<Mutex<Option<String>>> = Lazy::new(|| Mutex::new(None));
+
+const MAX_GUI_CACHE_INIT_FAILURE_CHARS: usize = 1_024;
 
 /// Monotonic revision counter bumped after every successful cache content or
 /// topology mutation. The counter is
@@ -104,6 +112,98 @@ static GUI_FONT_CACHE_GENERATION: AtomicU64 = AtomicU64::new(0);
 fn finish_gui_cache_mutation() {
     crate::fonts::clear_cache_provenance();
     GUI_FONT_CACHE_GENERATION.fetch_add(1, Ordering::Release);
+}
+
+fn sanitize_gui_cache_init_failure(message: &str) -> String {
+    let mut sanitized = String::with_capacity(message.len().min(MAX_GUI_CACHE_INIT_FAILURE_CHARS));
+    let mut chars = message.chars();
+    for _ in 0..MAX_GUI_CACHE_INIT_FAILURE_CHARS {
+        let Some(ch) = chars.next() else {
+            return sanitized;
+        };
+        if ch.is_control()
+            || matches!(
+                ch,
+                '\u{2028}' | '\u{2029}'
+                    | '\u{200B}'..='\u{200D}'
+                    | '\u{2060}'
+                    | '\u{180E}'
+                    | '\u{FEFF}'
+                    | '\u{061C}'
+                    | '\u{200E}'
+                    | '\u{200F}'
+                    | '\u{202A}'..='\u{202E}'
+                    | '\u{2066}'..='\u{2069}'
+            )
+        {
+            sanitized.push(' ');
+        } else {
+            sanitized.push(ch);
+        }
+    }
+    if chars.next().is_some() {
+        sanitized.push('…');
+    }
+    sanitized
+}
+
+fn store_gui_cache_init_failure(message: String) -> Result<(), String> {
+    let mut failure_slot = GUI_FONT_CACHE_INIT_FAILURE
+        .lock()
+        .map_err(|_| "GUI cache initialization-error mutex poisoned".to_string())?;
+    *failure_slot = Some(sanitize_gui_cache_init_failure(&message));
+    Ok(())
+}
+
+fn clear_gui_cache_init_failure() -> Result<(), String> {
+    let mut failure_slot = GUI_FONT_CACHE_INIT_FAILURE
+        .lock()
+        .map_err(|_| "GUI cache initialization-error mutex poisoned".to_string())?;
+    *failure_slot = None;
+    Ok(())
+}
+
+fn gui_cache_init_failure() -> Result<Option<String>, String> {
+    GUI_FONT_CACHE_INIT_FAILURE
+        .lock()
+        .map_err(|_| "GUI cache initialization-error mutex poisoned".to_string())
+        .map(|failure| failure.clone())
+}
+
+fn reset_gui_cache_state_for_init() -> Result<(), String> {
+    {
+        let mut cache_slot = GUI_FONT_CACHE
+            .lock()
+            .map_err(|_| "GUI cache mutex poisoned".to_string())?;
+        *cache_slot = None;
+        finish_gui_cache_mutation();
+    }
+    {
+        let mut path_slot = GUI_FONT_CACHE_PATH
+            .lock()
+            .map_err(|_| "GUI cache path mutex poisoned".to_string())?;
+        *path_slot = None;
+    }
+    clear_gui_cache_init_failure()
+}
+
+fn gui_cache_directory_failure_for_ipc(error: &std::io::Error) -> String {
+    let kind = match error.kind() {
+        std::io::ErrorKind::NotFound => "path not found",
+        std::io::ErrorKind::PermissionDenied => "permission denied",
+        std::io::ErrorKind::AlreadyExists | std::io::ErrorKind::NotADirectory => {
+            "a non-directory entry already exists there"
+        }
+        std::io::ErrorKind::InvalidInput => "invalid path",
+        _ => "filesystem error",
+    };
+    format!("GUI font cache initialization failed while creating its data directory: {kind}")
+}
+
+fn gui_cache_open_failure_for_ipc(cache_path: &Path, error: &CacheError) -> String {
+    let path = cache_path.display().to_string();
+    let redacted_detail = error.to_string().replace(&path, "<font-cache path>");
+    format!("GUI font cache initialization failed: {redacted_detail}")
 }
 
 /// One-shot migration of the legacy GUI font cache file from a prior
@@ -298,6 +398,9 @@ pub fn migrate_legacy_gui_cache(legacy_dir: &Path, new_dir: &Path) {
 ///   matches the locked "no auto-migrate" decision: never silently
 ///   delete a cache file the user might want to inspect.
 pub fn init_gui_font_cache(app_data_dir: &Path) -> Result<(), String> {
+    // Setup normally calls this exactly once. Reset all three slots anyway so a
+    // future explicit retry cannot retain a stale live handle, path, or error.
+    reset_gui_cache_state_for_init()?;
     // `app_data_dir` here is resolved via the caller in `lib.rs`
     // which passes `font_cache::unified_app_data_dir()` — chain is
     // `std::env::var("APPDATA")` (Windows) / `$XDG_DATA_HOME` (POSIX)
@@ -313,12 +416,14 @@ pub fn init_gui_font_cache(app_data_dir: &Path) -> Result<(), String> {
     // check — and contradicting the locked single-user-desktop threat
     // model. Revisit if the project ships in a multi-user /
     // MDM-managed deployment.
-    std::fs::create_dir_all(app_data_dir).map_err(|e| {
-        format!(
-            "Cannot create app data dir '{}': {e}",
+    if let Err(error) = std::fs::create_dir_all(app_data_dir) {
+        let detailed = format!(
+            "Cannot create app data dir '{}': {error}",
             app_data_dir.display()
-        )
-    })?;
+        );
+        store_gui_cache_init_failure(gui_cache_directory_failure_for_ipc(&error))?;
+        return Err(detailed);
+    }
     let cache_path = app_data_dir.join(GUI_CACHE_FILE_NAME);
 
     // Publish the path before attempting open so `clear_font_cache`
@@ -333,6 +438,7 @@ pub fn init_gui_font_cache(app_data_dir: &Path) -> Result<(), String> {
 
     match FontCache::open_or_create(&cache_path) {
         Ok(cache) => {
+            clear_gui_cache_init_failure()?;
             let mut slot = GUI_FONT_CACHE
                 .lock()
                 .map_err(|_| "GUI cache mutex poisoned".to_string())?;
@@ -340,6 +446,9 @@ pub fn init_gui_font_cache(app_data_dir: &Path) -> Result<(), String> {
             Ok(())
         }
         Err(CacheError::SchemaVersionMismatch { found, expected }) => {
+            // Schema mismatch has its own structured status and recovery path;
+            // never let a stale ordinary-init error take precedence over it.
+            clear_gui_cache_init_failure()?;
             log::warn!(
                 "GUI font cache at {} has schema version {found}; expected {expected}. \
                  Cache unavailable until user clears via drift modal.",
@@ -356,6 +465,7 @@ pub fn init_gui_font_cache(app_data_dir: &Path) -> Result<(), String> {
             if let Ok(mut path_slot) = GUI_FONT_CACHE_PATH.lock() {
                 *path_slot = None;
             }
+            store_gui_cache_init_failure(gui_cache_open_failure_for_ipc(&cache_path, &e))?;
             Err(format!(
                 "Cannot open GUI font cache at {}: {e}",
                 cache_path.display()
@@ -428,9 +538,9 @@ pub struct SkippedFolder {
     /// Cached source root that triggered the skip. Field name
     /// `folder` (not `folder_path`) is intentional and paired with
     /// TS `FontCacheSkippedFolder.folder` in `tauri-api.ts`; the
-    /// shorter form jars against `FolderRecord.folder_path` in
-    /// `font_cache.rs` but the trade is "shorter UI-facing field
-    /// name vs internal-storage descriptor" — keep the TS pairing.
+    /// shorter form differs from the internal source-record field, but
+    /// the trade is "shorter UI-facing field name vs internal-storage
+    /// descriptor" — keep the TS pairing.
     pub folder: String,
     pub scope: FontDirectoryScope,
     /// User-facing reason — the error message from the failing op
@@ -511,11 +621,22 @@ fn classify_unreadable_existing_as_modified(
 /// (frontend asks "is cache ready?" before calling detect_drift) and
 /// for re-checking after `clear_font_cache`.
 pub fn open_font_cache() -> Result<CacheStatus, String> {
+    // A stored non-schema failure is more precise than the absence-derived
+    // "setup did not run" fallback and must win over schema-mismatch inference.
+    if let Some(failure) = gui_cache_init_failure()? {
+        return Err(failure);
+    }
     let path = GUI_FONT_CACHE_PATH
         .lock()
         .map_err(|_| "GUI cache path mutex poisoned".to_string())?
-        .clone()
-        .ok_or_else(|| "Cache path not initialized; setup did not run".to_string())?;
+        .clone();
+    let path = match path {
+        Some(path) => path,
+        None => {
+            return Err(gui_cache_init_failure()?
+                .unwrap_or_else(|| "Cache path not initialized; setup did not run".to_string()));
+        }
+    };
     let available = GUI_FONT_CACHE
         .lock()
         .map_err(|_| "GUI cache mutex poisoned".to_string())?
@@ -1013,8 +1134,14 @@ pub fn clear_font_cache() -> Result<(), String> {
     let path = GUI_FONT_CACHE_PATH
         .lock()
         .map_err(|_| "GUI cache path mutex poisoned".to_string())?
-        .clone()
-        .ok_or_else(|| "Cache path not initialized; setup did not run".to_string())?;
+        .clone();
+    let path = match path {
+        Some(path) => path,
+        None => {
+            return Err(gui_cache_init_failure()?
+                .unwrap_or_else(|| "Cache path not initialized; setup did not run".to_string()));
+        }
+    };
 
     // Build the main-file + sidecar set and reject reparse points
     // BEFORE dropping the live cache handle. If a planted sidecar is
@@ -1051,7 +1178,7 @@ pub fn clear_font_cache() -> Result<(), String> {
     // A current, live database does not need file deletion. Clear its source
     // rows in one SQLite transaction so success cannot be reported while an
     // undeletable main file quietly preserves old data.
-    {
+    let cleared_live_cache = {
         let mut slot = GUI_FONT_CACHE
             .lock()
             .map_err(|_| "GUI cache mutex poisoned".to_string())?;
@@ -1060,8 +1187,14 @@ pub fn clear_font_cache() -> Result<(), String> {
                 .clear_sources()
                 .map_err(|e| format!("clear cached font sources: {e}"))?;
             finish_gui_cache_mutation();
-            return Ok(());
+            true
+        } else {
+            false
         }
+    };
+    if cleared_live_cache {
+        clear_gui_cache_init_failure()?;
+        return Ok(());
     }
 
     // No live handle means initialization rejected the file (normally a
@@ -1070,8 +1203,15 @@ pub fn clear_font_cache() -> Result<(), String> {
     // best-effort because a fresh SQLite open can safely decide whether any
     // surviving journal is usable.
     remove_cache_files_for_rebuild(&paths)?;
-    let fresh = FontCache::open_or_create(&path)
-        .map_err(|e| format!("re-create cache at {}: {e}", path.display()))?;
+    let fresh = match FontCache::open_or_create(&path) {
+        Ok(cache) => cache,
+        Err(error) => {
+            let detailed = format!("re-create cache at {}: {error}", path.display());
+            store_gui_cache_init_failure(gui_cache_open_failure_for_ipc(&path, &error))?;
+            return Err(detailed);
+        }
+    };
+    clear_gui_cache_init_failure()?;
     let mut slot = GUI_FONT_CACHE
         .lock()
         .map_err(|_| "GUI cache mutex poisoned".to_string())?;
@@ -1267,6 +1407,47 @@ mod tests {
     use crate::font_cache::try_modified_at;
     use std::fs;
 
+    static GUI_CACHE_STATE_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    fn clear_gui_cache_state_for_test() {
+        *GUI_FONT_CACHE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        *GUI_FONT_CACHE_PATH
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        *GUI_FONT_CACHE_INIT_FAILURE
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        CACHE_MUTATION_IN_PROGRESS.store(false, Ordering::Release);
+        crate::fonts::clear_cache_provenance();
+    }
+
+    struct GuiCacheStateTestGuard {
+        _font_state: std::sync::MutexGuard<'static, ()>,
+        _serial: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl GuiCacheStateTestGuard {
+        fn acquire() -> Self {
+            let font_state = crate::fonts::lock_font_state_for_test();
+            let serial = GUI_CACHE_STATE_TEST_LOCK
+                .lock()
+                .unwrap_or_else(|poisoned| poisoned.into_inner());
+            clear_gui_cache_state_for_test();
+            Self {
+                _font_state: font_state,
+                _serial: serial,
+            }
+        }
+    }
+
+    impl Drop for GuiCacheStateTestGuard {
+        fn drop(&mut self) {
+            clear_gui_cache_state_for_test();
+        }
+    }
+
     /// RAII guard mirroring `font_cache.rs::tests::TempCacheDir` —
     /// the canonical-shape comment on that sibling enumerates every
     /// other temp-dir construction in the workspace (dropzone.rs /
@@ -1318,6 +1499,75 @@ mod tests {
         let cache_path = guard.0.join("cache.sqlite3");
         let cache = FontCache::open_or_create(&cache_path).expect("open cache");
         (guard, cache)
+    }
+
+    #[test]
+    fn init_failure_is_reported_until_a_later_success_clears_it() {
+        let guard = TempCacheDir::new("init_failure_lifecycle");
+        let _state_guard = GuiCacheStateTestGuard::acquire();
+        let blocked_dir = guard.0.join("not-a-directory");
+        fs::write(&blocked_dir, b"file blocks create_dir_all").unwrap();
+
+        let init_error = init_gui_font_cache(&blocked_dir).unwrap_err();
+        assert!(init_error.contains("Cannot create app data dir"));
+        let reported = open_font_cache().unwrap_err();
+        assert!(
+            reported.contains("a non-directory entry already exists there"),
+            "stored error should retain the real failure class: {reported}"
+        );
+        assert!(!reported.contains("setup did not run"));
+        assert!(
+            !reported.contains(&blocked_dir.display().to_string()),
+            "IPC-safe failure must not disclose the operational path: {reported}"
+        );
+
+        let working_dir = guard.0.join("working");
+        init_gui_font_cache(&working_dir).expect("later initialization should succeed");
+        let status = open_font_cache().expect("stale failure should be cleared");
+        assert!(status.available);
+        assert!(!status.schema_mismatch);
+    }
+
+    #[test]
+    fn schema_mismatch_clears_stale_init_failure_and_keeps_structured_status() {
+        let guard = TempCacheDir::new("schema_mismatch_state");
+        let _state_guard = GuiCacheStateTestGuard::acquire();
+        let cache_path = guard.0.join(GUI_CACHE_FILE_NAME);
+        let conn = rusqlite::Connection::open(&cache_path).unwrap();
+        conn.execute_batch(
+            "CREATE TABLE cache_meta(key TEXT PRIMARY KEY, value TEXT NOT NULL);\
+             INSERT INTO cache_meta(key, value) VALUES('schema_version', '0');",
+        )
+        .unwrap();
+        drop(conn);
+        *GUI_FONT_CACHE_INIT_FAILURE.lock().unwrap() = Some("stale failure".to_string());
+
+        init_gui_font_cache(&guard.0).expect("schema mismatch is recoverable at startup");
+        let status =
+            open_font_cache().expect("schema mismatch should be a status, not stale error");
+        assert!(!status.available);
+        assert!(status.schema_mismatch);
+        assert!(GUI_FONT_CACHE_INIT_FAILURE.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn init_failure_sanitizer_strips_all_display_controls_and_caps_length() {
+        let unsafe_message = format!(
+            "prefix\u{061C}\u{202E}\u{2067}\u{200B}\n{}tail",
+            "x".repeat(MAX_GUI_CACHE_INIT_FAILURE_CHARS + 20)
+        );
+        let sanitized = sanitize_gui_cache_init_failure(&unsafe_message);
+        assert!(!sanitized.contains('\u{061C}'));
+        assert!(!sanitized.contains('\u{202E}'));
+        assert!(!sanitized.contains('\u{2067}'));
+        assert!(!sanitized.contains('\u{200B}'));
+        assert!(!sanitized.contains('\n'));
+        assert_eq!(
+            sanitized.chars().count(),
+            MAX_GUI_CACHE_INIT_FAILURE_CHARS + 1,
+            "capped messages include one trailing ellipsis"
+        );
+        assert!(sanitized.ends_with('…'));
     }
 
     #[derive(Default)]
@@ -1832,6 +2082,7 @@ mod tests {
         use std::os::unix::fs::symlink;
 
         let dir = TempCacheDir::new("clear_reparse_preserve");
+        let _state_guard = GuiCacheStateTestGuard::acquire();
         let cache_path = dir.0.join(GUI_CACHE_FILE_NAME);
         let cache = FontCache::open_or_create(&cache_path).expect("open cache");
         let target = dir.0.join("wal-target");
@@ -1856,10 +2107,6 @@ mod tests {
             GUI_FONT_CACHE.lock().unwrap().is_some(),
             "failed clear must leave the old cache handle available"
         );
-
-        *GUI_FONT_CACHE.lock().unwrap() = None;
-        *GUI_FONT_CACHE_PATH.lock().unwrap() = None;
-        crate::fonts::clear_cache_provenance();
     }
 
     // ── finalize_drift generation check ──

--- a/src-tauri/src/fonts.rs
+++ b/src-tauri/src/fonts.rs
@@ -2715,6 +2715,35 @@ fn add_preflight_file(path: &Path, out: &mut FontScanPreflight) {
     out.total_bytes = out.total_bytes.saturating_add(metadata.len());
 }
 
+/// Resolve one explicitly selected font file and validate both sides of the
+/// resolution boundary. The second validation is required even when the raw
+/// picker path passed: a symlink / junction / filesystem alias may resolve to
+/// a canonical Windows ADS path or another representation the IPC validator
+/// rejects. Return the normalized canonical string alongside the `PathBuf` so
+/// callers cannot accidentally deduplicate or publish the path before that
+/// post-canonicalization check.
+fn canonicalize_and_validate_explicit_font_path_with<F>(
+    path: &str,
+    canonicalize: F,
+) -> Result<(PathBuf, String), String>
+where
+    F: FnOnce(&Path) -> std::io::Result<PathBuf>,
+{
+    validate_ipc_path(path, "File")?;
+    let canonical = canonicalize(Path::new(path))
+        .map_err(|_| "A selected font file became unreadable".to_string())?;
+    let canonical_text = canonical
+        .to_str()
+        .ok_or_else(|| "A selected font path is not valid UTF-8".to_string())?;
+    let normalized = normalize_canonical_path(canonical_text);
+    validate_ipc_path(&normalized, "Resolved font")?;
+    Ok((canonical, normalized))
+}
+
+fn canonicalize_and_validate_explicit_font_path(path: &str) -> Result<(PathBuf, String), String> {
+    canonicalize_and_validate_explicit_font_path_with(path, Path::canonicalize)
+}
+
 fn preflight_files_inner(paths: Vec<String>) -> FontScanPreflight {
     // The public command enforces MAX_INPUT_PATHS, but the inner
     // helper has no caller-side check. Debug-mode assertion catches
@@ -2749,17 +2778,12 @@ fn preflight_files_inner(paths: Vec<String>) -> FontScanPreflight {
     let total_inputs = paths.len();
     let mut rejected = 0usize;
     for p in paths {
-        if validate_ipc_path(&p, "File").is_err() {
-            rejected += 1;
-            continue;
-        }
-        let Ok(canonical) = Path::new(&p).canonicalize() else {
+        let Ok((canonical, canonical_key)) = canonicalize_and_validate_explicit_font_path(&p)
+        else {
             rejected += 1;
             continue;
         };
-        if !canonical.is_file()
-            || !seen.insert(normalize_canonical_path(&canonical.to_string_lossy()))
-        {
+        if !canonical.is_file() || !seen.insert(canonical_key) {
             continue;
         }
         add_preflight_file(&canonical, &mut out);
@@ -3539,11 +3563,6 @@ fn scan_files_inner<F: FnMut(Vec<LocalFontEntry>) -> Result<(), String>>(
             });
         }
 
-        if validate_ipc_path(&p, "File").is_err() {
-            rejected += 1;
-            continue;
-        }
-
         // No `is_reparse_point` pre-check here, unlike
         // `scan_directory_inner`. The asymmetry is intentional:
         // this function processes paths the user
@@ -3558,8 +3577,8 @@ fn scan_files_inner<F: FnMut(Vec<LocalFontEntry>) -> Result<(), String>>(
         // count gate. `canonicalize` below + `has_allowed_font_extension`
         // (in `parse_local_font_file`) still bound the exfil surface
         // to font-extension targets.
-        let canonical = match Path::new(&p).canonicalize() {
-            Ok(c) => c,
+        let (canonical, canonical_key) = match canonicalize_and_validate_explicit_font_path(&p) {
+            Ok(resolved) => resolved,
             Err(_) => {
                 rejected += 1;
                 continue;
@@ -3568,7 +3587,7 @@ fn scan_files_inner<F: FnMut(Vec<LocalFontEntry>) -> Result<(), String>>(
         if !canonical.is_file() {
             continue;
         }
-        if !seen.insert(normalize_canonical_path(&canonical.to_string_lossy())) {
+        if !seen.insert(canonical_key) {
             continue;
         }
 
@@ -4878,6 +4897,71 @@ mod tests {
     /// Renamed from `DB_TEST_LOCK` once the cancel tests revealed it
     /// wasn't DB-only.
     static SCAN_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn explicit_font_path_revalidates_a_canonical_target_with_bidi_control() {
+        let selected = if cfg!(windows) {
+            r"C:\selected\font.ttf"
+        } else {
+            "/selected/font.ttf"
+        };
+        // A filesystem alias can legitimately resolve a visually safe picker
+        // path to an existing filename containing U+202E. Unlike a literal
+        // `.` component, canonicalization does not normalize this issue shape
+        // away, so the injected target models a reachable post-resolution
+        // rejection without requiring symlink privileges in CI.
+        let resolved_with_bidi = if cfg!(windows) {
+            PathBuf::from("C:\\resolved\\font\u{202e}ttf.ttf")
+        } else {
+            PathBuf::from("/resolved/font\u{202e}ttf.ttf")
+        };
+        let mut canonicalizer_called = false;
+
+        let error = canonicalize_and_validate_explicit_font_path_with(selected, |received| {
+            canonicalizer_called = true;
+            assert_eq!(received, Path::new(selected));
+            Ok(resolved_with_bidi)
+        })
+        .expect_err("an unsafe canonical target must be rejected");
+
+        assert!(canonicalizer_called);
+        assert!(error.to_lowercase().contains("invalid"));
+    }
+
+    #[test]
+    fn explicit_font_path_returns_only_a_validated_normalized_target() {
+        let selected = if cfg!(windows) {
+            r"C:\selected\font.ttf"
+        } else {
+            "/selected/font.ttf"
+        };
+        #[cfg(windows)]
+        let canonical = PathBuf::from(r"\\?\C:\resolved\font.ttf");
+        #[cfg(not(windows))]
+        let canonical = PathBuf::from("/resolved/font.ttf");
+
+        let (resolved, normalized) =
+            canonicalize_and_validate_explicit_font_path_with(selected, |_| Ok(canonical.clone()))
+                .expect("a safe canonical target should validate");
+
+        assert_eq!(resolved, canonical);
+        #[cfg(windows)]
+        assert_eq!(normalized, r"C:\resolved\font.ttf");
+        #[cfg(not(windows))]
+        assert_eq!(normalized, "/resolved/font.ttf");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn explicit_font_path_rejects_ads_introduced_by_resolution() {
+        let error =
+            canonicalize_and_validate_explicit_font_path_with(r"C:\selected\font.ttf", |_| {
+                Ok(PathBuf::from(r"C:\resolved\font.ttf:payload"))
+            })
+            .expect_err("an ADS canonical target must be rejected");
+
+        assert!(error.to_lowercase().contains("colon"));
+    }
 
     fn cache_candidate(
         reason: ScanStopReason,

--- a/src-tauri/src/fonts.rs
+++ b/src-tauri/src/fonts.rs
@@ -275,6 +275,18 @@ static ALLOWED_FONT_PATHS: Lazy<Mutex<HashSet<(String, u32)>>> =
 static ALLOWED_CACHE_FONT_PATHS: Lazy<Mutex<HashSet<(String, u32)>>> =
     Lazy::new(|| Mutex::new(HashSet::new()));
 
+/// Serializes unit tests that mutate scan/session/provenance globals across
+/// both this module and the GUI font-cache command module.
+#[cfg(test)]
+static SCAN_TEST_LOCK: Mutex<()> = Mutex::new(());
+
+#[cfg(test)]
+pub(crate) fn lock_font_state_for_test() -> std::sync::MutexGuard<'static, ()> {
+    SCAN_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
 /// Session SQLite path for user-picked font sources. Commands open short-lived
 /// connections to this path instead of sharing a global Connection, which keeps
 /// the static state simple and avoids holding SQLite page caches for longer
@@ -3286,7 +3298,7 @@ fn scan_directory_collecting_impl(
             // run_refresh_fonts catches this and continues with the next
             // dir; without the cap, a malicious pack could hold hundreds
             // of MB to multi-GB of font metadata in memory before the
-            // `cache.replace_folder` write would even start.
+            // `cache.replace_source` write would even start.
             if entries.len() + batch.len() > MAX_CACHE_POPULATE_FACES {
                 return Err(format!(
                     "Source has more font faces than the persistent cache safely accepts \
@@ -3967,7 +3979,7 @@ fn register_font_path(path: &Path, font_index: u32) -> Result<FontLookupResult, 
     crate::util::validate_ipc_path(&canonical_string, "System font")?;
     insert_with_cap(
         &ALLOWED_FONT_PATHS,
-        "system",
+        ProvenanceSetKind::System,
         canonical_string.clone(),
         font_index,
     )?;
@@ -3979,15 +3991,36 @@ fn register_font_path(path: &Path, font_index: u32) -> Result<FontLookupResult, 
 
 /// Shared (path, face_index) insertion helper used by both provenance
 /// sets. `cache` is the target set; `canonical_string` and `face_index`
-/// are the entry. `label` distinguishes the set in error messages so
-/// a future "Too many registered font paths" report can be attributed
-/// to system fonts vs cache hits — without the label, both would
-/// report the same text and triage would have to dig into the caller.
+/// are the entry. The typed set kind keeps the recovery advice aligned
+/// with the operation that can actually clear that set.
 /// Enforces
 /// `MAX_PROVENANCE_CACHE_SIZE` per-set as a rollback-on-overflow contract.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum ProvenanceSetKind {
+    System,
+    Cache,
+}
+
+fn provenance_overflow_message(kind: ProvenanceSetKind) -> String {
+    let (label, recovery) = match kind {
+        ProvenanceSetKind::System => (
+            "system",
+            "Restart the app to clear the system-font registration set, then retry.",
+        ),
+        ProvenanceSetKind::Cache => (
+            "cache",
+            "Clear font sources or clear the font cache, then retry.",
+        ),
+    };
+    format!(
+        "Too many registered font paths in {label} set (> {MAX_PROVENANCE_CACHE_SIZE}). \
+         {recovery}"
+    )
+}
+
 fn insert_with_cap(
     cache: &Lazy<Mutex<HashSet<(String, u32)>>>,
-    label: &str,
+    kind: ProvenanceSetKind,
     canonical_string: String,
     face_index: u32,
 ) -> Result<(), String> {
@@ -4004,10 +4037,7 @@ fn insert_with_cap(
     if newly_added && set.len() > MAX_PROVENANCE_CACHE_SIZE {
         // Roll back the speculative insert so the cap is firm.
         set.remove(&entry);
-        return Err(format!(
-            "Too many registered font paths in {label} set (> {MAX_PROVENANCE_CACHE_SIZE}). \
-             Restart the app to clear the cache."
-        ));
+        return Err(provenance_overflow_message(kind));
     }
     Ok(())
 }
@@ -4068,7 +4098,7 @@ pub(crate) fn cache_provenance_contains(path: &str, face_index: u32) -> bool {
 /// type layer rather than by manual convention — narrative comments
 /// decay across refactors; types don't.
 ///
-/// Cache row paths are canonicalized upstream by `replace_folder`;
+/// Cache row paths are canonicalized upstream by `replace_source`;
 /// this function re-validates via `validate_ipc_path` anyway so a
 /// hostile `--cache-file` swap can't smuggle crafted bytes past the
 /// trust set.
@@ -4090,7 +4120,7 @@ pub fn register_cache_provenance(hit: &crate::font_cache::FontLookupResult) -> R
     })?;
     insert_with_cap(
         &ALLOWED_CACHE_FONT_PATHS,
-        "cache",
+        ProvenanceSetKind::Cache,
         hit.font_path().to_string(),
         face_index,
     )
@@ -4889,14 +4919,6 @@ fn subset_with_index(font_data: &[u8], index: u32, codepoints: &[u32]) -> Result
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Serializes any unit test that reads or mutates DB state, the
-    /// `ACTIVE_SCAN_ID` / `CANCEL_SCAN_ID` atomics, or both. cargo test
-    /// runs in parallel by default — without serialization, two tests
-    /// can race on `compare_exchange` / `fetch_max` and silently flake.
-    /// Renamed from `DB_TEST_LOCK` once the cancel tests revealed it
-    /// wasn't DB-only.
-    static SCAN_TEST_LOCK: Mutex<()> = Mutex::new(());
 
     #[test]
     fn explicit_font_path_revalidates_a_canonical_target_with_bidi_control() {
@@ -6438,6 +6460,24 @@ mod tests {
     // the suite stays parallel-safe.
 
     #[test]
+    fn provenance_overflow_messages_match_each_set_recovery_path() {
+        assert_eq!(
+            provenance_overflow_message(ProvenanceSetKind::Cache),
+            format!(
+                "Too many registered font paths in cache set (> {MAX_PROVENANCE_CACHE_SIZE}). \
+                 Clear font sources or clear the font cache, then retry."
+            )
+        );
+        assert_eq!(
+            provenance_overflow_message(ProvenanceSetKind::System),
+            format!(
+                "Too many registered font paths in system set (> {MAX_PROVENANCE_CACHE_SIZE}). \
+                 Restart the app to clear the system-font registration set, then retry."
+            )
+        );
+    }
+
+    #[test]
     fn cache_provenance_gate_rejects_unregistered_path() {
         let _guard = SCAN_TEST_LOCK.lock().unwrap();
         // Snapshot the set so we restore it post-test (other tests
@@ -6544,8 +6584,8 @@ mod tests {
         );
         let err_msg = overflow.unwrap_err();
         assert!(
-            err_msg.contains("cache"),
-            "error message must name the cache set, got: {err_msg}"
+            err_msg.contains("Clear font sources or clear the font cache, then retry."),
+            "cache-set overflow must name a reachable recovery action, got: {err_msg}"
         );
         // The speculative insert must have been rolled back — set
         // size unchanged.

--- a/src-tauri/src/safe_io.rs
+++ b/src-tauri/src/safe_io.rs
@@ -971,6 +971,35 @@ mod tests {
         dir
     }
 
+    fn scope_alias_paths(name: &str, file_name: &str) -> (PathBuf, PathBuf, PathBuf) {
+        let real_dir = temp_dir(name);
+        let resolved = real_dir.canonicalize().unwrap().join(file_name);
+
+        #[cfg(unix)]
+        let raw = {
+            use std::os::unix::fs::symlink;
+
+            let alias_root = temp_dir(&format!("{name}_alias"));
+            let alias = alias_root.join("selected");
+            symlink(&real_dir, &alias).unwrap();
+            alias.join(file_name)
+        };
+
+        #[cfg(windows)]
+        let raw = real_dir.join(file_name);
+
+        #[cfg(not(any(unix, windows)))]
+        let raw = real_dir.join(file_name);
+
+        #[cfg(any(unix, windows))]
+        assert_ne!(
+            raw, resolved,
+            "scope-alias fixture must change after resolution"
+        );
+
+        (real_dir, raw, resolved)
+    }
+
     #[test]
     fn output_exists_probe_reports_existing_and_missing_outputs() {
         let dir = temp_dir("exists_probe_basic");
@@ -1109,9 +1138,8 @@ mod tests {
 
     #[test]
     fn write_rechecks_scope_after_canonicalizing_existing_parent() {
-        let dir = temp_dir("write_scope_canonical_parent");
-        let raw_path = dir.join(".").join("out.ass");
-        let resolved_path = dir.canonicalize().unwrap().join("out.ass");
+        let (dir, raw_path, resolved_path) =
+            scope_alias_paths("write_scope_canonical_parent", "out.ass");
 
         let err = safe_write_text_file_inner(&raw_path.to_string_lossy(), "x", false, move |p| {
             p != resolved_path
@@ -1503,10 +1531,9 @@ mod tests {
 
     #[test]
     fn copy_rechecks_destination_scope_after_canonicalizing_existing_parent() {
-        let dir = temp_dir("copy_scope_canonical_parent");
+        let (dir, raw_dst, resolved_dst) =
+            scope_alias_paths("copy_scope_canonical_parent", "dst.ass");
         let src = dir.join("src.ass");
-        let raw_dst = dir.join(".").join("dst.ass");
-        let resolved_dst = dir.canonicalize().unwrap().join("dst.ass");
         fs::write(&src, b"payload").unwrap();
 
         let err = safe_copy_file_inner(
@@ -1662,10 +1689,9 @@ mod tests {
 
     #[test]
     fn rename_rechecks_destination_scope_after_canonicalizing_existing_parent() {
-        let dir = temp_dir("rename_scope_canonical_parent");
+        let (dir, raw_dst, resolved_dst) =
+            scope_alias_paths("rename_scope_canonical_parent", "dst.ass");
         let src = dir.join("src.ass");
-        let raw_dst = dir.join(".").join("dst.ass");
-        let resolved_dst = dir.canonicalize().unwrap().join("dst.ass");
         fs::write(&src, b"payload").unwrap();
 
         let err = safe_rename_file_inner(

--- a/src-tauri/src/safe_io.rs
+++ b/src-tauri/src/safe_io.rs
@@ -487,7 +487,11 @@ fn create_new_and_write_bytes(path: &Path, content: &[u8]) -> Result<(), String>
         .open(path)
         .map_err(|e| format!("Failed to create destination: {e}"))?;
     file.write_all(content)
-        .map_err(|e| format!("Failed to write destination: {e}"))
+        .map_err(|error| partial_output_error("write destination", &error))
+}
+
+fn partial_output_error(action: &str, error: &std::io::Error) -> String {
+    format!("Failed to {action}; a partial output may remain: {error}")
 }
 
 fn check_plain_text_size(content_len: usize) -> Result<(), String> {
@@ -507,12 +511,10 @@ fn create_new_and_write_bytes_exclusive(path: &Path, content: &[u8]) -> Result<(
     // Keep a partial create-new file if write_all fails. Deleting by pathname
     // after closing would race with another process replacing that pathname,
     // which could make error cleanup delete a file we did not create.
-    file.write_all(content).map_err(|error| {
-        format!("Failed to write destination; a partial output may remain: {error}")
-    })?;
-    file.sync_all().map_err(|error| {
-        format!("Failed to flush destination; a partial output may remain: {error}")
-    })
+    file.write_all(content)
+        .map_err(|error| partial_output_error("write destination", &error))?;
+    file.sync_all()
+        .map_err(|error| partial_output_error("flush destination", &error))
 }
 
 fn encode_text_preserving_source(
@@ -796,7 +798,7 @@ pub fn safe_copy_file_inner(
         .map_err(|e| format!("Failed to create destination: {e}"))?;
     std::io::copy(&mut source, &mut destination)
         .map(|_| ())
-        .map_err(|e| format!("Failed to copy file: {e}"))
+        .map_err(|error| partial_output_error("copy file", &error))
 }
 
 /// File-preserving renames intentionally have no decoded-text size cap: they
@@ -998,6 +1000,19 @@ mod tests {
         );
 
         (real_dir, raw, resolved)
+    }
+
+    #[test]
+    fn partial_output_errors_are_explicit_without_claiming_residue_exists() {
+        let error = std::io::Error::other("injected write failure");
+        assert_eq!(
+            partial_output_error("write destination", &error),
+            "Failed to write destination; a partial output may remain: injected write failure"
+        );
+        assert_eq!(
+            partial_output_error("copy file", &error),
+            "Failed to copy file; a partial output may remain: injected write failure"
+        );
     }
 
     #[test]

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -48,6 +48,8 @@ pub const MAX_IPC_PATH_LEN: usize = 4096;
 ///    paths on disk and bypass `normalizeOutputKey`'s within-batch
 ///    dedup (it does NFC + slash + lowercase but not zero-width strip).
 ///    Reject at this boundary so they never reach IPC consumers.
+/// 5. Reserved Windows namespaces / device names, exact `.` / `..`
+///    components, and (on Windows) colons outside a leading drive prefix.
 ///
 /// Unicode noncharacters (U+FFFE, U+FFFF, U+FDD0..=U+FDEF) are
 /// intentionally not rejected — Windows file APIs already error with
@@ -135,7 +137,42 @@ pub fn validate_ipc_path(path: &str, label: &str) -> Result<(), String> {
     if is_dos_device || is_verbatim_drive {
         return Err(format!("{label} path uses a reserved device namespace"));
     }
-    // Reject `..` path components . A raw IPC
+    // On Windows, a colon is only valid as the separator in the first
+    // drive-prefix component (`C:`). Any other colon can select an NTFS
+    // alternate data stream (ADS), for example
+    // `C:\fonts\safe.ttf:payload`, while ordinary drive-rooted and UNC
+    // paths contain no such component. Keep this Windows-only: `:` is a
+    // legitimate filename character on POSIX filesystems.
+    #[cfg(windows)]
+    {
+        let has_non_drive_colon = path.split(['/', '\\']).enumerate().any(|(index, segment)| {
+            if !segment.contains(':') {
+                return false;
+            }
+            let bytes = segment.as_bytes();
+            let is_drive_prefix = index == 0
+                && bytes.len() == 2
+                && bytes[0].is_ascii_alphabetic()
+                && bytes[1] == b':';
+            !is_drive_prefix
+        });
+        if has_non_drive_colon {
+            return Err(format!(
+                "{label} path contains a colon outside the drive prefix"
+            ));
+        }
+    }
+
+    // Reject exact `.` path components. Besides matching the TypeScript
+    // boundary, this prevents two textual paths for the same target from
+    // reaching policy / dedup checks in different forms. A dot inside a
+    // filename (`font..backup.ttf`) remains valid.
+    let has_dot_component = path.split(['/', '\\']).any(|segment| segment == ".");
+    if has_dot_component {
+        return Err(format!("{label} path contains current-directory segments"));
+    }
+
+    // Reject `..` path components. A raw IPC
     // path like `C:\Allowed\..\Denied\file.ass` matches an
     // `allow=**` fs:scope rule literally (the deny patterns like
     // `$HOME/.ssh/**` don't string-match a `..`-bearing path), so the
@@ -447,6 +484,15 @@ mod tests {
     }
 
     #[test]
+    fn validate_rejects_dot_segment_in_path() {
+        let windows = validate_ipc_path(r"C:\Allowed\.\file.ass", "Test").unwrap_err();
+        assert!(windows.to_lowercase().contains("current-directory"));
+
+        let posix = validate_ipc_path("/home/u/./file.ass", "Test").unwrap_err();
+        assert!(posix.to_lowercase().contains("current-directory"));
+    }
+
+    #[test]
     fn validate_rejects_dotdot_segment_in_path() {
         // Closes a fs:scope bypass: a raw `C:\Allowed\..\Denied\file.ass`
         // could pass an `allow=**` literal match and let the OS resolve the
@@ -539,6 +585,57 @@ mod tests {
             .expect("dotdot inside a name segment should pass");
         validate_ipc_path("/home/u/file..name.ass", "Test")
             .expect("dotdot inside a name segment should pass on POSIX shape too");
+    }
+
+    #[test]
+    fn validate_accepts_dot_inside_filename() {
+        validate_ipc_path(r"C:\fonts\font.backup.ttf", "Test")
+            .expect("a dot inside a filename should pass");
+        validate_ipc_path("/home/u/.../font.ttf", "Test")
+            .expect("a non-exact dotted component should pass");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn validate_rejects_ntfs_alternate_data_stream_components() {
+        for path in [
+            r"C:\fonts\sample.ttf:payload",
+            r"C:/fonts:payload/sample.ttf",
+            r"\\server\share\sample.ttf:payload",
+        ] {
+            let err = validate_ipc_path(path, "Test").unwrap_err();
+            assert!(
+                err.to_lowercase().contains("colon"),
+                "{path} should reject as an alternate-data-stream shape"
+            );
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn validate_accepts_windows_drive_and_unc_prefixes() {
+        for path in [
+            r"C:\fonts\sample.ttf",
+            r"z:/fonts/sample.ttf",
+            r"\\server\share\sample.ttf",
+        ] {
+            validate_ipc_path(path, "Test")
+                .unwrap_or_else(|error| panic!("{path} should validate: {error}"));
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn validate_rejects_drive_relative_path_as_non_prefix_colon() {
+        let error = validate_ipc_path(r"C:font.ttf", "Test").unwrap_err();
+        assert!(error.to_lowercase().contains("colon"));
+    }
+
+    #[cfg(not(windows))]
+    #[test]
+    fn validate_accepts_colon_in_posix_filename() {
+        validate_ipc_path("/fonts/sample:variant.ttf", "Test")
+            .expect("a colon is a legitimate POSIX filename character");
     }
 
     // ── validate_ipc_path: byte-prefix DOS-device check ──

--- a/src-tauri/tests/test_chain.rs
+++ b/src-tauri/tests/test_chain.rs
@@ -63,6 +63,17 @@ fn write_fixture(dir: &Path, name: &str) -> PathBuf {
     path
 }
 
+fn write_oversized_fixture(dir: &Path, name: &str) -> PathBuf {
+    let path = dir.join(name);
+    let oversized = "X".repeat(70_000);
+    let mut content = FIXTURE_ASS.to_string();
+    content.push_str(&format!(
+        "Dialogue: 0,0:00:07.00,0:00:08.00,Default,,0,0,0,,{oversized}\n"
+    ));
+    fs::write(&path, content).expect("failed to write oversized fixture");
+    path
+}
+
 /// Returns Some(reason) if the engine bundle is the missing-bundle
 /// stub from build.rs (which throws "Run `npm run build:engine`").
 /// Returns None when the real bundle is loaded and tests can proceed.
@@ -222,6 +233,124 @@ fn chain_dry_run_prints_plan_without_writing() {
     assert!(
         !dir.join("cat.hdr.shifted.ass").exists(),
         "dry-run must not write files"
+    );
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn chain_quiet_dry_run_emits_no_plan_output() {
+    let dir = temp_dir("quiet_dryrun");
+    let input = write_fixture(&dir, "cat.ass");
+
+    let output = Command::new(cli_path())
+        .args([
+            "--lang",
+            "en",
+            "--quiet",
+            "--dry-run",
+            "chain",
+            "shift",
+            "--offset",
+            "+2s",
+        ])
+        .arg(&input)
+        .output()
+        .expect("failed to run quiet chain dry-run");
+
+    assert!(
+        output.status.success(),
+        "quiet dry-run should succeed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "--quiet must suppress the dry-run plan: stdout={}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "--quiet dry-run should not emit informational stderr: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(!dir.join("cat.shifted.ass").exists());
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn chain_summary_counts_written_files_with_warnings() {
+    if let Some(reason) = engine_bundle_missing() {
+        panic!("engine bundle missing — run `npm run build:engine` first ({reason})");
+    }
+
+    let dir = temp_dir("warning_summary");
+    let input = write_oversized_fixture(&dir, "oversized.ass");
+    let output = Command::new(cli_path())
+        .args(["--lang", "en", "chain", "shift", "--offset", "+2s"])
+        .arg(&input)
+        .output()
+        .expect("failed to run warning-summary chain");
+
+    assert!(
+        output.status.success(),
+        "warning-carrying write should succeed: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("1 written with warnings / incomplete (1 warning(s))"),
+        "summary must aggregate successful writes with warnings: {stdout}"
+    );
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
+fn chain_self_overwrite_fails_before_the_exists_check() {
+    if let Some(reason) = engine_bundle_missing() {
+        panic!("engine bundle missing — run `npm run build:engine` first ({reason})");
+    }
+
+    let dir = temp_dir("self_overwrite");
+    let input = write_fixture(&dir, "cat.ass");
+    let before = fs::read(&input).expect("read input before self-overwrite probe");
+
+    let output = Command::new(cli_path())
+        .args([
+            "--lang",
+            "en",
+            "chain",
+            "--output-template",
+            "{name}{ext}",
+            "shift",
+            "--offset",
+            "+2s",
+        ])
+        .arg(&input)
+        .output()
+        .expect("failed to run self-overwrite probe");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "single-input self-overwrite must be a complete failure"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("refusing self-overwrite")
+            && stderr.contains("choose a different --output-template or --output-dir"),
+        "failure should precisely explain the input/output collision: {stderr}"
+    );
+    assert!(
+        !stdout.contains("already exists"),
+        "the exists check must not mask self-overwrite as a skip: {stdout}"
+    );
+    assert_eq!(
+        fs::read(&input).expect("read input after self-overwrite probe"),
+        before,
+        "self-overwrite refusal must leave the input byte-identical"
     );
 
     let _ = fs::remove_dir_all(dir);

--- a/src-tauri/tests/test_cli_diagnostics.rs
+++ b/src-tauri/tests/test_cli_diagnostics.rs
@@ -26,6 +26,16 @@ const MISSING_FONT_ASS: &str = concat!(
     "Dialogue: 0,0:00:01.00,0:00:03.00,Default,,0,0,0,,Hello world\n",
 );
 const MISSING_FONT_EMBEDDED_NAME: &str = "definitelymissingssahdrifyfont.ttf";
+const NO_FONT_ASS: &str = concat!(
+    "[Script Info]\n",
+    "ScriptType: v4.00+\n",
+    "\n",
+    "[V4+ Styles]\n",
+    "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding\n",
+    "\n",
+    "[Events]\n",
+    "Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text\n",
+);
 
 fn cli_path() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_ssahdrify-cli"))
@@ -45,6 +55,13 @@ fn temp_dir(label: &str) -> PathBuf {
 fn write_missing_font_ass(dir: &Path) -> PathBuf {
     let path = dir.join("missing-font.ass");
     fs::write(&path, MISSING_FONT_ASS).expect("failed to write fixture ASS");
+    path
+}
+
+fn write_bomless_utf16le(dir: &Path, name: &str, content: &str) -> PathBuf {
+    let path = dir.join(name);
+    let bytes: Vec<u8> = content.encode_utf16().flat_map(u16::to_le_bytes).collect();
+    fs::write(&path, bytes).expect("failed to write BOM-less UTF-16LE fixture");
     path
 }
 
@@ -306,6 +323,46 @@ fn diagnose_fonts_json_reports_successful_files_as_diagnosed() {
     assert!(
         !String::from_utf8_lossy(&output.stdout).contains("next actions"),
         "human next-action prose must not be mixed into JSON stdout"
+    );
+
+    let _ = fs::remove_dir_all(work);
+}
+
+#[test]
+fn diagnose_fonts_encoding_warning_does_not_downgrade_font_qa() {
+    if let Some(reason) = engine_bundle_missing() {
+        panic!("engine bundle missing — run `npm run build:engine` first ({reason})");
+    }
+
+    let work = temp_dir("encoding-warning-qa");
+    let input = write_bomless_utf16le(&work, "no-fonts.ass", NO_FONT_ASS);
+    let output = run_cli(&[
+        "--lang",
+        "en",
+        "--json",
+        "--no-cache",
+        "diagnose-fonts",
+        "--no-system-fonts",
+        input.to_str().unwrap(),
+    ]);
+
+    assert!(
+        output.status.success(),
+        "font-free BOM-less ASS should diagnose successfully: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout should be JSON diagnostics");
+    assert!(
+        value["warningCount"]
+            .as_u64()
+            .is_some_and(|count| count > 0),
+        "fixture should carry an encoding-inference warning: {value}"
+    );
+    assert_eq!(value["qa"]["fontReferenceCount"], 0);
+    assert_eq!(
+        value["qa"]["status"], "complete",
+        "general encoding warnings must not change the font-only QA verdict"
     );
 
     let _ = fs::remove_dir_all(work);

--- a/src-tauri/tests/test_cli_diagnostics.rs
+++ b/src-tauri/tests/test_cli_diagnostics.rs
@@ -505,7 +505,9 @@ fn diagnose_fonts_does_not_mutate_cache_file() {
     let before_shm = sqlite_sidecar_path(&cache, "-shm");
     let before_wal_modified = optional_modified(&before_wal);
     let before_shm_modified = optional_modified(&before_shm);
-    thread::sleep(Duration::from_millis(20));
+    // Some supported filesystems expose only 1-2 second mtime resolution.
+    // Match the cache integration suite's stable cross-filesystem interval.
+    thread::sleep(Duration::from_millis(2100));
 
     let diagnose = run_cli(&[
         "--lang",

--- a/src-tauri/tests/test_cli_rename.rs
+++ b/src-tauri/tests/test_cli_rename.rs
@@ -27,11 +27,28 @@ fn touch(dir: &Path, name: &str) {
     fs::write(dir.join(name), b"").expect("failed to write rename fixture");
 }
 
+fn write_fixture(dir: &Path, name: &str, content: &str) -> PathBuf {
+    let path = dir.join(name);
+    fs::write(&path, content.as_bytes()).expect("failed to write rename fixture");
+    path
+}
+
 fn run_cli(args: &[&str]) -> std::process::Output {
     Command::new(cli_path())
         .args(args)
         .output()
         .expect("failed to spawn ssahdrify-cli")
+}
+
+fn run_cli_owned(args: &[String]) -> std::process::Output {
+    Command::new(cli_path())
+        .args(args)
+        .output()
+        .expect("failed to spawn ssahdrify-cli")
+}
+
+fn push_path(args: &mut Vec<String>, path: &Path) {
+    args.push(path.to_string_lossy().into_owned());
 }
 
 fn parse_json_output(output: &std::process::Output) -> serde_json::Value {
@@ -139,6 +156,233 @@ fn rename_langs_all_alias_collision_fails_before_writes() {
             .iter()
             .all(|row| row["error"] == "duplicate output path in planned batch"),
         "all duplicate participants should fail before writes: {value:#}"
+    );
+
+    let _ = fs::remove_dir_all(work);
+}
+
+#[test]
+fn swap_conflicts_fail_before_io_for_all_modes_and_overwrite_settings() {
+    for mode in ["rename", "copy-to-video", "copy-to-chosen"] {
+        for overwrite in [false, true] {
+            let work = temp_dir(&format!("swap-{mode}-{overwrite}"));
+            let video_1080 = write_fixture(&work, "[Raw][Show][01][1080p].mkv", "video-1080");
+            let video_720 = write_fixture(&work, "[Raw][Show][01][720p].mkv", "video-720");
+            let sub_720 =
+                write_fixture(&work, "[Raw][Show][01][720p].ass", "subtitle-720-original");
+            let sub_1080 = write_fixture(
+                &work,
+                "[Raw][Show][01][1080p].ass",
+                "subtitle-1080-original",
+            );
+
+            let mut args = vec!["--lang".to_string(), "en".to_string(), "--json".to_string()];
+            if overwrite {
+                args.push("--overwrite".to_string());
+            }
+            if mode == "copy-to-chosen" {
+                args.push("--output-dir".to_string());
+                push_path(&mut args, &work);
+            }
+            args.extend(["rename".to_string(), "--mode".to_string(), mode.to_string()]);
+            push_path(&mut args, &video_1080);
+            push_path(&mut args, &video_720);
+            // Deliberately reverse the subtitle order. Both videos have the
+            // same episode key, so index pairing plans a two-file swap.
+            push_path(&mut args, &sub_720);
+            push_path(&mut args, &sub_1080);
+
+            let output = run_cli_owned(&args);
+            assert!(
+                !output.status.success(),
+                "unsafe {mode} swap must fail (overwrite={overwrite}): stderr={}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+            let value = parse_json_output(&output);
+            assert_eq!(value["written"], 0, "{value:#}");
+            assert_eq!(value["planned"], 0, "{value:#}");
+            assert_eq!(value["skipped"], 0, "{value:#}");
+            assert_eq!(value["failed"], 2, "{value:#}");
+            assert!(
+                value["results"]
+                    .as_array()
+                    .expect("results should be an array")
+                    .iter()
+                    .all(|row| row["status"] == "failed"
+                        && row["error"]
+                            == "subtitle is part of a planned conflict where an output targets a loaded subtitle input; no files in that conflicting chain were changed"),
+                "every swap participant should report the preflight conflict: {value:#}"
+            );
+            assert!(
+                value["results"]
+                    .as_array()
+                    .expect("results should be an array")
+                    .iter()
+                    .all(|row| row["warnings"]
+                        .as_array()
+                        .is_some_and(|warnings| warnings.iter().any(|warning| {
+                            warning
+                                == "pairing is ambiguous because multiple videos share the same season and episode; verify the selected subtitle"
+                        }))),
+                "the TypeScript pairing source should survive into JSON diagnostics: {value:#}"
+            );
+            assert_eq!(
+                fs::read_to_string(&sub_720).unwrap(),
+                "subtitle-720-original",
+                "{mode} overwrite={overwrite} changed the first source"
+            );
+            assert_eq!(
+                fs::read_to_string(&sub_1080).unwrap(),
+                "subtitle-1080-original",
+                "{mode} overwrite={overwrite} changed the second source"
+            );
+
+            let _ = fs::remove_dir_all(work);
+        }
+    }
+}
+
+#[test]
+fn three_row_chain_reports_every_participant_and_preserves_all_bytes() {
+    let work = temp_dir("three-chain-human");
+    let video_b = write_fixture(&work, "[RawB][Show][01][1080p].mkv", "video-b");
+    let video_c = write_fixture(&work, "[RawC][Show][01][720p].mkv", "video-c");
+    let video_d = write_fixture(&work, "[RawD][Show][01][480p].mkv", "video-d");
+    let sub_a = write_fixture(&work, "[RawA][Show][01][2160p].ass", "subtitle-a-original");
+    let sub_b = write_fixture(&work, "[RawB][Show][01][1080p].ass", "subtitle-b-original");
+    let sub_c = write_fixture(&work, "[RawC][Show][01][720p].ass", "subtitle-c-original");
+    let final_output = work.join("[RawD][Show][01][480p].ass");
+
+    let mut args = vec![
+        "--lang".to_string(),
+        "en".to_string(),
+        "--overwrite".to_string(),
+        "rename".to_string(),
+        "--mode".to_string(),
+        "rename".to_string(),
+    ];
+    for path in [&video_b, &video_c, &video_d, &sub_a, &sub_b, &sub_c] {
+        push_path(&mut args, path);
+    }
+
+    let output = run_cli_owned(&args);
+    assert!(!output.status.success(), "unsafe chain must fail");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stdout.contains("Done: 0 written, 0 planned, 0 skipped, 3 failed"),
+        "human summary should report every failed chain participant: {stdout}"
+    );
+    assert_eq!(
+        stderr
+            .matches("planned conflict where an output targets a loaded subtitle input")
+            .count(),
+        3,
+        "each chain participant should have a human-readable failure: {stderr}"
+    );
+    assert_eq!(
+        stderr
+            .matches(
+                "pairing is ambiguous because multiple videos share the same season and episode"
+            )
+            .count(),
+        3,
+        "the human report should surface every ambiguous pairing: {stderr}"
+    );
+    assert_eq!(fs::read_to_string(&sub_a).unwrap(), "subtitle-a-original");
+    assert_eq!(fs::read_to_string(&sub_b).unwrap(), "subtitle-b-original");
+    assert_eq!(fs::read_to_string(&sub_c).unwrap(), "subtitle-c-original");
+    assert!(
+        !final_output.exists(),
+        "chain tail output must not be created"
+    );
+
+    let _ = fs::remove_dir_all(work);
+}
+
+#[test]
+fn dry_run_still_fails_an_input_conflict_instead_of_planning_it() {
+    let work = temp_dir("swap-dry-run");
+    let video_1080 = write_fixture(&work, "[Raw][Show][01][1080p].mkv", "video-1080");
+    let video_720 = write_fixture(&work, "[Raw][Show][01][720p].mkv", "video-720");
+    let sub_720 = write_fixture(&work, "[Raw][Show][01][720p].ass", "subtitle-720-original");
+    let sub_1080 = write_fixture(
+        &work,
+        "[Raw][Show][01][1080p].ass",
+        "subtitle-1080-original",
+    );
+    let mut args = vec![
+        "--lang".to_string(),
+        "en".to_string(),
+        "--json".to_string(),
+        "--dry-run".to_string(),
+        "rename".to_string(),
+        "--mode".to_string(),
+        "copy-to-video".to_string(),
+    ];
+    for path in [&video_1080, &video_720, &sub_720, &sub_1080] {
+        push_path(&mut args, path);
+    }
+
+    let output = run_cli_owned(&args);
+    let value = parse_json_output(&output);
+    assert!(!output.status.success());
+    assert_eq!(value["planned"], 0, "{value:#}");
+    assert_eq!(value["failed"], 2, "{value:#}");
+    assert_eq!(
+        fs::read_to_string(&sub_720).unwrap(),
+        "subtitle-720-original"
+    );
+    assert_eq!(
+        fs::read_to_string(&sub_1080).unwrap(),
+        "subtitle-1080-original"
+    );
+
+    let _ = fs::remove_dir_all(work);
+}
+
+#[test]
+fn fail_fast_blocks_a_threatened_endpoint_before_it_can_move() {
+    let work = temp_dir("fail-fast-endpoint-first");
+    let video_d = write_fixture(&work, "[RawD][Show][01][480p].mkv", "video-d");
+    let video_b = write_fixture(&work, "[RawB][Show][01][1080p].mkv", "video-b");
+    let sub_b = write_fixture(&work, "[RawB][Show][01][1080p].ass", "subtitle-b-original");
+    let sub_a = write_fixture(&work, "[RawA][Show][01][2160p].ass", "subtitle-a-original");
+    let tail_output = work.join("[RawD][Show][01][480p].ass");
+
+    let mut args = vec![
+        "--lang".to_string(),
+        "en".to_string(),
+        "--json".to_string(),
+        "--overwrite".to_string(),
+        "--fail-fast".to_string(),
+        "rename".to_string(),
+        "--mode".to_string(),
+        "rename".to_string(),
+    ];
+    // Pair by index as B -> D first, then A -> B. Whole-plan preflight must
+    // flag the threatened B row before fail-fast enters the execution loop;
+    // otherwise it would move B to D before the later writer is rejected.
+    for path in [&video_d, &video_b, &sub_b, &sub_a] {
+        push_path(&mut args, path);
+    }
+
+    let output = run_cli_owned(&args);
+    let value = parse_json_output(&output);
+    assert!(!output.status.success());
+    assert_eq!(value["failed"], 1, "{value:#}");
+    assert_eq!(value["written"], 0, "{value:#}");
+    assert_eq!(value["abortedByFailFast"], true, "{value:#}");
+    assert_eq!(
+        value["results"].as_array().map(Vec::len),
+        Some(1),
+        "fail-fast should stop after the preflight-failed endpoint: {value:#}"
+    );
+    assert_eq!(fs::read_to_string(&sub_b).unwrap(), "subtitle-b-original");
+    assert_eq!(fs::read_to_string(&sub_a).unwrap(), "subtitle-a-original");
+    assert!(
+        !tail_output.exists(),
+        "the first endpoint must not be moved"
     );
 
     let _ = fs::remove_dir_all(work);

--- a/src-tauri/tests/test_cli_shift.rs
+++ b/src-tauri/tests/test_cli_shift.rs
@@ -289,6 +289,66 @@ fn comment_only_vtt_fails_without_creating_an_output() {
 }
 
 #[test]
+fn declared_microdvd_fps_drives_shift_and_is_preserved_verbatim() {
+    let root = temp_dir("microdvd-declared-shift");
+    let input = write_file(&root, "episode.sub", "{1}{1}25.000\r\n{25}{50}Hello\r\n");
+
+    let output = run_shift(&root, &[], &[&input]);
+
+    assert!(output.status.success(), "{}", combined_output(&output));
+    let shifted = fs::read_to_string(root.join("episode.shifted.sub"))
+        .expect("declared-FPS shifted output missing");
+    assert_eq!(shifted, "{1}{1}25.000\r\n{50}{75}Hello\r\n");
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn declared_microdvd_hdr_converts_one_cue_without_metadata_dialogue() {
+    let root = temp_dir("microdvd-declared-hdr");
+    let input = write_file(&root, "episode.sub", "{1}{1}25.000\n{25}{50}{\\an8}Hello\n");
+
+    let output = Command::new(cli_path())
+        .current_dir(&root)
+        .args(["--lang", "en", "hdr", "--eotf", "pq"])
+        .arg(&input)
+        .output()
+        .expect("failed to run HDR command");
+
+    assert!(output.status.success(), "{}", combined_output(&output));
+    let converted =
+        fs::read_to_string(root.join("episode.hdr.ass")).expect("declared-FPS HDR output missing");
+    assert_eq!(converted.matches("Dialogue:").count(), 1);
+    assert!(converted.contains("0:00:01.00,0:00:02.00"));
+    assert!(converted.contains("\\{\\\\an8\\}Hello"));
+    assert!(!converted.contains("25.000"));
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
+fn all_oversized_hdr_fails_without_creating_predicted_output() {
+    let root = temp_dir("all-oversized-hdr");
+    let oversized = "X".repeat(65_000);
+    let input = write_file(
+        &root,
+        "oversized.sub",
+        &format!("{{1}}{{1}}25\n{{25}}{{50}}{oversized}\n"),
+    );
+
+    let output = Command::new(cli_path())
+        .current_dir(&root)
+        .args(["--lang", "en", "hdr", "--eotf", "pq"])
+        .arg(&input)
+        .output()
+        .expect("failed to run HDR command");
+    let combined = combined_output(&output);
+
+    assert!(!output.status.success(), "{combined}");
+    assert!(combined.contains("all 1 cue(s) exceeded the 64000-character limit"));
+    assert!(!root.join("oversized.hdr.ass").exists());
+    let _ = fs::remove_dir_all(root);
+}
+
+#[test]
 fn bomless_utf16_inference_is_reported_and_converted_safely() {
     let root = temp_dir("bomless-utf16");
     let input = write_bomless_utf16le(&root, "episode.srt", VALID_SRT);

--- a/src-tauri/tests/test_font_cache.rs
+++ b/src-tauri/tests/test_font_cache.rs
@@ -250,6 +250,208 @@ fn refresh_fonts_with_no_cache_errors() {
 }
 
 #[test]
+fn refresh_fonts_rejects_json_even_when_quiet() {
+    let work = temp_dir("json_quiet_rejected");
+    let font_dir = make_font_dir(&work);
+    let cache = cache_path(&work);
+
+    let output = run_cli(&[
+        "--quiet",
+        "--json",
+        "--cache-file",
+        cache.to_str().unwrap(),
+        "refresh-fonts",
+        "--font-dir",
+        font_dir.to_str().unwrap(),
+    ]);
+
+    assert_eq!(output.status.code(), Some(2));
+    assert!(
+        output.stdout.is_empty(),
+        "unsupported --json must never produce non-JSON stdout"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("refresh-fonts does not implement --json output"),
+        "hard error must survive --quiet: {stderr}"
+    );
+    assert!(
+        !cache.exists(),
+        "flag rejection must happen before cache I/O"
+    );
+
+    let _ = fs::remove_dir_all(work);
+}
+
+#[test]
+fn refresh_fonts_reports_verbose_as_inert() {
+    let work = temp_dir("verbose_inert");
+    let font_dir = make_font_dir(&work);
+    let cache = cache_path(&work);
+
+    let output = run_cli(&[
+        "--lang",
+        "en",
+        "--verbose",
+        "--cache-file",
+        cache.to_str().unwrap(),
+        "refresh-fonts",
+        "--font-dir",
+        font_dir.to_str().unwrap(),
+    ]);
+
+    assert!(
+        output.status.success(),
+        "--verbose should be a disclosed no-op, not a failure: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--verbose") && stderr.contains("no effect here"),
+        "refresh-fonts must not silently ignore --verbose: {stderr}"
+    );
+
+    let _ = fs::remove_dir_all(work);
+}
+
+#[test]
+fn refresh_fonts_corrupt_cache_names_path_and_offers_targeted_rebuild_in_both_open_modes() {
+    let work = temp_dir("corrupt_guidance");
+    let font_dir = make_font_dir(&work);
+    let cache = cache_path(&work);
+    let original = b"this is not a sqlite database";
+    fs::write(&cache, original).expect("write invalid cache fixture");
+
+    let dry_run = run_cli(&[
+        "--lang",
+        "en",
+        "--dry-run",
+        "--cache-file",
+        cache.to_str().unwrap(),
+        "refresh-fonts",
+        "--font-dir",
+        font_dir.to_str().unwrap(),
+    ]);
+    let normal = run_cli(&[
+        "--lang",
+        "en",
+        "--cache-file",
+        cache.to_str().unwrap(),
+        "refresh-fonts",
+        "--font-dir",
+        font_dir.to_str().unwrap(),
+    ]);
+
+    for (mode, output) in [("read-only dry-run", dry_run), ("read-write", normal)] {
+        assert_eq!(output.status.code(), Some(2), "mode={mode}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(cache.to_str().unwrap()),
+            "error must name the selected cache path in {mode}: {stderr}"
+        );
+        assert!(
+            stderr.contains("invalid or corrupt")
+                && stderr.contains("Delete the cache file")
+                && stderr.contains("rerun the same `refresh-fonts` command"),
+            "confirmed invalid SQLite should get precise rebuild guidance in {mode}: {stderr}"
+        );
+    }
+    assert_eq!(
+        fs::read(&cache).expect("read invalid cache after refusal"),
+        original,
+        "the CLI must not delete a corrupt cache automatically"
+    );
+
+    let _ = fs::remove_dir_all(work);
+}
+
+#[test]
+fn refresh_fonts_ordinary_open_error_does_not_recommend_deletion() {
+    let work = temp_dir("ordinary_open_error");
+    let font_dir = make_font_dir(&work);
+    let cache = cache_path(&work);
+    fs::create_dir(&cache).expect("create directory at cache-file path");
+
+    let output = run_cli(&[
+        "--lang",
+        "en",
+        "--cache-file",
+        cache.to_str().unwrap(),
+        "refresh-fonts",
+        "--font-dir",
+        font_dir.to_str().unwrap(),
+    ]);
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(cache.to_str().unwrap())
+            && stderr.contains("Check the cache path and file permissions"),
+        "ordinary I/O error should name its path and recovery boundary: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Delete the cache file")
+            && !stderr.contains("rerun the same `refresh-fonts` command"),
+        "permission/open failures must not receive destructive corruption guidance: {stderr}"
+    );
+
+    let _ = fs::remove_dir_all(work);
+}
+
+#[test]
+fn refresh_fonts_schema_mismatch_names_path_and_rerun_action() {
+    let work = temp_dir("schema_guidance");
+    let font_dir = make_font_dir(&work);
+    let cache = cache_path(&work);
+    drop(FontCache::open_or_create(&cache).expect("create current-schema cache"));
+    let connection = rusqlite::Connection::open(&cache).expect("open cache for schema mutation");
+    connection
+        .execute(
+            "UPDATE cache_meta SET value = '999' WHERE key = 'schema_version'",
+            [],
+        )
+        .expect("mutate schema version");
+    drop(connection);
+
+    let dry_run = run_cli(&[
+        "--lang",
+        "en",
+        "--dry-run",
+        "--cache-file",
+        cache.to_str().unwrap(),
+        "refresh-fonts",
+        "--font-dir",
+        font_dir.to_str().unwrap(),
+    ]);
+    let normal = run_cli(&[
+        "--lang",
+        "en",
+        "--cache-file",
+        cache.to_str().unwrap(),
+        "refresh-fonts",
+        "--font-dir",
+        font_dir.to_str().unwrap(),
+    ]);
+
+    for (mode, output) in [("read-only dry-run", dry_run), ("read-write", normal)] {
+        assert_eq!(output.status.code(), Some(2), "mode={mode}");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            stderr.contains(cache.to_str().unwrap())
+                && stderr.contains("requires schema version")
+                && stderr.contains("rerun the same `refresh-fonts` command"),
+            "schema mismatch should give a complete same-command recovery action in {mode}: {stderr}"
+        );
+        assert!(
+            !stderr.contains("(file:"),
+            "schema guidance must not end in the old dangling half-command in {mode}: {stderr}"
+        );
+    }
+
+    let _ = fs::remove_dir_all(work);
+}
+
+#[test]
 fn refresh_fonts_errors_when_every_source_is_skipped() {
     let work = temp_dir("all_skipped_refresh");
     let not_a_dir = work.join("not-a-dir.ttf");

--- a/src-tauri/tests/test_font_cache.rs
+++ b/src-tauri/tests/test_font_cache.rs
@@ -142,13 +142,13 @@ fn refresh_fonts_creates_cache_with_one_folder_row() {
 
     // Open via library API and inspect.
     let inspect = FontCache::open_or_create(&cache).expect("open cache for inspection");
-    let folders = inspect.list_folders().expect("list_folders");
+    let sources = inspect.list_sources().expect("list_sources");
     assert_eq!(
-        folders.len(),
+        sources.len(),
         1,
-        "expected exactly 1 cached folder, got {folders:?}"
+        "expected exactly 1 cached source, got {sources:?}"
     );
-    let stored = &folders[0].folder_path;
+    let stored = &sources[0].source_root;
     let canonical_str = cache_source_key(&font_dir, FontDirectoryScope::Shallow)
         .expect("derive normalized cache source key")
         .source_root;
@@ -182,11 +182,11 @@ fn refresh_fonts_idempotent_no_duplicate_folder_rows() {
     }
 
     let inspect = FontCache::open_or_create(&cache).expect("open cache");
-    let folders = inspect.list_folders().expect("list_folders");
+    let sources = inspect.list_sources().expect("list_sources");
     assert_eq!(
-        folders.len(),
+        sources.len(),
         1,
-        "two consecutive refreshes must yield exactly 1 row, got {folders:?}"
+        "two consecutive refreshes must yield exactly 1 row, got {sources:?}"
     );
 
     let _ = fs::remove_dir_all(work);

--- a/src-tauri/tests/test_real_fonts.rs
+++ b/src-tauri/tests/test_real_fonts.rs
@@ -588,19 +588,19 @@ fn real_font_package_refreshes_cache_and_diagnoses_cjk_fonts() {
     assert!(cache_path.exists(), "refresh-fonts did not create cache");
 
     let cache = FontCache::open_existing_read_only(&cache_path).expect("open cache read-only");
-    let cached_folders = cache.list_folders().expect("list cached folders");
+    let cached_sources = cache.list_sources().expect("list cached sources");
     assert_eq!(
-        cached_folders.len(),
+        cached_sources.len(),
         font_dirs.len(),
-        "refresh-fonts should write one row per representative font dir"
+        "refresh-fonts should write one source per representative font dir"
     );
     for dir in &font_dirs {
         let canonical = dir.canonicalize().expect("canonicalize font dir");
         let canonical = canonical.display().to_string();
         assert!(
-            cached_folders
+            cached_sources
                 .iter()
-                .any(|folder| folder.folder_path == canonical),
+                .any(|source| source.source_root == canonical),
             "cache did not include expected font dir: {canonical}"
         );
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { useStatus, type StatusTab } from "./lib/StatusContext";
 import { useClickOutside } from "./lib/useClickOutside";
 import { resolveAppModalVisibility } from "./lib/modal-coordination";
 import { TAB_LABEL_KEYS } from "./lib/tab-labels";
+import { completeFontCacheProbe } from "./lib/font-cache-ui-state";
 import {
   openFontCache,
   detectFontCacheDrift,
@@ -84,32 +85,24 @@ function App() {
   // Persistent font cache (#5): launch-time drift check. Probe the
   // cache, and if it exists with drift OR with a schema mismatch,
   // surface the FontCacheDriftModal so the user picks rescan / use
-  // as-is / clear. The cacheChecked ref guards against StrictMode's
-  // intentional double-mount in dev — drift queries are read-only
-  // but rescan_drifted writes; no need to double-do that.
-  //
-  // (comment accuracy): `useRef` is per-component-
-  // instance, not module-scoped — multi-instance App rendering would
-  // give each instance its own `cacheChecked` ref and each would run
-  // the launch check independently (redundant cache I/O), NOT skip
-  // the check for all but the first. Prior comment had the semantics
-  // inverted. The real concern (if a future routing refactor ever
-  // mounts App in multiple places) is redundant per-instance launch
-  // checks, not the suppression of subsequent ones.
+  // as-is / clear. cacheChecked is latched only by a live completed
+  // effect instance: React StrictMode cancels its first development
+  // setup, and that cancelled setup must not suppress the second one.
   const [cacheStatus, setCacheStatus] = useState<FontCacheStatus | null>(null);
+  const [cacheProbeFailed, setCacheProbeFailed] = useState(false);
   const [cacheDrift, setCacheDrift] = useState<FontCacheDriftReport | null>(null);
   const [showCacheModal, setShowCacheModal] = useState(false);
   const cacheChecked = useRef(false);
 
   useEffect(() => {
     if (cacheChecked.current) return;
-    cacheChecked.current = true;
     let cancelled = false;
-    (async () => {
+    void (async () => {
       try {
         const status = await openFontCache();
         if (cancelled) return;
         setCacheStatus(status);
+        setCacheProbeFailed(false);
         if (status.schemaMismatch) {
           // Empty drift: cache file is unreadable, modal renders the
           // rebuild-required path (Clear cache button only).
@@ -127,27 +120,26 @@ function App() {
           // Nothing actionable to surface; fall back to system fonts.
           return;
         }
-        const drift = await detectFontCacheDrift();
-        if (cancelled) return;
-        setCacheDrift(drift);
-        if (drift.modified.length > 0 || drift.removed.length > 0) {
-          // dropped a redundant `if (cancelled)
-          // return` here for the same reason as the schemaMismatch
-          // branch above — no await fires between the post-
-          // `detectFontCacheDrift` cancel check (`if (cancelled)
-          // return` a few lines above) and this synchronous setter
-          // pair. The previous comment misstated React's flush
-          // semantics (setState does not yield mid-call).
-          setShowCacheModal(true);
+        try {
+          const drift = await detectFontCacheDrift();
+          if (cancelled) return;
+          setCacheDrift(drift);
+          if (drift.modified.length > 0 || drift.removed.length > 0) {
+            setShowCacheModal(true);
+          }
+        } catch (e) {
+          if (!cancelled) {
+            console.warn("Font cache drift check failed; cached fonts remain available:", e);
+          }
         }
       } catch (e) {
-        // Don't block app launch on cache probe failures — the user
-        // can still use the app, embed just falls through to system
-        // fonts. Log so devs see it during tauri dev.
-        // WARN names the user-visible consequence (embed falls back
-        // to system fonts) instead of leaking only the internal
-        // function name.
-        console.warn("Font cache unavailable at launch; embed will use system fonts only:", e);
+        if (!cancelled) {
+          setCacheStatus(null);
+          setCacheProbeFailed(true);
+          console.warn("Font cache unavailable at launch; embed will use system fonts only:", e);
+        }
+      } finally {
+        completeFontCacheProbe(cacheChecked, cancelled);
       }
     })();
     return () => {
@@ -168,13 +160,11 @@ function App() {
     try {
       const status = await openFontCache();
       setCacheStatus(status);
+      setCacheProbeFailed(false);
     } catch (e) {
-      // WARN names the user-visible consequence.
-      // A failed re-probe means the launch-time `cacheStatus` is now
-      // stale relative to the user's just-performed action (Rescan /
-      // Clear); the drift modal won't auto-re-pop and embed continues
-      // to use whatever the prior probe captured.
-      console.warn("Font cache status re-probe failed; UI may show stale cache state:", e);
+      setCacheStatus(null);
+      setCacheProbeFailed(true);
+      console.warn("Font cache status re-probe failed; embed will use system fonts only:", e);
     }
   }, []);
 
@@ -452,7 +442,7 @@ function App() {
             aria-hidden={activeTab !== "fonts"}
             style={{ display: activeTab === "fonts" ? "block" : "none" }}
           >
-            <FontEmbed />
+            <FontEmbed cacheStatus={cacheStatus} cacheProbeFailed={cacheProbeFailed} />
           </div>
           <div
             id="panel-rename"

--- a/src/cli-engine-entry.test.ts
+++ b/src/cli-engine-entry.test.ts
@@ -192,6 +192,43 @@ describe("planRename", () => {
       noOp: true,
     });
   });
+
+  it("marks both endpoints of an ambiguous two-file rename swap", () => {
+    const video1080 = "C:\\media\\[Raw][Show][01][1080p].mkv";
+    const video720 = "C:\\media\\[Raw][Show][01][720p].mkv";
+    const sub720 = "C:\\media\\[Raw][Show][01][720p].ass";
+    const sub1080 = "C:\\media\\[Raw][Show][01][1080p].ass";
+
+    const plan = planRename({
+      paths: [video1080, video720, sub720, sub1080],
+      mode: "rename",
+      langs: "auto",
+    });
+
+    expect(plan.pairings.map((row) => row.inputPath)).toEqual([sub720, sub1080]);
+    expect(plan.pairings.map((row) => row.outputPath)).toEqual([sub1080, sub720]);
+    expect(plan.pairings.map((row) => row.source)).toEqual(["warning", "warning"]);
+    expect(plan.pairings.map((row) => row.inputConflict)).toEqual([true, true]);
+  });
+
+  it("protects a loaded subtitle that auto pairing leaves without a row", () => {
+    const video = "C:\\media\\[Raw][Show][01][1080p].mkv";
+    const chosenSub = "C:\\media\\[Subs][Show][01][source].ass";
+    const unpairedProtectedSub = "C:\\media\\[Raw][Show][01][1080p].ass";
+
+    const plan = planRename({
+      paths: [video, chosenSub, unpairedProtectedSub],
+      mode: "copy_to_video",
+      langs: "auto",
+    });
+
+    expect(plan.pairings).toHaveLength(1);
+    expect(plan.pairings[0]).toMatchObject({
+      inputPath: chosenSub,
+      outputPath: unpairedProtectedSub,
+      inputConflict: true,
+    });
+  });
 });
 
 describe("time shift timing-map engine helpers", () => {

--- a/src/cli-engine-entry.test.ts
+++ b/src/cli-engine-entry.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 
 import {
   applyFontEmbed,
+  convertHdr,
   convertShift,
   parseTimingMap,
   planFontEmbed,
@@ -231,6 +232,33 @@ describe("planRename", () => {
   });
 });
 
+describe("HDR text-cue engine helpers", () => {
+  it("converts declared-FPS MicroDVD through the CLI surface without a metadata Dialogue", () => {
+    const result = convertHdr({
+      inputPath: "C:\\subs\\sample.sub",
+      content: "{1}{1}25.000\n{25}{50}{\\an8}Hello\n",
+      eotf: "PQ",
+    });
+    const dialogues = result.content.split("\n").filter((line) => line.startsWith("Dialogue:"));
+
+    expect(result.skippedCount).toBe(0);
+    expect(dialogues).toHaveLength(1);
+    expect(dialogues[0]).toContain("0:00:01.00,0:00:02.00");
+    expect(dialogues[0]).toContain("\\{\\\\an8\\}Hello");
+    expect(result.content).not.toContain("25.000");
+  });
+
+  it("throws when every parsed text cue is oversized", () => {
+    expect(() =>
+      convertHdr({
+        inputPath: "C:\\subs\\sample.sub",
+        content: `{1}{1}25\n{25}{50}${"X".repeat(65_000)}\n`,
+        eotf: "PQ",
+      })
+    ).toThrow(/all 1 cue.*64000/i);
+  });
+});
+
 describe("time shift timing-map engine helpers", () => {
   it("parses timing maps and converts through the CLI engine surface", () => {
     const map = parseTimingMap({
@@ -274,6 +302,18 @@ describe("time shift timing-map engine helpers", () => {
         "",
       ].join("\n")
     );
+  });
+
+  it("uses and preserves a MicroDVD FPS declaration for standalone shift", () => {
+    const result = convertShift({
+      inputPath: "C:\\subs\\sample.sub",
+      content: "{1}{1}25.000\r\n{25}{50}Hello\r\n",
+      offsetMs: 1000,
+    });
+
+    expect(result.captionCount).toBe(1);
+    expect(result.shiftedCount).toBe(1);
+    expect(result.content).toBe("{1}{1}25.000\r\n{50}{75}Hello\r\n");
   });
 
   it("treats a runtime-null threshold as absent for a timing-map shift", () => {

--- a/src/cli-engine-entry.test.ts
+++ b/src/cli-engine-entry.test.ts
@@ -57,6 +57,23 @@ describe("planRename", () => {
     });
   });
 
+  it("auto mode pairs a mixed language-suffix and revision-tail batch", () => {
+    const videoOne = "C:\\media\\Show - 01v2.mkv";
+    const videoTwo = "C:\\media\\Show.S01E02v3.mkv";
+    const subtitleOne = "C:\\subs\\Show - 01.sc.ass";
+    const subtitleTwo = "C:\\subs\\Show.S01E02v1.eng.ass";
+
+    const plan = planRename({
+      paths: [videoOne, videoTwo, subtitleOne, subtitleTwo],
+      mode: "copy_to_video",
+      langs: "auto",
+    });
+
+    expect(plan.pairings.map((row) => row.inputPath)).toEqual([subtitleOne, subtitleTwo]);
+    expect(plan.pairings.map((row) => row.videoPath)).toEqual([videoOne, videoTwo]);
+    expect(plan.pairings.map((row) => row.language)).toEqual(["sc", "en"]);
+  });
+
   it("filters explicit language aliases before planning", () => {
     const plan = planRename({
       paths: [video, subSc, subTc, subJp],

--- a/src/cli-engine-entry.ts
+++ b/src/cli-engine-entry.ts
@@ -13,6 +13,7 @@ import {
   buildPairings,
   compareKeys,
   deriveRenameOutputPath,
+  findRenameInputConflictIndexes,
   isNoOpRename,
   parseFilename,
   type OutputMode,
@@ -137,6 +138,9 @@ export interface RenamePlanRow {
   key: string;
   language: string;
   noOp: boolean;
+  /** True when this executable row is connected to a planned output that
+   * targets any loaded subtitle input. The native shell fails it before I/O. */
+  inputConflict: boolean;
 }
 
 export interface FontEmbedPlanRequest {
@@ -320,33 +324,42 @@ export function planRename(request: RenamePlanRequest): RenamePlanResult {
       : buildMultiLanguageRenameCandidates(videos, filteredSubtitles);
   const preserveLanguageSuffix = selection.kind !== "auto";
 
+  const pairingsWithoutConflicts = candidates.map((candidate) => {
+    const outputPath = deriveRenameOutputPath(
+      candidate.video.path,
+      candidate.subtitle.path,
+      request.mode,
+      request.outputDir ?? null,
+      {
+        languageSuffix: preserveLanguageSuffix
+          ? subtitleLanguage(candidate.subtitle.name) || undefined
+          : undefined,
+      }
+    );
+    return {
+      inputPath: candidate.subtitle.path,
+      outputPath,
+      videoPath: candidate.video.path,
+      source: candidate.source,
+      key: candidate.key,
+      language: subtitleLanguage(candidate.subtitle.name),
+      noOp: isNoOpRename(candidate.subtitle.path, outputPath),
+    };
+  });
+  const inputConflictIndexes = findRenameInputConflictIndexes(
+    pairingsWithoutConflicts,
+    categorized.subtitles
+  );
+
   return {
     videoCount: videos.length,
     subtitleCount: subtitles.length,
     unknownCount: categorized.unknown.length,
     ignoredCount: categorized.ignored.length,
-    pairings: candidates.map((candidate) => {
-      const outputPath = deriveRenameOutputPath(
-        candidate.video.path,
-        candidate.subtitle.path,
-        request.mode,
-        request.outputDir ?? null,
-        {
-          languageSuffix: preserveLanguageSuffix
-            ? subtitleLanguage(candidate.subtitle.name) || undefined
-            : undefined,
-        }
-      );
-      return {
-        inputPath: candidate.subtitle.path,
-        outputPath,
-        videoPath: candidate.video.path,
-        source: candidate.source,
-        key: candidate.key,
-        language: subtitleLanguage(candidate.subtitle.name),
-        noOp: isNoOpRename(candidate.subtitle.path, outputPath),
-      };
-    }),
+    pairings: pairingsWithoutConflicts.map((pairing, index) => ({
+      ...pairing,
+      inputConflict: inputConflictIndexes.has(index),
+    })),
   };
 }
 

--- a/src/cli-engine-entry.ts
+++ b/src/cli-engine-entry.ts
@@ -2,10 +2,9 @@ import { parse as parseAss } from "ass-compiler";
 import { processAssContent } from "./features/hdr-convert/ass-processor";
 import {
   DEFAULT_STYLE,
-  buildAssDocumentFromCaptions,
+  convertTextCueSubtitleToAss,
   isConvertible,
   isNativeAss,
-  processSrtUserText,
 } from "./features/hdr-convert/srt-converter";
 import { DEFAULT_BRIGHTNESS, type Eotf } from "./features/hdr-convert/color-engine";
 import { DEFAULT_TEMPLATE, resolveOutputPath } from "./features/hdr-convert/output-naming";
@@ -41,7 +40,6 @@ import {
   substituteTemplate,
 } from "./lib/path-validation";
 import { categorizeForRename, type RenameCategory } from "./lib/rename-extensions";
-import { parseSubtitle } from "./lib/subtitle-parser";
 import { sanitizeError } from "./lib/dedup-helpers";
 import { stripUnicodeControls } from "./lib/unicode-controls";
 import { decodeBase64Bytes } from "./lib/base64-bytes";
@@ -239,15 +237,10 @@ export function convertHdr(request: HdrConversionRequest): HdrConversionResult {
   }
 
   if (isConvertible(fileName)) {
-    const preprocessed = processSrtUserText(request.content);
-    const { captions } = parseSubtitle(preprocessed, DEFAULT_STYLE.fps);
-    // Drop oversized-text placeholders before building ASS. parseSrt /
-    // parseSub / parseVtt emit `{ text: "", skipped: true }` for captions over
-    // MAX_CAPTION_TEXT_LEN; without this filter the
-    // CLI HDR path serializes each as a blank Dialogue line. Mirrors
-    // HdrConvert.tsx GUI-side filter. (parseAss placeholders don't
-    // reach here — `.ass` goes through the isNativeAss branch above.)
-    const { content: rawAss, skippedCount } = buildAssDocumentFromCaptions(captions, DEFAULT_STYLE);
+    const { content: rawAss, skippedCount } = convertTextCueSubtitleToAss(
+      request.content,
+      DEFAULT_STYLE
+    );
     return {
       outputPath,
       content: processAssContent(rawAss, brightness, request.eotf),

--- a/src/cli-engine-roundtrip.test.ts
+++ b/src/cli-engine-roundtrip.test.ts
@@ -28,10 +28,9 @@ import { DEFAULT_BRIGHTNESS, type Eotf } from "./features/hdr-convert/color-engi
 import { processAssContent } from "./features/hdr-convert/ass-processor";
 import {
   DEFAULT_STYLE,
-  buildAssDocumentFromCaptions,
+  convertTextCueSubtitleToAss,
   isConvertible,
   isNativeAss,
-  processSrtUserText,
 } from "./features/hdr-convert/srt-converter";
 import { DEFAULT_TEMPLATE, resolveOutputPath } from "./features/hdr-convert/output-naming";
 import { deriveShiftedPath, shiftSubtitles } from "./features/timing-shift/timing-engine";
@@ -41,7 +40,6 @@ import {
   deriveRenameOutputPath,
   parseFilename,
 } from "./features/batch-rename/pairing-engine";
-import { parseSubtitle } from "./lib/subtitle-parser";
 
 // ── Fixtures ─────────────────────────────────────────────
 
@@ -101,9 +99,7 @@ function guiHdrFlow(
   }
 
   if (isConvertible(fileName)) {
-    const preprocessed = processSrtUserText(content);
-    const { captions } = parseSubtitle(preprocessed, DEFAULT_STYLE.fps);
-    const { content: rawAss } = buildAssDocumentFromCaptions(captions, DEFAULT_STYLE);
+    const { content: rawAss } = convertTextCueSubtitleToAss(content, DEFAULT_STYLE);
     return { outputPath, content: processAssContent(rawAss, brightness, eotf) };
   }
 
@@ -114,6 +110,7 @@ describe("HDR convert — GUI ↔ CLI byte equivalence", () => {
   const inputAss = "C:\\subs\\episode01.ass";
   const inputSrt = "C:\\subs\\episode02.srt";
   const inputVtt = "C:\\subs\\episode03.vtt";
+  const inputSub = "C:\\subs\\episode04.sub";
 
   it("ASS path produces byte-identical output for shared (content, brightness, eotf)", () => {
     const cli = convertHdr({
@@ -158,6 +155,23 @@ describe("HDR convert — GUI ↔ CLI byte equivalence", () => {
     expect(cli.content).toBe(gui.content);
     expect(cli.content).toContain("Web");
     expect(cli.content).not.toContain("line:90%");
+  });
+
+  it("MicroDVD Auto FPS produces byte-identical GUI and CLI output", () => {
+    const content = "{1}{1}25.000\r\n{25}{50}Declared timing\r\n";
+    const cli = convertHdr({
+      inputPath: inputSub,
+      content,
+      eotf: "PQ",
+      brightness: 1000,
+      outputTemplate: DEFAULT_TEMPLATE,
+    });
+    const gui = guiHdrFlow(inputSub, content, "PQ", 1000, DEFAULT_TEMPLATE);
+
+    expect(cli.outputPath).toBe(gui.outputPath);
+    expect(cli.content).toBe(gui.content);
+    expect(cli.content).toContain("0:00:01.00,0:00:02.00");
+    expect(cli.content.match(/^Dialogue:/gm)).toHaveLength(1);
   });
 
   it("CLI applies DEFAULT_BRIGHTNESS when brightness is omitted, matching GUI default state", () => {
@@ -303,6 +317,17 @@ describe("Time shift — GUI ↔ CLI byte equivalence", () => {
 
     expect(cli.outputPath).toBe(deriveShiftedPath(input));
     expect(cli.content).toBe(guiResult.content);
+  });
+
+  it("MicroDVD declaration drives both GUI and CLI shift timing", () => {
+    const inputPath = "C:\\subs\\episode02.sub";
+    const content = "{1}{1}25.000\r\n{25}{50}Hello\r\n";
+    const cli = convertShift({ inputPath, content, offsetMs: 1000 });
+    const gui = shiftSubtitles(content, { offsetMs: 1000 });
+
+    expect(cli.content).toBe(gui.content);
+    expect(cli.content).toBe("{1}{1}25.000\r\n{50}{75}Hello\r\n");
+    expect(cli.captionCount).toBe(1);
   });
 });
 

--- a/src/features/batch-rename/BatchRename.tsx
+++ b/src/features/batch-rename/BatchRename.tsx
@@ -50,6 +50,7 @@ import {
   parseFilename,
   deriveRenameOutputPath,
   findDuplicateRenameOutputKeys,
+  findRenameInputConflictIndexes,
   isNoOpRename,
   assignSubtitleToRow,
   type PairingRow,
@@ -508,7 +509,7 @@ export default function BatchRename() {
       // count, hiding the skips during the moment the user can't see
       // the log).
       const derivedTargets: { row: PairingRow; outputPath: string }[] = [];
-      let skippedDeriveCount = 0;
+      let preflightFailedCount = 0;
       for (const row of actionableRows) {
         try {
           const outputPath = deriveRenameOutputPath(
@@ -530,13 +531,39 @@ export default function BatchRename() {
           // HDR / Timing / Embed already sanitize at every
           // addLog site, BatchRename was the outlier.
           addLog(t("msg_rename_skipped", sanitizeForDialog(row.subtitle!.name), reason), "error");
-          skippedDeriveCount += 1;
+          preflightFailedCount += 1;
         }
       }
       if (derivedTargets.length === 0) {
         addLog(t("msg_rename_nothing_to_do"), "error");
         return;
       }
+
+      // Input-conflict pre-flight. Detect executable edges against every
+      // loaded subtitle input, including no-op, unchecked, and unpaired rows:
+      // a planned output can otherwise overwrite user data or bytes a later
+      // row still needs. Mark both executable sides of every edge so swaps and
+      // longer chains fail as a unit before confirmation or filesystem access.
+      const inputConflictIndexes = findRenameInputConflictIndexes(
+        derivedTargets.map((target) => ({
+          inputPath: target.row.subtitle!.path,
+          outputPath: target.outputPath,
+        })),
+        subtitlePaths
+      );
+      const inputConflictTargets = derivedTargets.filter((_, index) =>
+        inputConflictIndexes.has(index)
+      );
+      for (const target of inputConflictTargets) {
+        addLog(
+          t("msg_rename_input_conflict", sanitizeForDialog(target.row.subtitle!.name)),
+          "error"
+        );
+      }
+      preflightFailedCount += inputConflictTargets.length;
+      const conflictFreeTargets = derivedTargets.filter(
+        (_, index) => !inputConflictIndexes.has(index)
+      );
 
       // No-op pre-flight. When a sub is already correctly named for its
       // paired video (e.g. raw-pack external-sub releases that ship subs
@@ -547,7 +574,7 @@ export default function BatchRename() {
       // through the regular flow.
       const noopTargets: { row: PairingRow; outputPath: string }[] = [];
       let targets: { row: PairingRow; outputPath: string }[] = [];
-      for (const tgt of derivedTargets) {
+      for (const tgt of conflictFreeTargets) {
         if (isNoOpRename(tgt.row.subtitle!.path, tgt.outputPath)) {
           noopTargets.push(tgt);
         } else {
@@ -559,7 +586,7 @@ export default function BatchRename() {
         addLog(t("msg_rename_already_named", sanitizeForDialog(tgt.row.subtitle!.name)), "info");
       }
       const duplicateOutputKeys = findDuplicateRenameOutputKeys(
-        derivedTargets.map((tgt) => tgt.outputPath)
+        conflictFreeTargets.map((tgt) => tgt.outputPath)
       );
       const duplicateTargets = targets.filter((tgt) =>
         duplicateOutputKeys.has(normalizeOutputKey(tgt.outputPath))
@@ -573,8 +600,11 @@ export default function BatchRename() {
         );
       }
       if (targets.length === 0) {
-        if (duplicateTargets.length > 0) {
-          addLog(t("msg_rename_all_failed", duplicateTargets.length), "error");
+        if (preflightFailedCount > 0 || duplicateTargets.length > 0) {
+          addLog(
+            t("msg_rename_all_failed", preflightFailedCount + duplicateTargets.length),
+            "error"
+          );
           setLastActionResult("error");
           return;
         }
@@ -611,7 +641,9 @@ export default function BatchRename() {
       // overwrite-branch callsite since the only consumer computes the
       // answer locally).
       const skippedSuffix =
-        skippedDeriveCount > 0 ? "\n\n" + t("msg_rename_skipped_count", skippedDeriveCount) : "";
+        preflightFailedCount > 0
+          ? "\n\n" + t("msg_rename_skipped_count", preflightFailedCount)
+          : "";
 
       if (outputMode === "rename") {
         // Strip BiDi overrides from filenames before rendering them in the
@@ -810,7 +842,17 @@ export default function BatchRename() {
     } finally {
       busyRef.current = false;
     }
-  }, [busy, actionableCount, actionableRows, outputMode, chosenDir, multiSubtitleMode, addLog, t]);
+  }, [
+    busy,
+    actionableCount,
+    actionableRows,
+    outputMode,
+    chosenDir,
+    multiSubtitleMode,
+    subtitlePaths,
+    addLog,
+    t,
+  ]);
 
   // Reset last-action on selection change.
   useEffect(() => {

--- a/src/features/batch-rename/BatchRename.tsx
+++ b/src/features/batch-rename/BatchRename.tsx
@@ -51,6 +51,11 @@ import {
   deriveRenameOutputPath,
   findDuplicateRenameOutputKeys,
   findRenameInputConflictIndexes,
+  findRenameOutputOwnershipConflictIndexes,
+  countUnpairedSubtitlePaths,
+  refreshRenameFilesAfterSuccessfulInPlaceRenames,
+  refreshPairingRowsAfterSuccessfulInPlaceRenames,
+  summarizeRenameRun,
   isNoOpRename,
   assignSubtitleToRow,
   type PairingRow,
@@ -148,7 +153,7 @@ export default function BatchRename() {
   const [busy, setBusy] = useState(false);
   const [progress, setProgress] = useState<{ processed: number; total: number } | null>(null);
   const [lastActionResult, setLastActionResult] = useState<
-    "success" | "error" | "cancelled" | "noop" | null
+    "success" | "partial" | "error" | "cancelled" | "noop" | null
   >(null);
   const [dropActive, setDropActive] = useState(false);
   const [dropError, setDropError] = useState<string | null>(null);
@@ -178,6 +183,14 @@ export default function BatchRename() {
   // a newer directory dialog must invalidate an older unresolved dialog.
   const chosenDirPickGenRef = useRef(0);
   const abortRef = useRef<AbortController | null>(null);
+  // A successful in-place run rewrites shared file identities. Skip exactly
+  // that resulting baseRows reset because the live row state is reconciled
+  // directly, preserving manual assignments and unchecked/failed-row intent.
+  const skipNextInternalBaseRowsResetRef = useRef(false);
+  // Keep the exact internally-skipped seed too. Development StrictMode can
+  // replay an effect; the replay must keep skipping that same seed without
+  // suppressing a later mode toggle or external picker selection.
+  const internallySkippedBaseRowsRef = useRef<PairingRow[] | null>(null);
   // Synchronous double-click guard — `busy` state lags setBusy(true) by
   // one render. busyRef is written synchronously at handler entry and
   // released in the outer finally so every exit path clears it.
@@ -219,10 +232,17 @@ export default function BatchRename() {
       : buildPairings(parsedVideos, parsedSubs);
   }, [videoPaths, videoNames, subtitlePaths, subtitleNames, multiSubtitleMode]);
 
-  // Reset edits when the input file lists change. baseRows only
-  // recomputes when the user re-picks / clears, so this isn't a
-  // surprise — it's an explicit "start fresh" point.
+  // Reset edits when an external selection re-picks / clears the file lists.
+  // A successful in-place operation also changes those lists, but reconciles
+  // live rows directly and arms the one-shot skip above so user intent stays.
   useEffect(() => {
+    if (skipNextInternalBaseRowsResetRef.current) {
+      skipNextInternalBaseRowsResetRef.current = false;
+      internallySkippedBaseRowsRef.current = baseRows;
+      return;
+    }
+    if (internallySkippedBaseRowsRef.current === baseRows) return;
+    internallySkippedBaseRowsRef.current = null;
     setEditedRows(baseRows);
   }, [baseRows]);
 
@@ -263,6 +283,10 @@ export default function BatchRename() {
   const warningCount = useMemo(
     () => pairingRows.filter((r) => r.source === "warning").length,
     [pairingRows]
+  );
+  const unpairedSubtitleCount = useMemo(
+    () => countUnpairedSubtitlePaths(subtitlePaths, pairingRows),
+    [subtitlePaths, pairingRows]
   );
 
   const pairingColumns = useMemo<PreviewTableColumn<PairingRow>[]>(
@@ -469,6 +493,7 @@ export default function BatchRename() {
     pickGenRef.current = pickGenRef.current + 1;
     chosenDirPickGenRef.current = chosenDirPickGenRef.current + 1;
     clearFile("rename");
+    setLastActionResult(null);
     setChosenDir(null);
     setUnknownCount(0);
     setDropError(null);
@@ -585,6 +610,33 @@ export default function BatchRename() {
         // Sanitize attacker-influenced filename.
         addLog(t("msg_rename_already_named", sanitizeForDialog(tgt.row.subtitle!.name)), "info");
       }
+
+      // A derived output can be a file currently loaded in HDR / Timing /
+      // Fonts / Style even though none of the Rename inputs use that path.
+      // Generic overwrite confirmation is not sufficient: replacing it would
+      // leave the owning tab with stale cached content. Reject those rows
+      // before any confirmation or filesystem operation.
+      const crossTabConflictIndexes = findRenameOutputOwnershipConflictIndexes(
+        targets,
+        (outputPath) => isFileInUse(outputPath, "rename") !== null
+      );
+      const crossTabConflictTargets = targets.filter((_, index) =>
+        crossTabConflictIndexes.has(index)
+      );
+      for (const target of crossTabConflictTargets) {
+        const reason = buildConflictMessage([target.outputPath], "rename", isFileInUse, t);
+        if (reason) {
+          addLog(
+            t("msg_rename_skipped", sanitizeForDialog(target.row.subtitle!.name), reason),
+            "error"
+          );
+        }
+      }
+      if (crossTabConflictTargets.length > 0) {
+        targets = targets.filter((_, index) => !crossTabConflictIndexes.has(index));
+        preflightFailedCount += crossTabConflictTargets.length;
+      }
+
       const duplicateOutputKeys = findDuplicateRenameOutputKeys(
         conflictFreeTargets.map((tgt) => tgt.outputPath)
       );
@@ -763,6 +815,7 @@ export default function BatchRename() {
         let successCount = 0;
         let processedCount = 0;
         const seenOutputs = new Set<string>();
+        const successfulInPlaceTargets: { inputPath: string; outputPath: string }[] = [];
 
         for (const { row, outputPath } of targets) {
           if (abortRef.current?.signal.aborted) {
@@ -800,6 +853,12 @@ export default function BatchRename() {
             }
             addLog(t("msg_rename_done", subName, outName), "success");
             successCount++;
+            if (outputMode === "rename") {
+              successfulInPlaceTargets.push({
+                inputPath: row.subtitle!.path,
+                outputPath,
+              });
+            }
           } catch (e) {
             const reason = sanitizeError(e);
             addLog(t("msg_rename_error", subName, reason), "error");
@@ -809,21 +868,46 @@ export default function BatchRename() {
           }
         }
 
-        // Avoid the success-log vs error-footer contradiction
-        // : when every row failed, the
-        // "Rename complete: 0/N" success line and the red
-        // "Rename failed" footer fired together — visually inconsistent
-        // signal. Split so success-log fires only when at least one row
-        // landed; full-batch failure gets its own error-log line.
+        // Rename mode consumes each successful source path. Refresh the
+        // shared FileContext only after the loop so partial failure/cancel
+        // keeps every untouched input stable. Cross-tab-owned outputs were
+        // rejected during preflight, so every produced path is safe to track.
+        if (successfulInPlaceTargets.length > 0) {
+          const refreshedRenameFiles = refreshRenameFilesAfterSuccessfulInPlaceRenames(
+            renameFiles,
+            successfulInPlaceTargets
+          );
+          if (refreshedRenameFiles !== renameFiles) {
+            skipNextInternalBaseRowsResetRef.current = true;
+            setEditedRows((rows) =>
+              refreshPairingRowsAfterSuccessfulInPlaceRenames(rows, successfulInPlaceTargets)
+            );
+            setRenameFiles(refreshedRenameFiles);
+          }
+        }
+
+        // Classify against executable + preflight-rejected rows. A batch with
+        // one write and one rejected/error row is partial, not a green 1/1
+        // success; a zero-write batch gets only the failure signal.
         const aborted = !!abortRef.current?.signal.aborted;
         if (aborted) {
           setLastActionResult("cancelled");
-        } else if (successCount > 0) {
-          addLog(t("msg_rename_complete", successCount, targets.length), "success");
-          setLastActionResult("success");
         } else {
-          addLog(t("msg_rename_all_failed", targets.length), "error");
-          setLastActionResult("error");
+          const summary = summarizeRenameRun(
+            successCount,
+            targets.length,
+            preflightFailedCount + duplicateTargets.length
+          );
+          if (summary.kind === "success") {
+            addLog(t("msg_rename_complete", successCount, summary.totalPlanned), "success");
+            setLastActionResult("success");
+          } else if (summary.kind === "partial") {
+            addLog(t("msg_rename_complete", successCount, summary.totalPlanned), "warn");
+            setLastActionResult("partial");
+          } else {
+            addLog(t("msg_rename_all_failed", summary.totalPlanned), "error");
+            setLastActionResult("error");
+          }
         }
       } catch (e) {
         // The default-branch throw inside the switch above (and any other
@@ -850,14 +934,12 @@ export default function BatchRename() {
     chosenDir,
     multiSubtitleMode,
     subtitlePaths,
+    renameFiles,
+    setRenameFiles,
+    isFileInUse,
     addLog,
     t,
   ]);
-
-  // Reset last-action on selection change.
-  useEffect(() => {
-    setLastActionResult(null);
-  }, [renameFiles]);
 
   const tabStatus = useMemo<Status>(() => {
     if (totalCount === 0) return { kind: "idle", message: t("status_rename_idle") };
@@ -869,6 +951,9 @@ export default function BatchRename() {
       };
     }
     if (lastActionResult === "success") return { kind: "done", message: t("status_rename_done") };
+    if (lastActionResult === "partial") {
+      return { kind: "pending", message: t("status_rename_partial") };
+    }
     if (lastActionResult === "error") return { kind: "error", message: t("status_rename_error") };
     if (lastActionResult === "cancelled") {
       return { kind: "pending", message: t("status_rename_cancelled") };
@@ -1165,6 +1250,11 @@ export default function BatchRename() {
                 <span style={{ color: "var(--warning)" }}>
                   {" · "}
                   {t("rename_grid_warning_suffix", warningCount)}
+                </span>
+              )}
+              {unpairedSubtitleCount > 0 && (
+                <span style={{ color: "var(--warning)" }}>
+                  {t("rename_grid_unpaired_subtitle_suffix", unpairedSubtitleCount)}
                 </span>
               )}
               <span className="flex-1" />

--- a/src/features/batch-rename/pairing-engine.test.ts
+++ b/src/features/batch-rename/pairing-engine.test.ts
@@ -24,6 +24,11 @@ import {
   deriveRenameOutputPath,
   findDuplicateRenameOutputKeys,
   findRenameInputConflictIndexes,
+  findRenameOutputOwnershipConflictIndexes,
+  countUnpairedSubtitlePaths,
+  refreshRenameFilesAfterSuccessfulInPlaceRenames,
+  refreshPairingRowsAfterSuccessfulInPlaceRenames,
+  summarizeRenameRun,
   isNoOpRename,
   assignSubtitleToRow,
   type PairingRow,
@@ -89,6 +94,17 @@ describe("extractEpisode — documented fan-sub samples", () => {
     expect(ep?.episode).toBe(3);
   });
 
+  it("Pattern A — accepts a known language suffix before the subtitle extension", () => {
+    const name = "Show - 01.sc.ass";
+    const ep = extractEpisode(name, bracketCleanup(name));
+    expect(ep?.episode).toBe(1);
+  });
+
+  it("Pattern A — rejects an unknown dotted suffix instead of treating it as a language tag", () => {
+    const name = "Show - 01.commentary.ass";
+    expect(extractEpisode(name, bracketCleanup(name))).toBeNull();
+  });
+
   it("Pattern B — SubD Sample Show [03]", () => {
     const name = "[SubD][Sample Show Title][03][1080p AVC AAC][CHT].mp4";
     const ep = extractEpisode(name, bracketCleanup(name));
@@ -103,6 +119,12 @@ describe("extractEpisode — documented fan-sub samples", () => {
 
   it("Pattern B — RawsX Show Title [01]", () => {
     const name = "[RawsX][Show Title][01][1080P][BDRip][HEVC-10bit][FLAC].sc.ass";
+    const ep = extractEpisode(name, bracketCleanup(name));
+    expect(ep?.episode).toBe(1);
+  });
+
+  it("Pattern B — skips a four-digit year and accepts the later revised episode", () => {
+    const name = "[Group][2024v2][Show Title][01v2][1080p].mkv";
     const ep = extractEpisode(name, bracketCleanup(name));
     expect(ep?.episode).toBe(1);
   });
@@ -132,6 +154,21 @@ describe("extractEpisode — Western fallbacks", () => {
 
   it("第N话 catches Chinese marker", () => {
     expect(extractEpisode("Show 第04话.ass", bracketCleanup("Show 第04话.ass"))?.episode).toBe(4);
+  });
+
+  it("accepts revision tails across every episode grammar", () => {
+    const cases: [string, number][] = [
+      ["Show.S01E05v2.1080p.mkv", 5],
+      ["[Group][Show][06v3][1080p].mkv", 6],
+      ["[Group] Show - 07V4 [1080p].mkv", 7],
+      ["Show - 08v5.ass", 8],
+      ["Show 第09v6话.ass", 9],
+      ["Show.EP10v7.mkv", 10],
+    ];
+
+    for (const [name, episode] of cases) {
+      expect(extractEpisode(name, bracketCleanup(name))?.episode, name).toBe(episode);
+    }
   });
 });
 
@@ -283,6 +320,16 @@ describe("parseFilename — end-to-end (season, episode)", () => {
 });
 
 describe("buildPairings — common shapes", () => {
+  it("pairs a mixed batch of language-suffixed and revision-tailed names", () => {
+    const videos = [parse("Show - 01v2 [1080p].mkv"), parse("Show.S01E02v3.1080p.mkv")];
+    const subtitles = [parse("Show - 01.sc.ass"), parse("Show.S01E02v1.eng.ass")];
+    const rows = buildPairings(videos, subtitles);
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((row) => row.subtitle?.path)).toEqual([subtitles[0]!.path, subtitles[1]!.path]);
+    expect(rows.map((row) => row.source)).toEqual(["regex", "regex"]);
+  });
+
   it("1 video + 2 subs (multi-language) → 1 row, first sub selected", () => {
     const v = parse("[Group][Show][01][1080p].mkv");
     const s1 = parse("[Group][Show][01][1080p].sc.ass");
@@ -511,6 +558,133 @@ describe("findRenameInputConflictIndexes", () => {
     );
 
     expect(Array.from(conflicts)).toEqual([0]);
+  });
+});
+
+describe("findRenameOutputOwnershipConflictIndexes", () => {
+  it("blocks only outputs owned by another tab before the filesystem loop", () => {
+    const targets = [
+      { inputPath: "C:/subs/one.ass", outputPath: "C:/out/free.ass" },
+      { inputPath: "C:/subs/two.ass", outputPath: "C:/out/loaded.ass" },
+      { inputPath: "C:/subs/three.ass", outputPath: "C:/out/also-free.ass" },
+    ];
+
+    const conflicts = findRenameOutputOwnershipConflictIndexes(
+      targets,
+      (outputPath) => outputPath === "C:/out/loaded.ass"
+    );
+
+    expect(Array.from(conflicts)).toEqual([1]);
+  });
+});
+
+describe("summarizeRenameRun", () => {
+  it("reports complete only when every planned row succeeds", () => {
+    expect(summarizeRenameRun(2, 2, 0)).toEqual({ kind: "success", totalPlanned: 2 });
+  });
+
+  it("includes preflight and runtime failures in partial-run arithmetic", () => {
+    expect(summarizeRenameRun(1, 1, 1)).toEqual({ kind: "partial", totalPlanned: 2 });
+    expect(summarizeRenameRun(1, 2, 0)).toEqual({ kind: "partial", totalPlanned: 2 });
+  });
+
+  it("reports an all-failed batch against the full planned denominator", () => {
+    expect(summarizeRenameRun(0, 2, 1)).toEqual({ kind: "error", totalPlanned: 3 });
+  });
+});
+
+describe("countUnpairedSubtitlePaths", () => {
+  it("counts unique loaded subtitles that have no pairing row", () => {
+    const video = parse("Show - 01.mkv");
+    const paired = parse("Show - 01.sc.ass");
+    const hidden = parse("Bonus commentary.ass");
+    const rows = buildPairings([video], [paired, hidden]);
+
+    expect(countUnpairedSubtitlePaths([paired.path, hidden.path, hidden.path], rows)).toBe(1);
+  });
+
+  it("reports a duplicated row owner as not uniquely paired", () => {
+    const video = parse("Show - 01.mkv");
+    const subtitle = parse("Show - 01.sc.ass");
+    const row = buildPairings([video], [subtitle])[0]!;
+
+    expect(countUnpairedSubtitlePaths([subtitle.path], [row, { ...row, id: "duplicate" }])).toBe(1);
+  });
+});
+
+describe("refreshRenameFilesAfterSuccessfulInPlaceRenames", () => {
+  it("updates only successful inputs and makes the next run an honest no-op", () => {
+    const state = {
+      videoPaths: ["C:/video/Show - 01.mkv", "C:/video/Show - 02.mkv"],
+      videoNames: ["Show - 01.mkv", "Show - 02.mkv"],
+      subtitlePaths: ["C:/subs/old - 01.ass", "C:/subs/old - 02.ass", "C:/subs/unselected.ass"],
+      subtitleNames: ["old - 01.ass", "old - 02.ass", "unselected.ass"],
+    };
+    const outputPath = "C:/subs/Show - 01.ass";
+
+    const refreshed = refreshRenameFilesAfterSuccessfulInPlaceRenames(state, [
+      { inputPath: state.subtitlePaths[0]!, outputPath },
+    ])!;
+
+    expect(refreshed.subtitlePaths).toEqual([
+      outputPath,
+      state.subtitlePaths[1],
+      state.subtitlePaths[2],
+    ]);
+    expect(refreshed.subtitleNames).toEqual(["Show - 01.ass", "old - 02.ass", "unselected.ass"]);
+    expect(state.subtitlePaths[0]).toBe("C:/subs/old - 01.ass");
+
+    const secondRunRows = buildPairings(
+      [parseFilename(refreshed.videoPaths[0]!, refreshed.videoNames[0]!)],
+      [parseFilename(refreshed.subtitlePaths[0]!, refreshed.subtitleNames[0]!)]
+    );
+    const secondOutput = deriveRenameOutputPath(
+      secondRunRows[0]!.video!.path,
+      secondRunRows[0]!.subtitle!.path,
+      "rename",
+      null
+    );
+    expect(isNoOpRename(secondRunRows[0]!.subtitle!.path, secondOutput)).toBe(true);
+  });
+
+  it("returns the original state when no successful input is currently loaded", () => {
+    const state = {
+      videoPaths: ["C:/video/Show - 01.mkv", "C:/video/Show - 02.mkv"],
+      videoNames: ["Show - 01.mkv", "Show - 02.mkv"],
+      subtitlePaths: ["C:/subs/old - 01.ass", "C:/subs/old - 02.ass"],
+      subtitleNames: ["old - 01.ass", "old - 02.ass"],
+    };
+
+    const refreshed = refreshRenameFilesAfterSuccessfulInPlaceRenames(state, [
+      { inputPath: "C:/subs/already-removed.ass", outputPath: "C:/subs/new.ass" },
+    ]);
+
+    expect(refreshed).toBe(state);
+  });
+});
+
+describe("refreshPairingRowsAfterSuccessfulInPlaceRenames", () => {
+  it("rewrites only successful subtitles while preserving manual and checkbox intent", () => {
+    const videos = [parse("Show - 01.mkv"), parse("Show - 02.mkv")];
+    const subtitles = [parse("old - 01.ass"), parse("old - 02.ass")];
+    const seed = buildPairings(videos, subtitles);
+    const rows: PairingRow[] = [
+      { ...seed[0]!, source: "manual", selected: true },
+      { ...seed[1]!, source: "manual", selected: false },
+    ];
+
+    const refreshed = refreshPairingRowsAfterSuccessfulInPlaceRenames(rows, [
+      { inputPath: subtitles[0]!.path, outputPath: "/dummy/Show - 01.ass" },
+    ]);
+
+    expect(refreshed[0]).toMatchObject({
+      id: rows[0]!.id,
+      source: "manual",
+      selected: true,
+      subtitle: { path: "/dummy/Show - 01.ass", name: "Show - 01.ass" },
+    });
+    expect(refreshed[1]).toBe(rows[1]);
+    expect(refreshed[1]).toMatchObject({ source: "manual", selected: false });
   });
 });
 

--- a/src/features/batch-rename/pairing-engine.test.ts
+++ b/src/features/batch-rename/pairing-engine.test.ts
@@ -13,6 +13,7 @@
  * "simplification" can't quietly regress the fan-sub paths.
  */
 import { describe, it, expect } from "vitest";
+import { isWindowsRuntime } from "../../lib/platform";
 import {
   parseFilename,
   bracketCleanup,
@@ -22,6 +23,7 @@ import {
   buildMultiSubtitlePairings,
   deriveRenameOutputPath,
   findDuplicateRenameOutputKeys,
+  findRenameInputConflictIndexes,
   isNoOpRename,
   assignSubtitleToRow,
   type PairingRow,
@@ -450,6 +452,65 @@ describe("findDuplicateRenameOutputKeys", () => {
       "C:/Subs/Episode.sc.ass",
     ]);
     expect(duplicates.size).toBe(1);
+  });
+});
+
+describe("findRenameInputConflictIndexes", () => {
+  it("marks both rows in a two-file swap", () => {
+    const conflicts = findRenameInputConflictIndexes([
+      { inputPath: "C:\\subs\\720.ass", outputPath: "C:\\subs\\1080.ass" },
+      { inputPath: "C:\\subs\\1080.ass", outputPath: "C:\\subs\\720.ass" },
+    ]);
+
+    expect(Array.from(conflicts).sort()).toEqual([0, 1]);
+  });
+
+  it("marks every participant in a longer output-to-input chain", () => {
+    const conflicts = findRenameInputConflictIndexes([
+      { inputPath: "C:\\subs\\a.ass", outputPath: "C:\\subs\\b.ass" },
+      { inputPath: "C:\\subs\\b.ass", outputPath: "C:\\subs\\c.ass" },
+      { inputPath: "C:\\subs\\c.ass", outputPath: "C:\\subs\\final.ass" },
+      { inputPath: "C:\\subs\\safe.ass", outputPath: "C:\\subs\\safe-out.ass" },
+    ]);
+
+    expect(Array.from(conflicts).sort()).toEqual([0, 1, 2]);
+  });
+
+  it("uses canonical slash and case aliases on Windows", () => {
+    if (!isWindowsRuntime) return;
+    const conflicts = findRenameInputConflictIndexes([
+      { inputPath: "C:\\Subs\\A.ass", outputPath: "c:/subs/B.ass" },
+      { inputPath: "C:\\SUBS\\b.ass", outputPath: "C:\\Subs\\final.ass" },
+    ]);
+
+    expect(Array.from(conflicts).sort()).toEqual([0, 1]);
+  });
+
+  it("uses canonical Unicode aliases on every platform", () => {
+    const conflicts = findRenameInputConflictIndexes([
+      { inputPath: "/subs/Cafe\u0301.ass", outputPath: "/subs/target.ass" },
+      { inputPath: "/subs/other.ass", outputPath: "/subs/Caf\u00e9.ass" },
+    ]);
+
+    expect(Array.from(conflicts).sort()).toEqual([0, 1]);
+  });
+
+  it("does not treat an ordinary self no-op as a conflict", () => {
+    const conflicts = findRenameInputConflictIndexes([
+      { inputPath: "/subs/ready.ass", outputPath: "/subs/ready.ass" },
+      { inputPath: "C:\\subs\\other.ass", outputPath: "C:\\subs\\other-out.ass" },
+    ]);
+
+    expect(conflicts.size).toBe(0);
+  });
+
+  it("blocks a target aimed at a loaded subtitle without an executable row", () => {
+    const conflicts = findRenameInputConflictIndexes(
+      [{ inputPath: "C:\\subs\\paired.ass", outputPath: "C:\\subs\\unpaired.ass" }],
+      ["C:\\subs\\paired.ass", "C:\\subs\\unpaired.ass"]
+    );
+
+    expect(Array.from(conflicts)).toEqual([0]);
   });
 });
 

--- a/src/features/batch-rename/pairing-engine.ts
+++ b/src/features/batch-rename/pairing-engine.ts
@@ -527,6 +527,57 @@ export function findDuplicateRenameOutputKeys(outputPaths: string[]): Set<string
   return duplicates;
 }
 
+export interface RenamePathTarget {
+  inputPath: string;
+  outputPath: string;
+}
+
+/**
+ * Return every executable row that participates in an
+ * output-to-loaded-input conflict.
+ *
+ * Batch rename/copy is executed sequentially. If row A writes to row B's
+ * loaded input, A can destroy the bytes B has not read yet. Refusing only A
+ * is also misleading for a longer A -> B -> C chain: B is both threatened by
+ * A and a threat to C. Mark both endpoints of every cross-row edge so the
+ * complete connected chain is rejected before any filesystem operation.
+ * `protectedInputPaths` is deliberately wider than `targets`: an unchecked,
+ * language-filtered, or currently unpaired subtitle is still user data and
+ * must not be overwritten merely because it has no executable row.
+ *
+ * A row whose output is its own input is an ordinary no-op, not a conflict.
+ * `normalizeOutputKey` keeps the comparison aligned with duplicate-output
+ * checks, including slash/case aliases on case-insensitive filesystems.
+ */
+export function findRenameInputConflictIndexes(
+  targets: RenamePathTarget[],
+  protectedInputPaths: string[] = targets.map((target) => target.inputPath)
+): Set<number> {
+  const inputOwners = new Map<string, number[]>();
+  targets.forEach((target, index) => {
+    const key = normalizeOutputKey(target.inputPath);
+    const owners = inputOwners.get(key) ?? [];
+    owners.push(index);
+    inputOwners.set(key, owners);
+  });
+  const protectedInputKeys = new Set(protectedInputPaths.map(normalizeOutputKey));
+
+  const conflicts = new Set<number>();
+  targets.forEach((target, writerIndex) => {
+    const inputKey = normalizeOutputKey(target.inputPath);
+    const outputKey = normalizeOutputKey(target.outputPath);
+    if (outputKey === inputKey || !protectedInputKeys.has(outputKey)) return;
+
+    conflicts.add(writerIndex);
+    const owners = inputOwners.get(outputKey) ?? [];
+    for (const ownerIndex of owners) {
+      if (ownerIndex === writerIndex) continue;
+      conflicts.add(ownerIndex);
+    }
+  });
+  return conflicts;
+}
+
 export function compareKeys(a: string, b: string): number {
   // Called only on matched-video keys (`${season}|${episode}` shape).
   // Unmatched videos take a separate branch above

--- a/src/features/batch-rename/pairing-engine.ts
+++ b/src/features/batch-rename/pairing-engine.ts
@@ -23,6 +23,8 @@
  */
 
 import { normalizeOutputKey } from "../../lib/dedup-helpers";
+import type { BatchRenameFilesState } from "../../lib/FileContext";
+import { LANG_TAGS } from "../../lib/lang-detection";
 import { assertSafeOutputFilename, assertSafeOutputPath } from "../../lib/path-validation";
 import { isWindowsRuntime } from "../../lib/platform";
 
@@ -61,11 +63,28 @@ interface EpisodePattern {
   build: (m: RegExpMatchArray) => EpisodeResult;
 }
 
+function escapeRegexLiteral(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+// Pattern A normally ends at the media/subtitle extension, but external
+// subtitle packs commonly insert a language tag first (`Show - 01.sc.ass`).
+// Build the optional tag branch from the same source of truth used by output
+// naming so widening language support cannot silently drift between features.
+const LANGUAGE_TAG_ALTERNATION = [...LANG_TAGS]
+  .sort((a, b) => b.length - a.length)
+  .map(escapeRegexLiteral)
+  .join("|");
+const PATTERN_A_RE = new RegExp(
+  String.raw`\s-\s*0*(\d+)(?:v\d+)?\s*(?:\[|\.(?:(?:${LANGUAGE_TAG_ALTERNATION})\.)?[a-z0-9]{1,10}$)`,
+  "i"
+);
+
 const EPISODE_PATTERNS: EpisodePattern[] = [
   // Western S01E01 — both season and episode, highest confidence.
   // Matches on either raw or cleaned (no bracket dependency).
   {
-    regex: /\bS(\d+)E(\d+)\b/i,
+    regex: /\bS(\d+)E(\d+)(?:v\d+)?\b/i,
     useRaw: true,
     build: (m) => ({
       episode: parseInt(m[2]!, 10),
@@ -84,7 +103,7 @@ const EPISODE_PATTERNS: EpisodePattern[] = [
   // anyway). Reject 4+ digit forms here and let Pattern A or LCS
   // handle the long-running edge.
   {
-    regex: /\]\s*\[\s*0*(\d{1,3})\s*\]/,
+    regex: /\]\s*\[\s*0*(\d{1,3})(?:v\d+)?\s*\]/i,
     useRaw: true,
     build: (m) => ({ episode: parseInt(m[1]!, 10) }),
   },
@@ -99,14 +118,14 @@ const EPISODE_PATTERNS: EpisodePattern[] = [
     // catastrophic-backtracking territory per Principle #3. No real
     // subtitle/video extension exceeds ~5 chars; cap at 10 leaves headroom
     // for any future codec naming weirdness.
-    regex: /\s-\s*0*(\d+)\s*(?:\[|\.[a-z0-9]{1,10}$)/i,
+    regex: PATTERN_A_RE,
     useRaw: true,
     build: (m) => ({ episode: parseInt(m[1]!, 10) }),
   },
   // 第N话 / 第N集 — Chinese marker, fallback. Doesn't appear in the
   // documented corpus but worth keeping for older naming styles.
   {
-    regex: /第\s*(\d+)\s*[话集]/,
+    regex: /第\s*(\d+)(?:v\d+)?\s*[话集]/i,
     useRaw: false,
     build: (m) => ({ episode: parseInt(m[1]!, 10) }),
   },
@@ -117,7 +136,7 @@ const EPISODE_PATTERNS: EpisodePattern[] = [
   // falls through to the LCS fallback instead of feeding parseInt a
   // precision-lossy 4+ digit value.
   {
-    regex: /\bEP?(\d{1,3})\b/i,
+    regex: /\bEP?(\d{1,3})(?:v\d+)?\b/i,
     useRaw: false,
     build: (m) => ({ episode: parseInt(m[1]!, 10) }),
   },
@@ -530,6 +549,129 @@ export function findDuplicateRenameOutputKeys(outputPaths: string[]): Set<string
 export interface RenamePathTarget {
   inputPath: string;
   outputPath: string;
+}
+
+export interface RenameRunSummary {
+  kind: "success" | "partial" | "error";
+  totalPlanned: number;
+}
+
+/**
+ * Classify a finished, non-cancelled run against every planned row, including
+ * rows rejected during preflight. This keeps `1/1 processed` from presenting
+ * a green success when another selected row was skipped before the I/O loop.
+ */
+export function summarizeRenameRun(
+  successCount: number,
+  executableTargetCount: number,
+  preflightFailureCount: number
+): RenameRunSummary {
+  const totalPlanned = executableTargetCount + preflightFailureCount;
+  if (successCount === 0) return { kind: "error", totalPlanned };
+  if (successCount === totalPlanned) return { kind: "success", totalPlanned };
+  return { kind: "partial", totalPlanned };
+}
+
+/** Identify planned outputs already owned by a different feature tab. */
+export function findRenameOutputOwnershipConflictIndexes<T extends { outputPath: string }>(
+  targets: readonly T[],
+  isOwnedByAnotherTab: (outputPath: string) => boolean
+): Set<number> {
+  const conflicts = new Set<number>();
+  targets.forEach((target, index) => {
+    if (isOwnedByAnotherTab(target.outputPath)) conflicts.add(index);
+  });
+  return conflicts;
+}
+
+/**
+ * Count loaded subtitle identities that are not represented by exactly one
+ * pairing row. Normally a paired subtitle has one owner; zero rows means the
+ * grammar could not pair it, while multiple rows would violate the manual
+ * assignment ownership invariant. Count normalized, unique input identities
+ * so a duplicate picker entry cannot inflate the user-facing number.
+ */
+export function countUnpairedSubtitlePaths(subtitlePaths: string[], rows: PairingRow[]): number {
+  const rowOwnerCounts = new Map<string, number>();
+  for (const row of rows) {
+    if (!row.subtitle) continue;
+    const key = normalizeOutputKey(row.subtitle.path);
+    rowOwnerCounts.set(key, (rowOwnerCounts.get(key) ?? 0) + 1);
+  }
+
+  const loadedKeys = new Set(subtitlePaths.map(normalizeOutputKey));
+  let unpairedCount = 0;
+  for (const key of loadedKeys) {
+    if (rowOwnerCounts.get(key) !== 1) unpairedCount += 1;
+  }
+  return unpairedCount;
+}
+
+/**
+ * Refresh the shared Batch Rename file identities after successful in-place
+ * renames. Only inputs present in `successfulTargets` move to their produced
+ * paths; failed, cancelled, unchecked, and unpaired inputs stay byte-for-byte
+ * unchanged. Callers must reject outputs owned by another tab before I/O;
+ * this helper only reconciles identities after those safety gates pass.
+ *
+ * Returning the original object when no loaded path changed lets the caller
+ * avoid arming its one-shot internal-refresh marker unnecessarily.
+ */
+export function refreshRenameFilesAfterSuccessfulInPlaceRenames(
+  state: BatchRenameFilesState | null,
+  successfulTargets: RenamePathTarget[]
+): BatchRenameFilesState | null {
+  if (!state || successfulTargets.length === 0) return state;
+
+  const targetsByInput = new Map(
+    successfulTargets.map((target) => [normalizeOutputKey(target.inputPath), target])
+  );
+  const subtitlePaths: string[] = [];
+  const subtitleNames: string[] = [];
+  let changed = false;
+
+  state.subtitlePaths.forEach((path, index) => {
+    const target = targetsByInput.get(normalizeOutputKey(path));
+    if (!target) {
+      subtitlePaths.push(path);
+      subtitleNames.push(state.subtitleNames[index] ?? baseName(path));
+      return;
+    }
+
+    changed = true;
+    subtitlePaths.push(target.outputPath);
+    subtitleNames.push(baseName(target.outputPath));
+  });
+
+  if (!changed) return state;
+  return { ...state, subtitlePaths, subtitleNames };
+}
+
+/**
+ * Rewrite successful in-place subtitle identities inside the live pairing
+ * rows without rebuilding the batch. This preserves manual assignments,
+ * checkbox intent, sources, and stable React IDs for every unaffected row.
+ */
+export function refreshPairingRowsAfterSuccessfulInPlaceRenames(
+  rows: PairingRow[],
+  successfulTargets: RenamePathTarget[]
+): PairingRow[] {
+  if (successfulTargets.length === 0) return rows;
+  const targetsByInput = new Map(
+    successfulTargets.map((target) => [normalizeOutputKey(target.inputPath), target])
+  );
+  let changed = false;
+  const refreshedRows = rows.map((row) => {
+    if (!row.subtitle) return row;
+    const target = targetsByInput.get(normalizeOutputKey(row.subtitle.path));
+    if (!target) return row;
+    changed = true;
+    return {
+      ...row,
+      subtitle: { path: target.outputPath, name: baseName(target.outputPath) },
+    };
+  });
+  return changed ? refreshedRows : rows;
 }
 
 /**

--- a/src/features/chain/chain-runtime.test.ts
+++ b/src/features/chain/chain-runtime.test.ts
@@ -96,6 +96,22 @@ describe("runChain — single shift step", () => {
     expect(result.content).toBe(expected.content);
   });
 
+  it("inherits and preserves a MicroDVD FPS declaration", () => {
+    const content = "{1}{1}25.000\r\n{25}{50}Hello\r\n";
+    const plan: ChainPlan = {
+      steps: [{ kind: "shift", params: { offsetMs: 1000 } }],
+      outputTemplate: "{name}.shifted.sub",
+    };
+    const result = runChain({
+      plan,
+      inputPath: "C:\\subs\\episode01.sub",
+      content,
+    });
+
+    expect(result.content).toBe("{1}{1}25.000\r\n{50}{75}Hello\r\n");
+    expect(result.notes[0]).toMatch(/format: sub/i);
+  });
+
   it("rejects a non-finite shift offset in a chain step (no misleading zero-shift)", () => {
     // Same CLI-boundary guard as the standalone convertShift: a NaN offset
     // would be silently clamped to a zero-shift success. The chain shift
@@ -501,6 +517,18 @@ describe("resolveChainOutputPath", () => {
     // no idea what to do. `[\s\S]*?` (lazy) crosses the newline between
     // sentence one and the guidance.
     expect(() => runChain({ plan, inputPath: INPUT_PATH, content: srt })).toThrow(
+      /requires ASS.*SSA content[\s\S]*?Run `hdr` standalone first/
+    );
+  });
+
+  it("keeps standalone conversion guidance for MicroDVD input to a chain HDR step", () => {
+    const plan: ChainPlan = {
+      steps: [{ kind: "hdr", params: { eotf: "PQ", brightness: 1000 } }],
+      outputTemplate: "{name}.hdr.ass",
+    };
+    const sub = "{1}{1}25.000\n{25}{50}Hello\n";
+
+    expect(() => runChain({ plan, inputPath: "C:\\subs\\episode01.sub", content: sub })).toThrow(
       /requires ASS.*SSA content[\s\S]*?Run `hdr` standalone first/
     );
   });

--- a/src/features/font-embed/FontCacheDriftModal.tsx
+++ b/src/features/font-embed/FontCacheDriftModal.tsx
@@ -186,6 +186,12 @@ export default function FontCacheDriftModal({
   const modifiedCount = drift?.modified.length ?? 0;
   const removedCount = drift?.removed.length ?? 0;
   const totalChanged = modifiedCount + removedCount;
+  const closeLabel =
+    working === "rescanning"
+      ? t("font_cache_close_busy_rescan")
+      : working === "clearing"
+        ? t("font_cache_close_busy_clear")
+        : t("font_cache_drift_btn_use_as_is");
 
   return (
     <div
@@ -216,8 +222,8 @@ export default function FontCacheDriftModal({
             onClick={requestClose}
             disabled={working !== null}
             className="modal-close"
-            title={t("font_cache_drift_btn_use_as_is")}
-            aria-label={t("font_cache_drift_btn_use_as_is")}
+            title={closeLabel}
+            aria-label={closeLabel}
           >
             <svg
               width="16"

--- a/src/features/font-embed/FontEmbed.tsx
+++ b/src/features/font-embed/FontEmbed.tsx
@@ -383,6 +383,9 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
 
   const handlePickFiles = useCallback(async () => {
     const gen = (pickGenRef.current = pickGenRef.current + 1);
+    // Match drag-and-drop: a new selection attempt must not leave the
+    // previous embed outcome visible beside a fresh picker error or batch.
+    setLastActionResult(null);
     // catch dialog IPC failures so a click
     // that can't open the picker doesn't read as a silent no-op. See
     // TimingShift.handlePickFiles for the full rationale.
@@ -397,7 +400,7 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
     if (gen !== pickGenRef.current) return;
     if (!paths || paths.length === 0) return;
     await ingestPaths(paths, gen);
-  }, [ingestPaths, addLog, t]);
+  }, [ingestPaths, addLog, setLastActionResult, t]);
 
   const handleDroppedPaths = useCallback(
     async (paths: string[]) => {

--- a/src/features/font-embed/FontEmbed.tsx
+++ b/src/features/font-embed/FontEmbed.tsx
@@ -3,12 +3,12 @@ import {
   clearFontSources,
   fileNameFromPath,
   isInferredUtf16,
-  openFontCache,
   pickAssFiles,
   pickOutputDirectory,
   readTextDetectEncoding,
   removeFontSource,
   writeText,
+  type FontCacheStatus,
 } from "../../lib/tauri-api";
 import { ask } from "@tauri-apps/plugin-dialog";
 import {
@@ -35,6 +35,7 @@ import { useLogPanel } from "../../lib/useLogPanel";
 import { LogPanel } from "../../lib/LogPanel";
 import { DropErrorBanner } from "../../lib/DropErrorBanner";
 import { buildConflictMessage, sanitizeError, sanitizeForDialog } from "../../lib/dedup-helpers";
+import { isFontCacheUnavailable } from "../../lib/font-cache-ui-state";
 
 type FontEmbedOutputMode = "beside_input" | "chosen_dir";
 
@@ -107,7 +108,12 @@ const MAX_BATCH_FILES = 500;
 // so the lower cap is invisible to legitimate workflows.
 const MAX_BATCH_AGGREGATE_BYTES = 200 * 1024 * 1024;
 
-export default function FontEmbed() {
+interface FontEmbedProps {
+  cacheStatus: FontCacheStatus | null;
+  cacheProbeFailed: boolean;
+}
+
+export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedProps) {
   const { t } = useI18n();
   const fontStyleLabels = useMemo(
     () => ({ bold: t("font_style_bold"), italic: t("font_style_italic") }),
@@ -132,7 +138,7 @@ export default function FontEmbed() {
     null
   );
   const [lastActionResult, setLastActionResult] = useState<
-    "success" | "noop" | "partial" | "error" | "cancelled" | null
+    "success" | "partial" | "error" | "cancelled" | null
   >(null);
   // Synchronous "Cancelling…" feedback for the embed Cancel button. The abort
   // only lands at the next per-file iteration boundary, so without this the
@@ -170,36 +176,10 @@ export default function FontEmbed() {
   const dropZoneRef = useRef<HTMLDivElement>(null);
   const fileContainerRef = useRef<HTMLDivElement>(null);
 
-  // Persistent cache availability — when init failed for a non-schema
-  // reason (disk full, permissions denied), the App-level launch hook
-  // logs WARN to stderr but a GUI app has no visible stderr. Surface
-  // the state inline here so users see why embed is silently using
-  // system fonts only. Schema-mismatch is handled by the launch-time
-  // modal and is NOT shown as a banner (avoids double-surfacing).
-  //
-  // Per-component probe is intentional (vs lifting cacheStatus into a
-  // Context shared with App.tsx): the banner needs to stay accurate
-  // across the user's session — if they hit "Clear cache" in the drift
-  // modal mid-session and clear succeeds-then-fails, this probe re-runs
-  // when they next mount Font Embed. App.tsx's launch-time probe is
-  // load-bearing for the modal; this one is load-bearing for the
-  // banner. Two cheap SQL queries per launch is below the perf bar.
-  const [cacheUnavailable, setCacheUnavailable] = useState(false);
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const status = await openFontCache();
-        if (cancelled) return;
-        setCacheUnavailable(!status.available && !status.schemaMismatch);
-      } catch {
-        if (!cancelled) setCacheUnavailable(true);
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+  // App owns the authoritative launch/re-probe lifecycle and refreshes these
+  // props after modal actions. Schema mismatch has its own modal, so only a
+  // non-schema init failure or a rejected probe shows this fallback banner.
+  const cacheUnavailable = isFontCacheUnavailable(cacheStatus, cacheProbeFailed);
 
   // ── Local font sources (persist for the tab session) ─────
   const [fontSources, setFontSources] = useState<FontSource[]>([]);
@@ -665,7 +645,12 @@ export default function FontEmbed() {
         const safePath = safeDisplayFileName(skipped.inputPath);
         if (skipped.reason === "duplicate") {
           addLog(t("msg_skipped_duplicate", safePath), "error");
+        } else if (skipped.reason === "input_conflict") {
+          addLog(t("msg_fonts_input_conflict", safePath), "error");
         } else {
+          // Validation messages carry path-specific details from the planner;
+          // keep them verbatim (after its sanitization) instead of pretending
+          // an arbitrary runtime error is an i18n key.
           addLog(t("msg_fonts_error", safePath, skipped.message), "error");
         }
       }
@@ -713,11 +698,6 @@ export default function FontEmbed() {
 
         let successCount = 0;
         let issueCount = planned.skipped.length;
-        // Files that processed cleanly but needed no embedding (every
-        // referenced font already present). Tracked apart from successCount /
-        // issueCount so an all-no-change batch isn't misframed as total
-        // failure in the final summary.
-        let noChangeCount = 0;
         let processedCount = planned.skipped.length;
 
         for (const target of planned.targets) {
@@ -826,27 +806,15 @@ export default function FontEmbed() {
             const safeOutName = sanitizeForDialog(fileNameFromPath(outputPath));
             if (result.embeddedCount === 0) {
               const fileWarnings = [...missingWarnings, ...result.warnings];
-              if (fileWarnings.length > 0) {
-                issueCount += fileWarnings.length;
-                for (const warning of fileWarnings) {
-                  addLog(t("msg_fonts_file_warning", safeFileName, warning), "warn");
-                }
-              } else {
-                // Benign no-change: every referenced font is already present,
-                // so there was nothing to embed. Not a failure — tracked
-                // separately so an all-no-change batch isn't routed to
-                // msg_fonts_all_failed below.
-                noChangeCount++;
+              // selectedFonts is non-empty and each selected font either
+              // produces an entry or a warning inside embedFonts. Therefore a
+              // zero-entry result is a failed/skipped embed, never an
+              // "already present" no-op.
+              issueCount += fileWarnings.length;
+              for (const warning of fileWarnings) {
+                addLog(t("msg_fonts_file_warning", safeFileName, warning), "warn");
               }
-              // Nothing was actually embedded — skip the write so we
-              // don't produce a `.embedded.ass` that's identical to the
-              // input and log "saved" for a no-op. Surface as a warning
-              // so the user knows the file was processed but the output
-              // would have been a copy of the source.
-              addLog(
-                t("msg_embed_no_change", safeOutName),
-                fileWarnings.length > 0 ? "warn" : "info"
-              );
+              addLog(t("msg_embed_no_change", safeOutName), "warn");
               continue;
             }
             if (cached.inferredEncodingId) {
@@ -891,38 +859,15 @@ export default function FontEmbed() {
         const aborted = !!abortRef.current?.signal.aborted;
         if (aborted) {
           setLastActionResult("cancelled");
-        } else if (successCount > 0 && issueCount > 0 && noChangeCount > 0) {
-          addLog(
-            t("msg_fonts_complete_partial_mixed", successCount, noChangeCount, issueCount),
-            "warn"
-          );
-          setLastActionResult("partial");
         } else if (successCount > 0 && issueCount > 0) {
           addLog(
             t("msg_fonts_complete_partial", successCount, filePaths.length, issueCount),
             "warn"
           );
           setLastActionResult("partial");
-        } else if (successCount > 0 && noChangeCount > 0) {
-          addLog(t("msg_fonts_complete_mixed", successCount, noChangeCount), "success");
-          setLastActionResult("success");
         } else if (successCount > 0) {
           addLog(t("msg_fonts_complete", successCount, filePaths.length), "success");
           setLastActionResult("success");
-        } else if (issueCount === 0 && noChangeCount > 0) {
-          // Every processed file already had all its referenced fonts —
-          // nothing to embed. A benign outcome, not a failure: don't route it
-          // to msg_fonts_all_failed.
-          addLog(t("msg_fonts_all_no_change", noChangeCount), "info");
-          setLastActionResult("noop");
-        } else if (noChangeCount > 0 && issueCount > 0) {
-          // Some files were benign no-ops while others failed preflight
-          // or processing. That is incomplete, not "all failed".
-          addLog(
-            t("msg_fonts_complete_partial_mixed", successCount, noChangeCount, issueCount),
-            "warn"
-          );
-          setLastActionResult("partial");
         } else {
           addLog(t("msg_fonts_all_failed", filePaths.length), "error");
           setLastActionResult("error");
@@ -954,7 +899,6 @@ export default function FontEmbed() {
     }
     if (analyzing) return { kind: "busy", message: t("status_fonts_analyzing") };
     if (lastActionResult === "success") return { kind: "done", message: t("status_fonts_done") };
-    if (lastActionResult === "noop") return { kind: "done", message: t("status_fonts_noop") };
     if (lastActionResult === "partial") {
       return { kind: "pending", message: t("status_fonts_partial") };
     }

--- a/src/features/font-embed/font-collector.test.ts
+++ b/src/features/font-embed/font-collector.test.ts
@@ -39,33 +39,19 @@ describe("fontKeyLabel", () => {
 });
 
 describe("font-collector \\p drawing-tag whitespace handling", () => {
-  it("rejects `\\p 1` (space before digit) and continues collecting glyphs", async () => {
-    // libass requires `\p` followed immediately by a digit — `\p 1`
-    // with a space is malformed and does NOT enter drawing mode. The
-    // collector regex `\\p(\\d+)` enforces this by requiring `\d`
-    // directly after `\p`. If a future "be lenient about whitespace"
-    // refactor accepted `\p 1` as a valid drawing-on tag, isDrawing
-    // would flip to true and the text after the block would be
-    // skipped from glyph collection — the rendered subtitle would
-    // then miss those glyphs (renderer + collector disagree).
-    //
-    // Test: send text starting with `{\p 1}` followed by a sentinel
-    // codepoint (Z = U+005A). If the regex correctly rejects, Z is
-    // collected; if it falsely accepts, Z is treated as a drawing
-    // command and dropped.
+  it("accepts `\\p 1` with leading argument whitespace", async () => {
     await ensureLoaded();
-    const usage = collectFonts(makeASS(String.raw`{\p 1}ZZZZ`));
+    const usage = collectFonts(makeASS(String.raw`{\p 1}ZZZZ{\p0}Y`));
     const defaultStyle = usage.find((u) => u.key.family === "Arial");
     expect(defaultStyle, "Default style FontUsage should exist").toBeDefined();
-    expect(defaultStyle!.codepoints.has(0x5a), "Z (U+005A) must be in collected codepoints").toBe(
-      true
-    );
+    expect(defaultStyle!.codepoints.has(0x5a), "Z must be skipped in drawing mode").toBe(false);
+    expect(defaultStyle!.codepoints.has(0x59), "Y after \\p0 must be collected").toBe(true);
   });
 
   it("accepts `\\p1` (no whitespace) and skips subsequent text as drawing commands", async () => {
     // Counter-test pinning the other direction of the contract:
     // `\p1` (well-formed, scale 1, no whitespace) IS drawing-on per
-    // libass, and the collector must skip glyphs until `\p0` or `\r`.
+    // libass, and the collector must skip glyphs until `\p0`.
     await ensureLoaded();
     const usage = collectFonts(makeASS(String.raw`{\p1}XXXX{\p0}YYYY`));
     const defaultStyle = usage.find((u) => u.key.family === "Arial");
@@ -248,23 +234,9 @@ Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\rStyleA\rStyleB}DDDD`}
   });
 });
 
-// ── Boundary-pin for \r and \fn capture caps. An earlier change
-// added {0,127}/{0,128} caps, but without a
-// trailing boundary the bounded regex silently TRUNCATED overlong
-// names to the prefix, then performed styleMap.has(prefix). An
-// attacker-crafted ASS defining both a 128-char prefix style and a
-// longer same-prefix style would mis-attribute glyphs to PrefixFont
-// while libass renders LongFont — embedded subsets diverge from
-// what's drawn. The fix adds a negative-lookahead boundary so
-// overlong names fail to match outright and fall through to the
-// dialogue's initial style (libass parity for an unknown name).
-// Tests below pin both sides of the boundary: at-cap match works,
-// over-cap match does NOT mis-attribute. \fn sibling parity is
-// tested though it has no demonstrated real-world exploit.
-describe("font-collector \\r / \\fn overlong-name boundary", () => {
-  it("\\r at 128-char cap matches and selects the named style", async () => {
+describe("font-collector exact \\r names and \\fn length boundary", () => {
+  it("selects a 128-character style exactly after trimming a trailing tab", async () => {
     await ensureLoaded();
-    // {0,127} = leading letter + up to 127 continuation chars = 128 total.
     const styleName = "A".repeat(128);
     const ass = `[Script Info]
 ScriptType: v4.00+
@@ -276,22 +248,18 @@ Style: ${styleName},Times New Roman,40,0,0
 
 [Events]
 Format: Layer, Start, End, Style, Text
-Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\r` + styleName + `}E`}
+Dialogue: 0,0:00:00.00,0:00:05.00,Default,${`{\\r${styleName}\t}E`}
 `;
     const usage = collectFonts(ass);
     const times = usage.find((u) => u.key.family === "Times New Roman");
-    expect(times, "128-char style must match \\r at the cap").toBeDefined();
+    expect(times, "128-character style must match exactly").toBeDefined();
     expect(times!.codepoints.has(0x45), "E must be collected under the 128-char style").toBe(true);
   });
 
-  it("\\r overlong name with prefix-sharing sibling falls through to default", async () => {
-    // Regression PoC: pre-fix the 128-char prefix style would absorb F.
-    // Post-fix the overlong \r fails to match, so F stays under the
-    // dialogue's initial style (Arial). The 128-char prefix style
-    // FontUsage may exist (registered in styleMap) but must NOT carry F.
+  it("does not alias an overlong style name to its shared prefix", async () => {
     await ensureLoaded();
     const prefix = "A".repeat(128);
-    const longer = prefix + "B"; // 129 chars sharing the 128-char prefix
+    const longer = prefix + "B";
     const ass = `[Script Info]
 ScriptType: v4.00+
 
@@ -303,50 +271,36 @@ Style: ${longer},Courier New,40,0,0
 
 [Events]
 Format: Layer, Start, End, Style, Text
-Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\r` + longer + `}F`}
+Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\r` + longer + `   }F`}
 `;
     const usage = collectFonts(ass);
-    // F (0x46) MUST land in Arial (initial style), NOT Times New Roman.
     const times = usage.find((u) => u.key.family === "Times New Roman");
     if (times) {
-      expect(times.codepoints.has(0x46), "F must NOT mis-attribute to PrefixFont (Times)").toBe(
-        false
-      );
+      expect(times.codepoints.has(0x46), "F must not use the prefix style").toBe(false);
     }
+    const courier = usage.find((u) => u.key.family === "Courier New");
+    expect(courier, "an overlong style must not be selected").toBeUndefined();
     const arial = usage.find((u) => u.key.family === "Arial");
-    expect(arial, "Arial (Default) FontUsage must exist").toBeDefined();
-    expect(
-      arial!.codepoints.has(0x46),
-      "F must land in Arial — overlong \\r falls through to initial style"
-    ).toBe(true);
+    expect(arial).toBeDefined();
+    expect(arial!.codepoints.has(0x46)).toBe(true);
   });
 
-  it("\\fn at 128-char cap matches the family", async () => {
-    // Sibling at-cap test. \fn's cap is {0,128} flat (no separate
-    // leading-letter requirement), so 128 chars match exactly.
+  it("accepts a 128-character inline family after trimming leading space and trailing tab", async () => {
     await ensureLoaded();
     const family = "A".repeat(128);
-    const usage = collectFonts(makeASS(`{\\fn${family}}G`));
+    const usage = collectFonts(makeASS(`{\\fn ${family}\t}G`));
     const match = usage.find((u) => u.key.family === family);
     expect(match, "128-char family must be captured by \\fn at the cap").toBeDefined();
     expect(match!.codepoints.has(0x47), "G must be collected under the 128-char family").toBe(true);
   });
 
-  it("\\fn overlong name does NOT capture the prefix (sibling parity with \\r)", async () => {
-    // Real-world exploit for \fn is much harder than \r (would need
-    // two installed fonts with a 128-char shared family-name prefix)
-    // but the structural defect is identical. 129-char input must
-    // NOT yield a 128-char-prefix capture; the dialogue's initial
-    // style stays in force.
+  it("does not alias an overlong inline family to its 128-character prefix", async () => {
     await ensureLoaded();
     const overlong = "A".repeat(129);
-    const usage = collectFonts(makeASS(`{\\fn${overlong}}H`));
+    const usage = collectFonts(makeASS(`{\\fn${overlong}   }H`));
     const overlongPrefix = "A".repeat(128);
     const prefixHit = usage.find((u) => u.key.family === overlongPrefix);
-    expect(
-      prefixHit,
-      "128-char prefix MUST NOT be captured when input is 129-char (overlong fails to match)"
-    ).toBeUndefined();
+    expect(prefixHit, "an overlong family must not alias its sanitized prefix").toBeUndefined();
     const arial = usage.find((u) => u.key.family === "Arial");
     expect(arial, "Arial (Default) FontUsage must exist").toBeDefined();
     expect(arial!.codepoints.has(0x48), "H must land in Arial — overlong \\fn falls through").toBe(
@@ -355,17 +309,6 @@ Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\r` + longer + `}F`}
   });
 });
 
-// ── State-retention pair for the boundary fix above. A boundary
-// lookahead alone made overlong \r / \fn silently disappear from
-// matchAll. The if-block at the caller doesn't execute when matchAll
-// returns no token, so a PRIOR valid \r / \fn in the same override
-// block leaves its state in `result` — X / Y get attributed to the
-// prior style / family instead of being reset to the dialogue initial
-// (libass semantics). The fix uses a second alternation that matches
-// overlong runs with undefined capture, so the if-block runs and
-// falls through to the initialFont path. These tests pin the
-// state-retention contract specifically, complementing the boundary
-// tests above which only cover the no-prior-override case.
 describe("font-collector \\r / \\fn overlong state-retention", () => {
   it("\\r overlong after a valid prior \\r resets to initial style", async () => {
     // PoC: `{\rStyleA\r<overlong>}X` — the FIRST tag sets state to
@@ -401,6 +344,13 @@ Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\rStyleA\r` + overlong +
       arial!.codepoints.has(0x58),
       "X must land in Arial after overlong \\r resets to initial style"
     ).toBe(true);
+  });
+
+  it("resets only exact \\fn0 before leading whitespace is removed", async () => {
+    await ensureLoaded();
+    const usage = collectFonts(makeASS(String.raw`{\fn 0}J{\fn0}K`));
+    expect(usage.find((entry) => entry.key.family === "0")?.codepoints.has(0x4a)).toBe(true);
+    expect(usage.find((entry) => entry.key.family === "Arial")?.codepoints.has(0x4b)).toBe(true);
   });
 
   it("\\fn overlong after a valid prior \\fn resets to initial family", async () => {
@@ -468,18 +418,6 @@ Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\rStyleA\r` + overlong +
   });
 });
 
-// ── Digit-led style name pair for the state-retention fix. The
-// earlier alternation closed the overlong-run shape but kept the
-// original `[\p{L}_]` leading-char class on BOTH branches, so a
-// digit-led style name (`1MainTitle`) still failed both alternation
-// branches — same state-retention divergence in a different input
-// shape. ass-compiler accepts digit-led names and stores them in
-// styleMap unchanged; the parser-vs-override-tag asymmetry was an
-// internal inconsistency regardless of libass behavior. Fix extends
-// both leading classes to `[\p{L}\p{N}_]`. Tests below cover both
-// directions: digit-led name DEFINED in V4+ Styles (must switch to
-// that style) and digit-led name UNDEFINED (must reset to initial,
-// matching the overlong path).
 describe("font-collector \\r digit-led style name", () => {
   it("\\r1MainTitle resolves to the digit-led style when defined", async () => {
     // ass-compiler accepts `Style: 1MainTitle,...`; our \r regex
@@ -519,13 +457,7 @@ Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\rStyleA\r1MainTitle}X`}
   });
 
   it("\\r9NonexistentStyle (digit-led, undefined) falls through to initial style", async () => {
-    // Sibling counter-test for the undefined case: `\r<digit-led-name>`
-    // where the name is NOT in styleMap. Before the digit-led fix,
-    // both alternation branches rejected the digit-led leading char,
-    // so matchAll missed the token and prior state stayed in force.
-    // Post-fix, the first branch matches with capture =
-    // "9NonexistentStyle", styleMap.has returns false, the else-arm
-    // resets to initialFont.
+    // Strict lookup of an unknown named reset returns to the event style.
     await ensureLoaded();
     const ass = `[Script Info]
 ScriptType: v4.00+
@@ -556,48 +488,29 @@ Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\rStyleA\r9NonexistentSt
   });
 });
 
-// ── Drawing-reset parity for digit-led \r. Widening the \r
-// alternation regex inside applyOverrideTags to accept digit-led
-// style names was incomplete because the SIBLING regex R_RESET_RE at
-// module top (which the walkText loop used to decide whether \r was
-// present → reset isDrawing) still used the old [\p{L}_] leading
-// class. When an attacker-controlled ASS pairs \p1 with
-// \r<digit-led>, the two regexes disagree: applyOverrideTags
-// switches style correctly but R_RESET_RE.test() returns false, so
-// isDrawing stays true from the prior \p1. Plain text after the
-// block becomes drawing-mode commands → glyphs missing from the
-// embedded subset. libass renders normally (\r resets drawing-off).
-// Same regex-pair coherence failure mode predicted by the WHY
-// comment for the alternation widening; the hiding spot was 458
-// lines above in the same file.
-//
-// Tests below pair the two halves of the contract:
-//   1. Drawing-mode reset fires for digit-led \r (so subsequent text
-//      is collected, not skipped).
-//   2. Style-undefined fallback to initialFont still works in
-//      combination with the drawing reset.
-describe("font-collector \\r digit-led drawing-mode reset", () => {
-  it("\\p1 in one block, \\r1MainTitle in the next: digit-led \\r resets drawing AND switches style", async () => {
-    // Two-block sequence: {\p1}{\r1MainTitle}X. isDrawing is a sticky
-    // state that persists across blocks until reset. Block 1's \p1
-    // sets isDrawing=true; block 2's \r1MainTitle must reset
-    // isDrawing=false (via R_RESET_RE.test) AND switch to 1MainTitle
-    // (via applyOverrideTags's matchAll). Then X is collected under
-    // Courier New.
-    //
-    // Before the fix: R_RESET_RE used [\p{L}_] which rejected the
-    // digit leading char; .test returned false; isDrawing stayed
-    // true from block 1; X was treated as drawing-mode commands and
-    // DROPPED. applyOverrideTags still switched style correctly
-    // (alternation regex was widened separately), but Courier New's
-    // bucket would be empty because no glyphs reached recordChars.
-    //
-    // Single-block {\p1\r1MainTitle}X is NOT used here — the
-    // earlier walkText drawing-mode pass ran pTags AFTER
-    // R_RESET_RE, so the \p1 in the same block always wins
-    // regardless of R_RESET_RE's result. That positional-order
-    // defect was a separate refactor target; this test isolates the
-    // R_RESET_RE contract via cross-block state propagation.
+describe("font-collector libass style baselines", () => {
+  it("resets bare and invalid bold/italic tags to the event style", async () => {
+    await ensureLoaded();
+    const ass = `[Script Info]
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, Bold, Italic
+Style: Default,Arial,40,-1,-1
+
+[Events]
+Format: Layer, Start, End, Style, Text
+Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\fnTimes New Roman\fn0\b0\b2\i0\i-1}X`}
+`;
+    const usage = collectFonts(ass);
+    const restored = usage.find(
+      (entry) => entry.key.family === "Arial" && entry.key.bold && entry.key.italic
+    );
+    expect(restored).toBeDefined();
+    expect(restored!.codepoints.has(0x58)).toBe(true);
+  });
+
+  it("uses the latest named style for \\fn0 and invalid bold/italic resets", async () => {
     await ensureLoaded();
     const ass = `[Script Info]
 ScriptType: v4.00+
@@ -605,36 +518,141 @@ ScriptType: v4.00+
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, Bold, Italic
 Style: Default,Arial,40,0,0
-Style: 1MainTitle,Courier New,40,0,0
+Style: Named,Courier New,40,-1,-1
 
 [Events]
 Format: Layer, Start, End, Style, Text
-Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\p1}{\r1MainTitle}X`}
+Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\rNamed\fnTimes New Roman\fn0\b0\b99\i0\i2}Y`}
 `;
     const usage = collectFonts(ass);
-    const courier = usage.find((u) => u.key.family === "Courier New");
+    const restored = usage.find(
+      (entry) => entry.key.family === "Courier New" && entry.key.bold && entry.key.italic
+    );
+    expect(restored, "all resets must use Named rather than Default").toBeDefined();
+    expect(restored!.codepoints.has(0x59)).toBe(true);
+  });
+
+  it("returns style-relative resets to the event baseline after bare \\r", async () => {
+    await ensureLoaded();
+    const ass = `[Script Info]
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, Bold, Italic
+Style: Default,Arial,40,0,0
+Style: Named,Courier New,40,-1,-1
+
+[Events]
+Format: Layer, Start, End, Style, Text
+Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\rNamed\r\fnTimes\fn0\b1\b2\i1\i2}S`}
+`;
+    const usage = collectFonts(ass);
+    const event = usage.find(
+      (entry) => entry.key.family === "Arial" && !entry.key.bold && !entry.key.italic
+    );
+    expect(event?.codepoints.has(0x53)).toBe(true);
+  });
+
+  it("resets literal bare and tab-only bold/italic tags to the named style", async () => {
+    await ensureLoaded();
+    const bare = String.raw`{\rNamed\b0\i0\b\i}V`;
+    const tabOnly = "{\\b0\\i0\\b\t\\i\t}W";
+    const ass = `[Script Info]
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, Bold, Italic
+Style: Default,Arial,40,0,0
+Style: Named,Courier New,40,-1,-1
+
+[Events]
+Format: Layer, Start, End, Style, Text
+Dialogue: 0,0:00:00.00,0:00:05.00,Default,${bare}${tabOnly}
+Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\b1\i1\b\i}R`}
+`;
+    const usage = collectFonts(ass);
+    const named = usage.find(
+      (entry) => entry.key.family === "Courier New" && entry.key.bold && entry.key.italic
+    );
+    expect(named?.codepoints.has(0x56)).toBe(true);
+    expect(named?.codepoints.has(0x57)).toBe(true);
+    const regular = usage.find(
+      (entry) => entry.key.family === "Arial" && !entry.key.bold && !entry.key.italic
+    );
+    expect(regular?.codepoints.has(0x52), "bare tags must also restore a regular style").toBe(true);
+  });
+
+  it("treats present nonnumeric bold/italic arguments as zero", async () => {
+    await ensureLoaded();
+    const ass = `[Script Info]
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, Bold, Italic
+Style: Default,Arial,40,-1,-1
+
+[Events]
+Format: Layer, Start, End, Style, Text
+Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\bbanana\iabc}Z`}
+`;
+    const usage = collectFonts(ass);
+    const regular = usage.find(
+      (entry) => entry.key.family === "Arial" && !entry.key.bold && !entry.key.italic
+    );
+    expect(regular).toBeDefined();
+    expect(regular!.codepoints.has(0x5a)).toBe(true);
+  });
+
+  it("accepts leading argument whitespace for bold and italic", async () => {
+    await ensureLoaded();
+    const usage = collectFonts(makeASS(String.raw`{\b 1\i 1}W`));
+    const styled = usage.find(
+      (entry) => entry.key.family === "Arial" && entry.key.bold && entry.key.italic
+    );
+    expect(styled).toBeDefined();
+    expect(styled!.codepoints.has(0x57)).toBe(true);
+  });
+
+  it("looks up Default and lowercase default exactly", async () => {
+    await ensureLoaded();
+    const ass = `[Script Info]
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, Bold, Italic
+Style: Default,Arial,40,0,0
+Style: default,Courier New,40,0,0
+Style: EventStyle,Times New Roman,40,0,0
+
+[Events]
+Format: Layer, Start, End, Style, Text
+Dialogue: 0,0:00:00.00,0:00:05.00,EventStyle,${String.raw`{\rDefault}A{\rdefault}B{\rDEFAULT}C{\r}D`}
+Dialogue: 0,0:00:00.00,0:00:05.00,default,E
+Dialogue: 0,0:00:00.00,0:00:05.00,***EventStyle,F
+Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\r***EventStyle}G`}
+`;
+    const usage = collectFonts(ass);
+    expect(usage.find((entry) => entry.key.family === "Arial")?.codepoints.has(0x41)).toBe(true);
+    expect(usage.find((entry) => entry.key.family === "Courier New")?.codepoints.has(0x42)).toBe(
+      true
+    );
+    const event = usage.find((entry) => entry.key.family === "Times New Roman");
+    expect(event?.codepoints.has(0x43), "unknown uppercase name must use the event style").toBe(
+      true
+    );
+    expect(event?.codepoints.has(0x44), "bare reset must use the event style").toBe(true);
     expect(
-      courier,
-      "Courier New FontUsage must exist — block-2 R_RESET_RE must reset isDrawing for digit-led \\r"
-    ).toBeDefined();
+      usage.find((entry) => entry.key.family === "Arial")?.codepoints.has(0x45),
+      "event-style default is normalized to exact Default"
+    ).toBe(true);
+    expect(event?.codepoints.has(0x46), "all leading event-style stars are ignored").toBe(true);
     expect(
-      courier!.codepoints.has(0x58),
-      "X must land in 1MainTitle's bucket (Courier New) — proves block-2 \\r1MainTitle both switched style AND reset isDrawing"
+      usage.find((entry) => entry.key.family === "Arial")?.codepoints.has(0x47),
+      "\\r lookup remains strict and does not strip stars"
     ).toBe(true);
   });
 
-  it("\\p1 in one block, \\r9Nonexistent in the next: digit-led undefined \\r resets drawing AND falls through to initial", async () => {
-    // Sibling counter-test: {\p1}{\r9Nonexistent}Y. Block 1 sets
-    // isDrawing=true. Block 2's \r9Nonexistent must reset isDrawing
-    // (via R_RESET_RE.test) AND fall through to initialFont (style
-    // name not in styleMap). Y is collected under Arial.
-    //
-    // Before any digit-led fix: applyOverrideTags's alternation
-    // rejected digit-led → state retained block 1's style. After
-    // only the alternation fix: R_RESET_RE still rejected digit-led
-    // → isDrawing stayed true → Y dropped. After both fixes: both
-    // regexes accept digit-led; style resets to initial AND
-    // isDrawing resets; Y collected under Arial.
+  it("accepts spaces and punctuation and trims trailing tag spaces", async () => {
     await ensureLoaded();
     const ass = `[Script Info]
 ScriptType: v4.00+
@@ -642,41 +660,92 @@ ScriptType: v4.00+
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, Bold, Italic
 Style: Default,Arial,40,0,0
-Style: StyleA,Times New Roman,40,0,0
+Style: Signs - Top! #1,Courier New,40,0,0
 
 [Events]
 Format: Layer, Start, End, Style, Text
-Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\p1}{\r9NonexistentStyle}Y`}
+Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\rSigns - Top! #1   \b1}Q`}
 `;
     const usage = collectFonts(ass);
-    const arial = usage.find((u) => u.key.family === "Arial");
-    expect(arial, "Arial (Default/initial) FontUsage must exist").toBeDefined();
+    const signs = usage.find((entry) => entry.key.family === "Courier New" && entry.key.bold);
+    expect(signs).toBeDefined();
+    expect(signs!.codepoints.has(0x51)).toBe(true);
+  });
+
+  it("falls back from an undefined event style to Default, then Arial", async () => {
+    await ensureLoaded();
+    const withDefault = `[Script Info]
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, Bold, Italic
+Style: Default,Courier New,40,0,0
+
+[Events]
+Format: Layer, Start, End, Style, Text
+Dialogue: 0,0:00:00.00,0:00:05.00,Missing,X
+`;
     expect(
-      arial!.codepoints.has(0x59),
-      "Y must land in Arial — proves block-2 R_RESET_RE reset isDrawing for digit-led \\r AND undefined-style fall-through fired"
+      collectFonts(withDefault)
+        .find((entry) => entry.key.family === "Courier New")
+        ?.codepoints.has(0x58)
+    ).toBe(true);
+
+    const withoutDefault = `[Script Info]
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, Bold, Italic
+Style: Other,Times New Roman,40,0,0
+
+[Events]
+Format: Layer, Start, End, Style, Text
+Dialogue: 0,0:00:00.00,0:00:05.00,Missing,Y
+`;
+    expect(
+      collectFonts(withoutDefault)
+        .find((entry) => entry.key.family === "Arial")
+        ?.codepoints.has(0x59)
     ).toBe(true);
   });
 });
 
-// ── Position-sorted single-pass override handling. An earlier
-// applyOverrideTags ran four independent matchAll().at(-1) passes
-// (one per tag family) and walkText ran two more (R_RESET_RE +
-// pTags). Family-independent last-wins ignored relative position
-// between families: e.g. `{\fnArial\r}` would set family=Arial AND
-// style=initial because the \fn pass ran after \r and overwrote
-// `result.family`; libass / xy-VSFilter process tags left-to-right,
-// so \r should reset family back to initialFont. Same shape applied
-// to `{\b1\r}`, `{\i1\r}`, `{\p1\r}`. The current code consolidates
-// into one position-sorted walk; these tests pin libass-parity for
-// each divergent shape.
-describe("font-collector \\r resets siblings within the same block", () => {
+describe("font-collector \\r and drawing-mode state", () => {
+  it("switches style without ending drawing mode", async () => {
+    await ensureLoaded();
+    const ass = `[Script Info]
+ScriptType: v4.00+
+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, Bold, Italic
+Style: Default,Arial,40,0,0
+Style: StyleA,Courier New,40,0,0
+
+[Events]
+Format: Layer, Start, End, Style, Text
+Dialogue: 0,0:00:00.00,0:00:05.00,Default,${String.raw`{\p1}{\rStyleA}m 0 0 l 1 1{\p0}X`}
+`;
+    const usage = collectFonts(ass);
+    const courier = usage.find((u) => u.key.family === "Courier New");
+    expect(courier).toBeDefined();
+    expect(courier!.codepoints.has(0x6d), "drawing command m must remain skipped").toBe(false);
+    expect(courier!.codepoints.has(0x58), "X after \\p0 must use StyleA").toBe(true);
+  });
+
+  it("unknown \\r falls back to the event style while preserving drawing mode", async () => {
+    await ensureLoaded();
+    const usage = collectFonts(makeASS(String.raw`{\p1}{\r9NonexistentStyle}m 0 0 l 1 1{\p0}Y`));
+    const arial = usage.find((u) => u.key.family === "Arial");
+    expect(arial).toBeDefined();
+    expect(arial!.codepoints.has(0x6d)).toBe(false);
+    expect(arial!.codepoints.has(0x59)).toBe(true);
+  });
+});
+
+describe("font-collector left-to-right override order", () => {
   it("{\\fnTimes\\r}X resets family to initial — \\fn-then-\\r positional order", async () => {
-    // libass: \fn sets family=Times, then \r resets EVERYTHING
-    // including family to dialogue initial (Arial). X collected
-    // under Arial, NOT Times. Before the position-sorted fix: \fn
-    // matchAll.at(-1) ran AFTER \r matchAll.at(-1), so family=Times
-    // overrode \r's style reset → embed attributed X to Times while
-    // libass rendered it under Arial.
+    // \r resets font styling to the event baseline, but drawing mode is
+    // intentionally tested separately because libass preserves it.
     await ensureLoaded();
     const usage = collectFonts(makeASS(String.raw`{\fnTimes New Roman\r}X`));
     const times = usage.find((u) => u.key.family === "Times New Roman");
@@ -730,22 +799,15 @@ describe("font-collector \\r resets siblings within the same block", () => {
     expect(arialPlain!.codepoints.has(0x58), "X must land in Arial non-italic").toBe(true);
   });
 
-  it("{\\p1\\r}X resets drawing-mode to OFF — \\p-then-\\r positional order", async () => {
-    // libass: \p1 enables drawing, then \r resets drawing-off
-    // (libass treats \r as a full state reset including drawing
-    // mode). X collected under Arial. Before the position-sorted
-    // fix: walkText ran R_RESET_RE first (drawing=false from \r),
-    // THEN pTags matchAll.at(-1) (drawing=true from \p1) — the \p
-    // pass clobbered the \r reset, so X was treated as
-    // drawing-mode commands and dropped from glyph collection.
+  it("{\\p1\\r} preserves drawing mode until \\p0", async () => {
     await ensureLoaded();
-    const usage = collectFonts(makeASS(String.raw`{\p1\r}X`));
+    const usage = collectFonts(makeASS(String.raw`{\p1\r}m 0 0 l 1 1{\p0}X`));
     const arial = usage.find((u) => u.key.family === "Arial");
-    expect(arial, "Arial (Default/initial) FontUsage must exist").toBeDefined();
-    expect(
-      arial!.codepoints.has(0x58),
-      "X must land in Arial — \\r after \\p1 must reset drawing-mode OFF"
-    ).toBe(true);
+    expect(arial).toBeDefined();
+    expect(arial!.codepoints.has(0x6d), "drawing command m must stay skipped after \\r").toBe(
+      false
+    );
+    expect(arial!.codepoints.has(0x58), "X after \\p0 must be collected").toBe(true);
   });
 
   it("{\\r\\fnTimes}X — \\r-then-\\fn keeps the later \\fn family (libass parity, sanity check)", async () => {
@@ -769,53 +831,19 @@ describe("font-collector \\r resets siblings within the same block", () => {
   });
 });
 
-// ── Overlong second-alternation cap (1 leading + {128,199999}
-// continuation = 200000 total). The earlier 129-char test pins the
-// LOWER bound of the overlong branch; these two pin the UPPER bound
-// from both sides. Both alternations now carry the trailing boundary
-// lookahead; the 200001-char case relies on the lookahead to refuse
-// rather than silently prefix-matching. ──
-describe("font-collector R_TAG overlong-cap boundary (200000 / 200001)", () => {
-  it("\\r at 200000-char overlong cap matches and resets to initial style", async () => {
-    // At-limit: 1 leading + 199999 continuation = 200000 total, the
-    // exact ceiling of the overlong second alt. m[1] is undefined
-    // (second alt has no capture group), applyOverrideTags treats
-    // the match as "\r with no name" — reset-to-initial-style per
-    // libass parity. F lands under Arial (the dialogue's initial
-    // style), NOT under the prior `\fn Times` family.
+describe("font-collector long \\r arguments", () => {
+  it("consumes a 200000-character name as an event-style fallback", async () => {
     await ensureLoaded();
     const longName = "A".repeat(200000);
     const usage = collectFonts(makeASS(String.raw`{\fnTimes\r` + longName + String.raw`}F`));
-    const arial = usage.find((u) => u.key.family === "Arial");
-    expect(arial, "Arial (Default initial) FontUsage must exist").toBeDefined();
-    expect(
-      arial!.codepoints.has(0x46),
-      "F must land in Arial — 200000-char overlong \\r resets to initial"
-    ).toBe(true);
+    expect(usage.find((entry) => entry.key.family === "Arial")?.codepoints.has(0x46)).toBe(true);
   });
 
-  it("\\r over 200000-char cap: \\r fails to match, prior \\fn family persists", async () => {
-    // Over-limit: 200001 chars can't satisfy either alternation
-    // under the new boundary lookahead — alt 1 caps at 128, alt 2
-    // can't terminate with a non-identifier inside the run of 'A's.
-    // The `\r` is unmatched, the override block is parsed without a
-    // reset, and the prior `\fn Times` family persists through to
-    // the trailing text. Pinned even though MAX_DIALOGUE_TEXT_LEN +
-    // MAX_CAPTION_TEXT_LEN make the over-cap case mostly unreachable
-    // for legitimate input — the contract is what we're locking, not
-    // a likely runtime path.
+  it("also consumes longer names instead of retaining a prior override", async () => {
     await ensureLoaded();
     const tooLong = "A".repeat(200001);
     const usage = collectFonts(makeASS(String.raw`{\fnTimes\r` + tooLong + String.raw`}F`));
-    const times = usage.find((u) => u.key.family === "Times");
-    expect(
-      times,
-      "Times FontUsage must exist — \\fn applied before the unmatched \\r"
-    ).toBeDefined();
-    expect(
-      times!.codepoints.has(0x46),
-      "F must land in Times — over-cap \\r is unrecognized, prior \\fn persists"
-    ).toBe(true);
+    expect(usage.find((entry) => entry.key.family === "Arial")?.codepoints.has(0x46)).toBe(true);
   });
 });
 

--- a/src/features/font-embed/font-collector.ts
+++ b/src/features/font-embed/font-collector.ts
@@ -13,48 +13,13 @@
 import type { ParsedASS } from "ass-compiler";
 import { ASCII_CONTROL_CHARS, BIDI_AND_ZERO_WIDTH_CHARS } from "../../lib/unicode-controls";
 
-// Module-scope override-tag regexes. Compiling once (rather than per
-// override block) avoids `\p{L}` Unicode-property recompilation cost
-// .
-//
-// REFACTOR NOTE: an earlier design had a separate `R_RESET_RE` here
-// that `walkText` used to detect "did this block contain a `\r` →
-// reset isDrawing", plus a different `\r` matchAll regex inside
-// `applyOverrideTags`. The two regexes disagreed on digit-led names
-// and silently broke state. More structurally, the four tag-family
-// matchAll passes inside `applyOverrideTags` each picked their own
-// `.at(-1)` independently, ignoring relative position between
-// families — so `{\fnArial\r}` set family=Arial then style=initial
-// (correct), but `{\rStyleA\fn…}` came out STYLE=StyleA + family=…
-// (also correct), while `{\fnArial\r}` from a left-to-right libass
-// POV should end at font=initialFont. The current design consolidates
-// into a single position-sorted pass over all five tag families
-// inside `applyOverrideTags`, returning `{font, isDrawing}` together.
-// `R_RESET_RE` is no longer needed — the `\r` handler in
-// `applyOverrideTags` does the drawing reset inline alongside the
-// style reset.
-// Overlong-branch upper bound made explicit. Transitively bounded by
-// MAX_DIALOGUE_TEXT_LEN = 1_000_000 upstream; 200_000 leaves comfortable
-// headroom while still being a concrete cap future audits can check
-// without chasing the upstream transitive bound. R_TAG_RE overlong upper
-// {128,199999} (1 leading + 199999 continuation = 200000 total) matches
-// FN_TAG_RE's {129,200000} total ceiling; the symmetry is the contract
-// future audits can search for.
-//
-// Both alternations now carry the trailing boundary lookahead — the
-// first alt (1-128 chars) AND the overlong second alt (129-200000
-// chars) require a non-identifier char after the match. Pre-fix the
-// second alt lacked the lookahead and relied on having no capture
-// group (m[1] = undefined → libass parity reset-to-initial-style) for
-// its safety; a future refactor adding a capture or unifying the two
-// alts would have silently re-created the f871d0cc-class
-// state-retention / prefix-truncation bug. Shape parity with the
-// first alt removes the "safe-by-accident" footgun. Inputs longer
-// than 200000 chars can't reach this regex in practice (upstream
-// MAX_CAPTION_TEXT_LEN caps captions at 64,000 bytes), so the
-// behavior change is unreachable for legitimate or malformed input.
-const R_TAG_RE =
-  /\\r(?:([\p{L}\p{N}_][\p{L}\p{N}_-]{0,127})?(?![\p{L}\p{N}_-])|[\p{L}\p{N}_][\p{L}\p{N}_-]{128,199999}(?![\p{L}\p{N}_-]))/gu;
+// libass parses a non-parenthesized override argument through the next
+// backslash, opening parenthesis, or end of the override block. Supported
+// style names are looked up exactly after trailing ASCII spaces/tabs are removed.
+// Names over the supported 128-codepoint style-name limit are consumed as an
+// unknown reset so they cannot alias a valid prefix. The surrounding dialogue
+// cap bounds this linear full-token scan.
+const R_TAG_RE = /\\r([^\\(]*)/gu;
 // Display-spoofing chars rejected from font family names. NOT added to
 // unicode-controls.ts's BIDI_AND_ZERO_WIDTH_CHARS — that set is mirrored
 // codepoint-for-codepoint to Rust `util.rs` and extended only on a CVE (see
@@ -71,45 +36,13 @@ const R_TAG_RE =
 // the full spoofed family name.
 const FAMILY_SPOOFING_CHARS = "\\u00A0\\u2000-\\u200A\\u202F\\u205F\\u{10000}-\\u{10FFFF}";
 
-// `\fn` regex constructed dynamically because the exclusion class
-// is easier to audit as one named fragment. Capture every codepoint up
-// to the next override/backslash or brace, then sanitize the full value
-// in the tag handler. Excluding display-spoofing chars here would turn
-// them into prefix-truncation boundaries instead of sanitizable input.
-const FN_CHAR_SET = `[^\\\\}{]`;
-const FN_TAG_RE = new RegExp(
-  `\\\\fn(?:(${FN_CHAR_SET}{0,128})(?!${FN_CHAR_SET})|${FN_CHAR_SET}{129,200000}(?!${FN_CHAR_SET}))`,
-  "gu"
-);
-// The three numeric tag regexes must capture the FULL digit run, not
-// a bounded prefix. An earlier attempt to bound them to `\d{1,4}` /
-// `\d{1,2}` / `\d{1,4}` introduced prefix-truncation divergence from
-// ass-compiler's full numeric parse: `\b00700` captured `0070`
-// (weight 70, NOT bold) instead of 700 (bold); `\i001` captured `00`
-// (not italic) instead of 1 (italic); `\p00001` captured `0000`
-// (drawing OFF) instead of 1 (drawing ON). Each path silently
-// mis-attributes embedded fonts vs what libass renders.
-//
-// The bounded-form rationale ("avoids match-object pressure under
-// `\b1\b1\b1...` packed into 1 MB ~330k match objects") didn't hold:
-// every `\b<N>` produces one match regardless of digit bound, so the
-// match-object count is identical with or without the bound; only the
-// per-match capture length changes. Higher-layer caps already bound
-// resource usage: MAX_CAPTION_TEXT_LEN (64,000 bytes per caption) +
-// MAX_FONT_VARIANTS (500) + MAX_CODEPOINTS_PER_VARIANT (65,536) +
-// MAX_TOTAL_CODEPOINTS (1,000,000), and `\d+` over a single-char class
-// is linear with no backtracking.
-//
-// Asymmetry note vs R_TAG_RE / FN_TAG_RE: those two ARE bounded with an
-// explicit overlong second-alternation branch that consumes overlong
-// names rather than truncating — style / family names are strings, so
-// length-capping the captured identifier makes sense. Numeric tags are
-// integer literals; `\d+` + `parseInt` already handles arbitrary
-// length, so the same "bounded + overlong branch" shape is unnecessary
-// and the simplest correct form is unbounded `\d+`.
-const B_TAG_RE = /\\b(\d+)/g;
-const I_TAG_RE = /\\i(\d+)/g;
-const P_TAG_RE = /\\p(\d+)/g;
+// Capture full raw arguments so bare, signed, and otherwise invalid values
+// still participate in the state machine.
+const FN_TAG_RE = /\\fn([^\\(]*)/gu;
+// Exclude longer tags that libass dispatches before the one-letter forms.
+const B_TAG_RE = /\\b(?!lur|ord|e)([^\\(]*)/g;
+const I_TAG_RE = /\\i(?!clip)([^\\(]*)/g;
+const P_TAG_RE = /\\p(?!bo|os)([^\\(]*)/g;
 
 // Lazy dynamic import — only triggers when ensureLoaded() is first called.
 // Previously this ran at module load time, which blocked startup after the
@@ -352,12 +285,22 @@ export function collectFontsWithParser(assContent: string, parser: AssParseFunct
 
   if (parsed.events?.dialogue) {
     for (const dialogue of parsed.events.dialogue) {
-      const styleName = dialogue.Style || "Default";
-      const baseStyle: FontKey = styleMap.get(styleName) ?? {
-        family: "Arial",
-        bold: false,
-        italic: false,
-      };
+      const rawStyleName = dialogue.Style || "Default";
+      // Event styles use libass's common lookup: leading `*` characters are ignored,
+      // and every case variant of "default" resolves to exact `Default`.
+      // `\rNamed` deliberately uses the strict lookup in applyOverrideTags.
+      const unstarredStyleName = rawStyleName.replace(/^\*+/u, "");
+      const styleName =
+        unstarredStyleName.toLowerCase() === "default" ? "Default" : unstarredStyleName;
+      // libass resolves an event's missing/unknown style to the track's exact
+      // `Default` style. Arial is only a synthetic last resort for malformed
+      // tracks that define neither the requested style nor `Default`.
+      const baseStyle: FontKey = styleMap.get(styleName) ??
+        styleMap.get("Default") ?? {
+          family: "Arial",
+          bold: false,
+          italic: false,
+        };
       const rawText: string = dialogue.Text?.raw ?? "";
       processDialogueText(rawText, baseStyle, styleMap, recordChars);
     }
@@ -384,7 +327,7 @@ const MAX_DIALOGUE_TEXT_LEN = 1_000_000;
 
 function processDialogueText(
   text: string,
-  initialFont: FontKey,
+  eventStyle: FontKey,
   styleMap: Map<string, FontKey>,
   recordChars: (key: FontKey, text: string) => void
 ) {
@@ -399,7 +342,11 @@ function processDialogueText(
     // worth surfacing as a hard error the user can act on.
     throw new Error(`Dialogue text too long: ${text.length}+ (max ${MAX_DIALOGUE_TEXT_LEN})`);
   }
-  let current = { ...initialFont };
+  let current = { ...eventStyle };
+  // `currentStyle` is the active style baseline. Inline `\fn`, `\b`, and
+  // `\i` overrides change `current` only; a successful `\rNamed` changes
+  // both. Bare or numerically invalid `\b`/`\i` tags reset against this baseline.
+  let currentStyle = { ...eventStyle };
   let isDrawing = false;
   let i = 0;
 
@@ -434,19 +381,16 @@ function processDialogueText(
       }
 
       const block = text.slice(i + 1, closeIdx);
-      // Position-sorted single-pass override handling:
-      // applyOverrideTags processes all five tag families
-      // (\r / \fn / \b / \i / \p) in source order and returns both the
-      // updated font state AND the new drawing-mode flag. The previous
-      // walkText design ran three independent passes — applyOverrideTags
-      // (for font), then `R_RESET_RE.test` (drawing reset on \r), then
-      // `\p` matchAll (drawing toggle) — which made `{\p1\r}X` drop X
-      // because the \p pass ran AFTER the \r reset. The new design
-      // walks the block left-to-right and lets each tag take effect
-      // in spec order. See REFACTOR NOTE above the regex constants
-      // at module top + the WHY block on applyOverrideTags itself.
-      const overrideResult = applyOverrideTags(block, current, isDrawing, initialFont, styleMap);
+      const overrideResult = applyOverrideTags(
+        block,
+        current,
+        currentStyle,
+        isDrawing,
+        eventStyle,
+        styleMap
+      );
       current = overrideResult.font;
+      currentStyle = overrideResult.style;
       isDrawing = overrideResult.isDrawing;
       i = closeIdx + 1;
     } else {
@@ -470,11 +414,13 @@ function processDialogueText(
 }
 
 /**
- * Result of processing one override block. `font` is the new style/family
- * state; `isDrawing` is the new drawing-mode flag (\p<n>/\r combined).
+ * Result of processing one override block. `font` includes active inline
+ * overrides, while `style` is the baseline selected by the latest successful
+ * `\rNamed` (or the event style after bare/unknown `\r`).
  */
 interface OverrideResult {
   font: FontKey;
+  style: FontKey;
   isDrawing: boolean;
 }
 
@@ -482,88 +428,29 @@ interface OverrideResult {
  *  tag-family regexes. `pos` is the match's byte index inside the block,
  *  used to sort tags into source order before applying. */
 type OverrideTag =
-  | { kind: "r"; pos: number; styleName: string | undefined }
-  | { kind: "fn"; pos: number; family: string | undefined }
-  | { kind: "b"; pos: number; weight: number }
-  | { kind: "i"; pos: number; flag: number }
-  | { kind: "p"; pos: number; scale: number };
+  | { kind: "r"; pos: number; styleName: string }
+  | { kind: "fn"; pos: number; family: string }
+  | { kind: "b"; pos: number; value: string }
+  | { kind: "i"; pos: number; value: string }
+  | { kind: "p"; pos: number; value: string };
 
 /**
- * Apply override tags from a single `{ … }` block in libass left-to-right
- * order, returning the new font + drawing-mode state.
- *
- * **Tag-family regex history** (preserved for archeology — git log has
- * the per-commit detail):
- *
- * - `\r` capture-group leading class: progressively widened from
- *   `[A-Za-z]` → `[\p{L}_]` (accept CJK / `_Alt` / `José`) →
- *   `[\p{L}\p{N}_]` (accept digit-led style names that ass-compiler
- *   stores in styleMap without validation). The continuation class
- *   is `[\p{L}\p{N}_-]` — leading + continuation now differ only on
- *   dash (dash-at-start is a typo trap). Lesson: when a regex change
- *   alters what `matchAll` returns for
- *   some input shape, audit every caller that walks the matches for
- *   state-machine effects, AND audit the ENTIRE input-shape catalog
- *   before declaring the fix complete (one shape closed is not the
- *   whole catalog).
- *
- * - `\r` overlong handling: bare `{0,127}` upper bound + boundary
- *   lookahead `(?![\p{L}\p{N}_-])` → SECOND alternation branch
- *   `[\p{L}\p{N}_][\p{L}\p{N}_-]{128,}` matching overlong runs
- *   WITHOUT a capture group. Without the second branch, `matchAll`
- *   simply skipped overlong tokens, letting a prior `\r<valid>` in
- *   the same block leave its state in force. With it, overlong
- *   matches with undefined capture → falls through the
- *   `styleName && …` check to `font = initialFont`.
- *
- * - `\rdefault`: canonical "reset to dialogue initial" form, handled
- *   by the literal-string check `styleName.toLowerCase() !== "default"`.
- *   This pre-empts a `Style: default,…` definition in [V4+ Styles]
- *   that would otherwise shadow the dialogue's initial style.
- *
- * - `\fn` family capture: sibling-parity with `\r` for the boundary
- *   lookahead and overlong-alternation patterns. Exclusion class
- *   `[^\\}{C0/DEL/C1/BiDi]` stops the capture at a literal `{` so
- *   `\fn{Evil}` doesn't carry the brace into match keys, and stops
- *   at control chars so `\fn<U+202E>evil` doesn't make the embed
- *   family diverge from the libass-rendered family.
- *
- * - `\b`: relies on `\b` being followed strictly by a digit; ASS spec
- *   tags `\blur<n>` / `\bord<n>` start with `\b` but follow with a
- *   letter, so the regex won't false-match. If a future ASS extension
- *   adds a `\b<word>` tag, tighten the regex.
- *
- * - **Position-sorted single-pass**: an earlier design ran four
- *   independent `matchAll().at(-1)` passes (one per tag family) and
- *   the walkText caller ran two more passes for `\r` reset detection
- *   and `\p` drawing-mode toggle. Family-independent last-wins
- *   ignored relative position between families: e.g.
- *   `{\fnArial\r}` would set family=Arial AND style=initial because
- *   the `\fn` pass ran after `\r` and overwrote `result.family`; but
- *   libass / xy-VSFilter process tags left-to-right and `\r` should
- *   reset family back to initialFont. Same shape applied to
- *   `{\p1\r}` (drawing-on then reset → libass renders, our code
- *   dropped glyphs), `{\b1\r}`, `{\i1\r}`. The current code collects
- *   all five tag families into one position-sorted list and walks
- *   them left-to-right; `\r` resets both font state AND drawing-mode
- *   in the same handler. Tests pinning previous edge-case behavior
- *   (`current.family` fallback in `\fn` sanitize-failure path) are
- *   preserved by referencing the function parameter `current` (the
- *   pre-block snapshot) rather than the running `font` state.
- *
- * - **Last-wins per family** is preserved by the sort being stable
- *   per family: when the same family appears twice in one block
- *   (`{\fnArial\fnTimes}`), the later match simply overwrites in the
- *   walk and the family-final = last occurrence.
+ * Apply override tags from one `{ … }` block in source order. The style
+ * baseline must be distinct from inline overrides because style-relative
+ * `\fn`, `\b`, and `\i` resets use the style selected by the latest `\rNamed`,
+ * not necessarily the dialogue's original style. Present nonnumeric `\b`/`\i`
+ * arguments parse as zero instead of using the baseline.
  */
 function applyOverrideTags(
   block: string,
   current: FontKey,
+  activeStyle: FontKey,
   currentDrawing: boolean,
-  initialFont: FontKey,
+  eventStyle: FontKey,
   styleMap: Map<string, FontKey>
 ): OverrideResult {
   let font = { ...current };
+  let style = { ...activeStyle };
   let isDrawing = currentDrawing;
 
   // Collect matches from each tag family into one position-tagged list.
@@ -572,19 +459,19 @@ function applyOverrideTags(
   // a `.match()` non-global concern that doesn't apply to matchAll.
   const tags: OverrideTag[] = [];
   for (const m of block.matchAll(R_TAG_RE)) {
-    tags.push({ kind: "r", pos: m.index!, styleName: m[1] });
+    tags.push({ kind: "r", pos: m.index!, styleName: m[1]! });
   }
   for (const m of block.matchAll(FN_TAG_RE)) {
-    tags.push({ kind: "fn", pos: m.index!, family: m[1] });
+    tags.push({ kind: "fn", pos: m.index!, family: m[1]! });
   }
   for (const m of block.matchAll(B_TAG_RE)) {
-    tags.push({ kind: "b", pos: m.index!, weight: parseInt(m[1]!, 10) });
+    tags.push({ kind: "b", pos: m.index!, value: m[1]! });
   }
   for (const m of block.matchAll(I_TAG_RE)) {
-    tags.push({ kind: "i", pos: m.index!, flag: parseInt(m[1]!, 10) });
+    tags.push({ kind: "i", pos: m.index!, value: m[1]! });
   }
   for (const m of block.matchAll(P_TAG_RE)) {
-    tags.push({ kind: "p", pos: m.index!, scale: parseInt(m[1]!, 10) });
+    tags.push({ kind: "p", pos: m.index!, value: m[1]! });
   }
 
   // Stable position sort — preserves insertion order on tie, though
@@ -595,60 +482,81 @@ function applyOverrideTags(
   for (const tag of tags) {
     switch (tag.kind) {
       case "r": {
-        const styleName = tag.styleName;
-        if (styleName && styleName.toLowerCase() !== "default" && styleMap.has(styleName)) {
-          font = { ...styleMap.get(styleName)! };
-        } else {
-          font = { ...initialFont };
-        }
-        // libass: `\r` resets ALL style state including drawing mode.
-        // Previous walkText design did this via a separate
-        // `R_RESET_RE.test(block)` pass, which the `\p` pass then
-        // overwrote on `{\p1\r}` . Folded into the `\r`
-        // handler here so the position-sorted walk gets it right.
-        isDrawing = false;
+        const trimmedStyleName = trimTrailingTagSpaces(tag.styleName);
+        const styleName = Array.from(trimmedStyleName).length <= 128 ? trimmedStyleName : "";
+        const namedStyle = styleName ? styleMap.get(styleName) : undefined;
+        style = { ...(namedStyle ?? eventStyle) };
+        font = { ...style };
+        // libass's `\r` render-context reset intentionally leaves
+        // `drawing_scale` unchanged; only `\p` changes drawing mode.
         break;
       }
       case "fn": {
-        // `\fn<empty>` and the overlong second-alternation branch
-        // both produce `tag.family === undefined`; the `?? ""` keeps
-        // the existing fall-through-to-initialFont semantic.
-        //
         // Capture first, sanitize second. If FN_TAG_RE treats spoofing
         // whitespace, BiDi, or astral codepoints as boundaries, malformed
         // names become prefix aliases (for example `Arial<NBSP>Black` ->
-        // `Arial`). Let sanitizeFamily see the full family name, then reset
-        // to the initial family only when sanitization leaves no usable name.
-        const rawFamily = normalizeFamily(tag.family ?? "");
+        // `Arial`). Let sanitizeFamily see the full family name. Bare `\fn`
+        // and exact `\fn0` reset to the currently active style family.
+        const familyArg = trimTrailingTagSpaces(tag.family);
+        if (!familyArg || familyArg === "0") {
+          font.family = style.family;
+          break;
+        }
+        // libass checks exact `0` before skipping leading argument whitespace.
+        // Apply the project length gate after that same leading trim.
+        const familyForLength = familyArg.replace(/^[ \t]+/u, "");
+        if (Array.from(familyForLength).length > 128) {
+          font.family = style.family;
+          break;
+        }
+        const rawFamily = normalizeFamily(familyArg);
         const sanitizedFamily = sanitizeFamily(rawFamily);
         if (!sanitizedFamily) {
-          font.family = initialFont.family;
+          font.family = style.family;
         } else {
           font.family = sanitizedFamily;
         }
         break;
       }
-      case "b":
-        // `\b0` = not bold; `\b1` = bold; `\b2`-`\b699` = libass treats
-        // as not-bold (only `1` is the bold-on flag in the low range);
-        // `\b700+` = bold by font weight value (CSS-style weight scale).
-        // middle range named explicitly so the contract
-        // matches the predicate. B_TAG_RE captures the full digit run
-        // (see WHY block at the regex const); overlong
-        // values like `\b00700` parse as 700 → bold-on per libass.
-        font.bold = tag.weight === 1 || tag.weight >= 700;
+      case "b": {
+        const weight = parseTagInteger(tag.value);
+        if (weight === null || !(weight === 0 || weight === 1 || weight >= 100)) {
+          font.bold = style.bold;
+        } else {
+          // FontKey has a boolean bold axis, while libass preserves exact
+          // weights >=100. Keep the existing regular/bold threshold without
+          // claiming exact fidelity for intermediate weights.
+          font.bold = weight === 1 || weight >= 700;
+        }
         break;
-      case "i":
-        font.italic = tag.flag !== 0;
+      }
+      case "i": {
+        const flag = parseTagInteger(tag.value);
+        font.italic = flag === 0 || flag === 1 ? flag === 1 : style.italic;
         break;
-      case "p":
-        // libass: positive scale = drawing-on, zero = drawing-off.
-        // libass parses the full numeric value; treat any positive
-        // integer as drawing-on.
-        isDrawing = tag.scale > 0;
+      }
+      case "p": {
+        const scale = parseTagInteger(tag.value);
+        // Bare, invalid, and negative drawing scales resolve to zero.
+        isDrawing = scale !== null && scale > 0;
         break;
+      }
     }
   }
 
-  return { font, isDrawing };
+  return { font, style, isDrawing };
+}
+
+function trimTrailingTagSpaces(value: string): string {
+  return value.replace(/[ \t]+$/u, "");
+}
+
+function parseTagInteger(value: string): number | null {
+  const normalized = trimTrailingTagSpaces(value);
+  if (!normalized) return null;
+  const match = /^\s*[+-]?\d+/.exec(normalized);
+  // libass's integer parser yields zero for a present but nonnumeric argument.
+  if (!match) return 0;
+  const parsed = Number.parseInt(match[0], 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
 }

--- a/src/features/hdr-convert/HdrConvert.tsx
+++ b/src/features/hdr-convert/HdrConvert.tsx
@@ -8,8 +8,7 @@ import {
 } from "../../lib/tauri-api";
 import { processAssContent, parseAssColor, formatAssColor } from "./ass-processor";
 import {
-  processSrtUserText,
-  buildAssDocumentFromCaptions,
+  convertTextCueSubtitleToAss,
   isNativeAss,
   isConvertible,
   DEFAULT_STYLE,
@@ -19,12 +18,17 @@ import { resolveOutputPath, OUTPUT_PRESETS, DEFAULT_TEMPLATE } from "./output-na
 import { DEFAULT_BRIGHTNESS, MIN_BRIGHTNESS, MAX_BRIGHTNESS, type Eotf } from "./color-engine";
 import { ask } from "@tauri-apps/plugin-dialog";
 
-import { parseSubtitle } from "../../lib/subtitle-parser";
 import NumberInput from "../../lib/NumberInput";
 import { parseFiniteNumberText } from "../../lib/strict-number";
 import NitViz from "./NitViz";
 import { isHdrBrightnessInvalid, isHdrConvertDisabled } from "./hdr-ui-state";
-import { parseHdrStyleNumberInput } from "./hdr-style-ui-state";
+import {
+  hasMicroDvdInput,
+  isHdrFpsInvalid,
+  parseHdrFpsOverrideForInput,
+  parseHdrStyleNumberInput,
+  type HdrFpsMode,
+} from "./hdr-style-ui-state";
 import { useI18n } from "../../i18n/useI18n";
 import { useFileContext } from "../../lib/FileContext";
 import type { Status } from "../../lib/StatusContext";
@@ -97,6 +101,8 @@ export default function HdrConvert() {
   const [customTemplate, setCustomTemplate] = useState("");
   const [showStylePanel, setShowStylePanel] = useState(false);
   const [style, setStyle] = useState<StyleConfig>({ ...DEFAULT_STYLE });
+  const [fpsMode, setFpsMode] = useState<HdrFpsMode>("auto");
+  const [fpsText, setFpsText] = useState("23.976");
   const [processing, setProcessing] = useState(false);
   const { logs, addLog, clearLogs, logScrollRef } = useLogPanel();
   const [showFileList, setShowFileList] = useState(false);
@@ -196,6 +202,9 @@ export default function HdrConvert() {
 
   const activeTemplate = template === "custom" ? customTemplate : template;
   const templateInvalid = template === "custom" && customTemplate.trim().length === 0;
+  const batchHasSub = hasMicroDvdInput(hdrFiles?.fileNames ?? []);
+  const fpsInputInvalid = isHdrFpsInvalid(fpsMode, fpsText);
+  const fpsInvalid = batchHasSub && fpsInputInvalid;
   // Gate Convert on the same visible-input validity shown by the
   // controls, so keyboard activation cannot commit a stale prior
   // brightness value or start a batch with a universally invalid template.
@@ -204,6 +213,7 @@ export default function HdrConvert() {
     processing,
     brightnessInvalid,
     templateInvalid,
+    fpsInvalid,
   });
 
   // ── File selection (separate from conversion) ──────────
@@ -295,6 +305,7 @@ export default function HdrConvert() {
         processing,
         brightnessInvalid,
         templateInvalid,
+        fpsInvalid,
       })
     ) {
       return;
@@ -461,16 +472,10 @@ export default function HdrConvert() {
               // Direct ASS processing
               assContent = processAssContent(content, brightness, eotf);
             } else if (isConvertible(fileName)) {
-              // Text-cue → ASS conversion path. processSrtUserText composes
-              // the two-step user-text pipeline (escape user braces, then
-              // inject our trusted color tags) so the order can't be swapped
-              // or one step skipped by a future caller.
-              const preprocessed = processSrtUserText(content);
+              const fpsOverride = parseHdrFpsOverrideForInput(fileName, fpsMode, fpsText);
+              if (fpsOverride === null) throw new Error(t("style_fps_invalid"));
 
-              // Parse with our browser-compatible parser
-              const { captions } = parseSubtitle(preprocessed, style.fps);
-
-              // Surface skipped-placeholder count. All four parsers
+              // Surface skipped-placeholder count. All text-cue parsers
               // push `skipped: true` Captions for entries whose text
               // exceeded MAX_CAPTION_TEXT_LEN (64 KB). Without
               // surfacing the count, the data loss is invisible to
@@ -478,9 +483,10 @@ export default function HdrConvert() {
               // dropped from the captions array on the SRT/VTT side).
               // Log via addLog so the user sees it rather than
               // discovering it after the fact.
-              const { content: rawAss, skippedCount } = buildAssDocumentFromCaptions(
-                captions,
-                style
+              const { content: rawAss, skippedCount } = convertTextCueSubtitleToAss(
+                content,
+                style,
+                fpsOverride
               );
               if (skippedCount > 0) {
                 addLog(t("msg_oversized_skipped", skippedCount, fileName), "warn");
@@ -551,10 +557,13 @@ export default function HdrConvert() {
     processing,
     brightnessInvalid,
     templateInvalid,
+    fpsInvalid,
     brightness,
     eotf,
     activeTemplate,
     style,
+    fpsMode,
+    fpsText,
     addLog,
     t,
   ]);
@@ -868,7 +877,9 @@ export default function HdrConvert() {
       {/* Collapsible Style Settings */}
       <div className="rounded-lg" style={{ border: "1px solid var(--border)" }}>
         <button
+          type="button"
           onClick={() => setShowStylePanel(!showStylePanel)}
+          aria-expanded={showStylePanel}
           className="w-full flex items-center gap-2 px-4 py-3 text-sm font-medium rounded-lg transition-colors"
           style={{ color: "var(--text-secondary)" }}
         >
@@ -877,6 +888,11 @@ export default function HdrConvert() {
           <span className="text-xs ml-2" style={{ color: "var(--text-muted)" }}>
             {t("style_hint")}
           </span>
+          {fpsInvalid && !showStylePanel && (
+            <span className="text-xs ml-auto" style={{ color: "var(--error)" }}>
+              {t("style_fps_invalid_summary")}
+            </span>
+          )}
         </button>
         {showStylePanel && (
           <div className="px-4 pb-4 grid grid-cols-2 gap-3">
@@ -1014,20 +1030,57 @@ export default function HdrConvert() {
               />
             </div>
             <div>
-              <label className="block text-xs mb-1" style={{ color: "var(--text-muted)" }}>
+              <label
+                htmlFor="hdr-fps-mode"
+                className="block text-xs mb-1"
+                style={{ color: "var(--text-muted)" }}
+              >
                 {t("style_fps")}
               </label>
-              <NumberInput
-                value={style.fps}
-                onChange={(v) => {
-                  const n = parseHdrStyleNumberInput(v, 1, 120);
-                  if (n !== null) setStyle({ ...style, fps: n });
-                }}
-                min={1}
-                max={120}
-                step="0.001"
+              <select
+                id="hdr-fps-mode"
+                value={fpsMode}
+                onChange={(event) => setFpsMode(event.target.value as HdrFpsMode)}
                 disabled={processing}
+                className="w-full px-2 py-1.5 rounded text-sm"
+                style={{
+                  background: "var(--bg-input)",
+                  border: "1px solid var(--border)",
+                  color: "var(--text-primary)",
+                }}
+              >
+                <option value="auto">{t("style_fps_auto")}</option>
+                <option value="manual">{t("style_fps_manual")}</option>
+              </select>
+            </div>
+            <div>
+              <label
+                htmlFor="hdr-fps-value"
+                className="block text-xs mb-1"
+                style={{ color: "var(--text-muted)" }}
+              >
+                {t("style_fps_value")}
+              </label>
+              <NumberInput
+                id="hdr-fps-value"
+                value={fpsText}
+                onChange={setFpsText}
+                min={3}
+                max={120}
+                step="any"
+                disabled={processing || fpsMode === "auto"}
+                invalid={fpsInputInvalid}
+                ariaDescribedBy={fpsInputInvalid ? "hdr-fps-error" : undefined}
               />
+              {fpsInputInvalid && (
+                <span
+                  id="hdr-fps-error"
+                  className="block text-xs mt-1"
+                  style={{ color: "var(--error)" }}
+                >
+                  {t("style_fps_invalid")}
+                </span>
+              )}
             </div>
           </div>
         )}

--- a/src/features/hdr-convert/hdr-style-ui-state.test.ts
+++ b/src/features/hdr-convert/hdr-style-ui-state.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from "vitest";
 
-import { parseHdrStyleNumberInput } from "./hdr-style-ui-state";
+import {
+  hasMicroDvdInput,
+  isHdrFpsInvalid,
+  parseHdrFpsOverride,
+  parseHdrFpsOverrideForInput,
+  parseHdrStyleNumberInput,
+} from "./hdr-style-ui-state";
 
 describe("HDR style UI state", () => {
   it("rejects malformed numeric-prefix style values", () => {
@@ -21,5 +27,27 @@ describe("HDR style UI state", () => {
     expect(parseHdrStyleNumberInput("48", 1, 200)).toBe(48);
     expect(parseHdrStyleNumberInput("1e2", 1, 200)).toBe(100);
     expect(parseHdrStyleNumberInput("0.5", 0, 20)).toBe(0.5);
+  });
+
+  it("represents Auto FPS as no explicit override", () => {
+    expect(parseHdrFpsOverride("auto", "not used")).toBeUndefined();
+    expect(isHdrFpsInvalid("auto", "")).toBe(false);
+  });
+
+  it("accepts only a finite manual FPS greater than 3 and at most 120", () => {
+    expect(parseHdrFpsOverride("manual", "23.976")).toBe(23.976);
+    expect(parseHdrFpsOverride("manual", "120")).toBe(120);
+    for (const invalid of ["", "3", "120.001", "NaN", "Infinity", "25fps", "1e"]) {
+      expect(parseHdrFpsOverride("manual", invalid)).toBeNull();
+      expect(isHdrFpsInvalid("manual", invalid)).toBe(true);
+    }
+  });
+
+  it("applies manual FPS validation only to MicroDVD inputs", () => {
+    expect(hasMicroDvdInput(["episode.srt", "episode.ass"])).toBe(false);
+    expect(hasMicroDvdInput(["episode.srt", "EPISODE.SUB"])).toBe(true);
+    expect(parseHdrFpsOverrideForInput("episode.srt", "manual", "bad")).toBeUndefined();
+    expect(parseHdrFpsOverrideForInput("episode.sub", "manual", "bad")).toBeNull();
+    expect(parseHdrFpsOverrideForInput("episode.sub", "manual", "25")).toBe(25);
   });
 });

--- a/src/features/hdr-convert/hdr-style-ui-state.ts
+++ b/src/features/hdr-convert/hdr-style-ui-state.ts
@@ -1,4 +1,7 @@
 import { parseFiniteNumberText } from "../../lib/strict-number";
+import { isValidMicroDvdFps } from "../../lib/subtitle-parser";
+
+export type HdrFpsMode = "auto" | "manual";
 
 export function parseHdrStyleNumberInput(
   text: string,
@@ -8,4 +11,32 @@ export function parseHdrStyleNumberInput(
   const value = parseFiniteNumberText(text);
   if (value === null || value < minValue || value > maxValue) return null;
   return value;
+}
+
+/** Auto is represented by `undefined`; `null` means invalid manual text. */
+export function parseHdrFpsOverride(mode: HdrFpsMode, text: string): number | undefined | null {
+  if (mode === "auto") return undefined;
+  const value = parseFiniteNumberText(text);
+  if (value === null || !isValidMicroDvdFps(value)) return null;
+  return value;
+}
+
+export function isHdrFpsInvalid(mode: HdrFpsMode, text: string): boolean {
+  return parseHdrFpsOverride(mode, text) === null;
+}
+
+export function isMicroDvdInputName(fileName: string): boolean {
+  return fileName.toLowerCase().endsWith(".sub");
+}
+
+export function hasMicroDvdInput(fileNames: readonly string[]): boolean {
+  return fileNames.some(isMicroDvdInputName);
+}
+
+export function parseHdrFpsOverrideForInput(
+  fileName: string,
+  mode: HdrFpsMode,
+  text: string
+): number | undefined | null {
+  return isMicroDvdInputName(fileName) ? parseHdrFpsOverride(mode, text) : undefined;
 }

--- a/src/features/hdr-convert/hdr-ui-state.test.ts
+++ b/src/features/hdr-convert/hdr-ui-state.test.ts
@@ -28,6 +28,7 @@ describe("HDR UI state guards", () => {
         processing: false,
         brightnessInvalid: true,
         templateInvalid: false,
+        fpsInvalid: false,
       })
     ).toBe(true);
   });
@@ -39,6 +40,7 @@ describe("HDR UI state guards", () => {
         processing: false,
         brightnessInvalid: false,
         templateInvalid: true,
+        fpsInvalid: false,
       })
     ).toBe(true);
   });
@@ -50,7 +52,20 @@ describe("HDR UI state guards", () => {
         processing: false,
         brightnessInvalid: false,
         templateInvalid: false,
+        fpsInvalid: false,
       })
     ).toBe(false);
+  });
+
+  it("disables Convert when the visible manual FPS is invalid", () => {
+    expect(
+      isHdrConvertDisabled({
+        hasFiles: true,
+        processing: false,
+        brightnessInvalid: false,
+        templateInvalid: false,
+        fpsInvalid: true,
+      })
+    ).toBe(true);
   });
 });

--- a/src/features/hdr-convert/hdr-ui-state.ts
+++ b/src/features/hdr-convert/hdr-ui-state.ts
@@ -5,6 +5,7 @@ export interface HdrConvertDisabledState {
   processing: boolean;
   brightnessInvalid: boolean;
   templateInvalid: boolean;
+  fpsInvalid: boolean;
 }
 
 export function isHdrBrightnessInvalid(
@@ -17,5 +18,11 @@ export function isHdrBrightnessInvalid(
 }
 
 export function isHdrConvertDisabled(state: HdrConvertDisabledState): boolean {
-  return !state.hasFiles || state.processing || state.brightnessInvalid || state.templateInvalid;
+  return (
+    !state.hasFiles ||
+    state.processing ||
+    state.brightnessInvalid ||
+    state.templateInvalid ||
+    state.fpsInvalid
+  );
 }

--- a/src/features/hdr-convert/srt-converter.test.ts
+++ b/src/features/hdr-convert/srt-converter.test.ts
@@ -32,14 +32,19 @@ describe("preprocessSrtColors", () => {
     expect(result).not.toContain("<font");
   });
 
-  it("inserts color reset after </font>", () => {
+  it("restores the current style primary color after the outer </font>", () => {
     const result = preprocessSrtColors('<font color="#FF0000">Red</font> normal');
-    // Pin the reset shape — the loose alternation `\{\\1c&H[0-9A-F]{6}\}`
-    // would still pass for an emitted `&HDEADBE` (any 6 hex). The reset
-    // contract is "either ASS reset tag {\r}, OR explicit BGR black
-    // (000000)." Anchor on those two specific shapes so a regression
-    // emitting a stray non-zero color still fails.
-    expect(result).toMatch(/Red(?:\{\\r\}|\{\\1c&H0+&?\}) normal/);
+    expect(result).toBe("{\\1c&H0000FF&}Red{\\1c} normal");
+    expect(result).not.toContain("{\\r}");
+  });
+
+  it("restores the previous inline color when colored font tags nest", () => {
+    const result = preprocessSrtColors(
+      '<font color="#FF0000">red <font color="#00FF00">green</font> red</font> default'
+    );
+
+    expect(result).toBe("{\\1c&H0000FF&}red {\\1c&H00FF00&}green{\\1c&H0000FF&} red{\\1c} default");
+    expect(result).not.toContain("{\\r}");
   });
 
   it("handles multiple attributes on <font> tag", () => {
@@ -73,16 +78,28 @@ describe("preprocessSrtColors", () => {
   it("handles text with no color attribute on font tag", () => {
     const input = '<font face="Arial">Styled</font>';
     const result = preprocessSrtColors(input);
-    // Layer-of-responsibility note: preprocessSrtColors only handles
-    // color-bearing <font> tags here. The opener without color is
-    // intentionally left in — it's stripped downstream by
-    // buildAssDocument's HTML-tag removal pass (see srt-converter.ts
-    // line 64 comment). The </font> closer DOES become {\\r} regardless,
-    // because that path is a uniform style-reset emitter.
-    expect(result).toContain("Styled");
-    // Closer always becomes {\r}, including when the opener carried no color.
-    expect(result).not.toContain("</font>");
-    expect(result).toContain("{\\r}");
+    // This stage owns color only. The document builder strips the untouched
+    // non-color HTML tags later, so neither side may inject a style reset.
+    expect(result).toBe(input);
+    expect(result).not.toContain("{\\r}");
+    expect(result).not.toContain("{\\1c}");
+  });
+
+  it("tracks mixed color and non-color font frames without popping color early", () => {
+    const result = preprocessSrtColors(
+      '<font color="#FF0000">outer <font face="Arial">inner</font> outer</font> default'
+    );
+
+    expect(result).toBe('{\\1c&H0000FF&}outer <font face="Arial">inner</font> outer{\\1c} default');
+  });
+
+  it("lets a colored inner frame reset without changing its non-color outer frame", () => {
+    const result = preprocessSrtColors(
+      '<font face="Arial">outer <font color="#00FF00">green</font> outer</font> default'
+    );
+
+    expect(result).toBe('<font face="Arial">outer {\\1c&H00FF00&}green{\\1c} outer</font> default');
+    expect(result).not.toContain("{\\r}");
   });
 
   it("does not match color openers beyond the bounded windows in a 100KB payload", () => {
@@ -94,7 +111,8 @@ describe("preprocessSrtColors", () => {
     const chunk = '<font face="Arial" data-extra="x"'.repeat(40); // ~1300 bytes
     const payload = chunk.repeat(80) + ">Styled</font>"; // ~100KB
     const result = preprocessSrtColors(payload);
-    expect(result).toBe(payload.replace("</font>", "{\\r}"));
+    expect(result).toBe(payload);
+    expect(result).not.toContain("{\\1c");
   });
 
   it.each([
@@ -110,8 +128,51 @@ describe("preprocessSrtColors", () => {
     const atLimit = makeInput(512);
     const overLimit = makeInput(513);
 
-    expect(preprocessSrtColors(atLimit)).toBe("{\\1c&H0000FF&}Styled{\\r}");
-    expect(preprocessSrtColors(overLimit)).toBe(overLimit.replace("</font>", "{\\r}"));
+    expect(preprocessSrtColors(atLimit)).toBe("{\\1c&H0000FF&}Styled{\\1c}");
+    expect(preprocessSrtColors(overLimit)).toBe(overLimit);
+  });
+
+  it("leaves malformed and unmatched font markup non-resetting", () => {
+    expect(preprocessSrtColors("before</font>after")).toBe("before</font>after");
+    expect(preprocessSrtColors('<font color="#FF0000">unclosed')).toBe("{\\1c&H0000FF&}unclosed");
+    expect(preprocessSrtColors("<font color='#FF0000'>unsupported quote</font>")).toBe(
+      "<font color='#FF0000'>unsupported quote</font>"
+    );
+  });
+
+  it("keeps overflow closers from popping the last tracked color frame", () => {
+    const trackedNonColorOpeners = '<font face="Arial">'.repeat(255);
+    const trackedNonColorClosers = "</font>".repeat(255);
+    const input =
+      '<font color="#FF0000">outer ' +
+      trackedNonColorOpeners +
+      '<font color="#00FF00">overflow</font> sentinel ' +
+      trackedNonColorClosers +
+      " outer-tail</font> default";
+
+    const processed = processSrtUserText(input);
+    const document = buildAssDocument([{ start: 0, end: 1_000, text: processed }]);
+    const dialogue = document.split("\n").find((line) => line.startsWith("Dialogue:"));
+
+    expect(dialogue).toContain("{\\1c&H0000FF&}outer overflow sentinel  outer-tail{\\1c} default");
+    expect(dialogue).not.toContain("{\\1c&H00FF00&}");
+    expect(dialogue).not.toContain("{\\r}");
+  });
+
+  it("keeps an overlength opener from closing its tracked outer color early", () => {
+    const overlengthColorOpener = `<font ${"x".repeat(1_040)} color="#00FF00">`;
+    const input =
+      '<font color="#FF0000">outer ' +
+      overlengthColorOpener +
+      "overflow</font> sentinel</font> default";
+
+    const processed = processSrtUserText(input);
+    const document = buildAssDocument([{ start: 0, end: 1_000, text: processed }]);
+    const dialogue = document.split("\n").find((line) => line.startsWith("Dialogue:"));
+
+    expect(dialogue).toContain("{\\1c&H0000FF&}outer overflow sentinel{\\1c} default");
+    expect(dialogue).not.toContain("{\\1c&H00FF00&}");
+    expect(dialogue).not.toContain("{\\r}");
   });
 });
 
@@ -129,6 +190,15 @@ describe("processSrtUserText", () => {
     expect(out).toContain("\\{\\\\an8\\}");
     // Our injected color tag DID land in the output (real `{\1c…}`).
     expect(out).toMatch(/\{\\1c&H/);
+  });
+
+  it("does not expose a raw user override through color-tag attributes or text", () => {
+    const input = '<font color="#FF0000" title="{\\an8}">Red</font>{\\pos(10,20)} after color';
+    const out = processSrtUserText(input);
+
+    expect(out).toBe("{\\1c&H0000FF&}Red{\\1c}\\{\\\\pos(10,20)\\} after color");
+    expect(out).not.toContain("{\\an8}");
+    expect(out).not.toContain("{\\pos(10,20)}");
   });
 
   it("equals preprocessSrtColors(escapeSrtUserText(text)) by composition", () => {
@@ -374,6 +444,19 @@ describe("SRT pipeline integration — color-tag preservation regression", () =>
     expect(doc).toContain("Red text");
     // `{` must NOT appear escaped in the Dialogue line emitted for our tag
     expect(doc).not.toMatch(/\\\{\\\\1c/);
+  });
+
+  it("restores only color while surrounding bold, italic, and underline stay active", () => {
+    const processed = processSrtUserText(
+      '<b><i><u><font color="#FF0000">colored</font> styled tail</u></i></b>'
+    );
+    const doc = buildAssDocument([{ start: 0, end: 1_000, text: processed }]);
+    const dialogue = doc.split("\n").find((line) => line.startsWith("Dialogue:"));
+
+    expect(dialogue).toContain(
+      "{\\b1}{\\i1}{\\u1}{\\1c&H0000FF&}colored{\\1c} styled tail{\\u0}{\\i0}{\\b0}"
+    );
+    expect(dialogue).not.toContain("{\\r}");
   });
 });
 

--- a/src/features/hdr-convert/srt-converter.test.ts
+++ b/src/features/hdr-convert/srt-converter.test.ts
@@ -11,6 +11,7 @@ import {
   processSrtUserText,
   buildAssDocument,
   buildAssDocumentFromCaptions,
+  convertTextCueSubtitleToAss,
   isNativeAss,
   isConvertible,
   DEFAULT_STYLE,
@@ -147,6 +148,53 @@ describe("processSrtUserText", () => {
   it("is idempotent on text with no user braces and no color tags", () => {
     const plain = "Hello world, no markup at all.";
     expect(processSrtUserText(plain)).toBe(plain);
+  });
+});
+
+describe("shared text-cue to ASS conversion", () => {
+  it("parses MicroDVD structure before escaping cue text and excludes FPS metadata", () => {
+    const sub = '{1}{1}25.000\n{25}{50}{\\an8}<font color="#FF0000">Red</font>\n';
+    const result = convertTextCueSubtitleToAss(sub);
+    const dialogues = result.content.split("\n").filter((line) => line.startsWith("Dialogue:"));
+
+    expect(dialogues).toHaveLength(1);
+    expect(dialogues[0]).toContain("0:00:01.00,0:00:02.00");
+    expect(dialogues[0]).toContain("\\{\\\\an8\\}");
+    expect(dialogues[0]).toContain("{\\1c&H0000FF&}Red");
+    expect(result.content).not.toContain("25.000");
+  });
+
+  it("uses an explicit manual FPS override instead of the declaration", () => {
+    const result = convertTextCueSubtitleToAss("{1}{1}25\n{25}{50}Hello\n", DEFAULT_STYLE, 50);
+    const dialogue = result.content.split("\n").find((line) => line.startsWith("Dialogue:"));
+
+    expect(dialogue).toContain("0:00:00.50,0:00:01.00");
+  });
+
+  it.each([
+    ["SRT", (text: string) => `1\n00:00:01,000 --> 00:00:02,000\n${text}\n`],
+    ["WebVTT", (text: string) => `WEBVTT\n\n00:00:01.000 --> 00:00:02.000\n${text}\n`],
+    ["MicroDVD", (text: string) => `{1}{1}25\n{25}{50}${text}\n`],
+  ])(
+    "rejects all-oversized %s input with the skipped count before returning empty ASS",
+    (_format, makeInput) => {
+      expect(() => convertTextCueSubtitleToAss(makeInput("X".repeat(65_000)))).toThrow(
+        /all 1 cue.*64000/i
+      );
+    }
+  );
+
+  it("keeps valid cues when an oversized sibling is skipped without emitting a blank Dialogue", () => {
+    const oversized = "X".repeat(65_000);
+    const srt =
+      `1\n00:00:01,000 --> 00:00:02,000\n${oversized}\n\n` +
+      "2\n00:00:03,000 --> 00:00:04,000\nNormal\n";
+    const result = convertTextCueSubtitleToAss(srt);
+    const dialogues = result.content.split("\n").filter((line) => line.startsWith("Dialogue:"));
+
+    expect(result.skippedCount).toBe(1);
+    expect(dialogues).toHaveLength(1);
+    expect(dialogues[0]).toContain("Normal");
   });
 });
 

--- a/src/features/hdr-convert/srt-converter.ts
+++ b/src/features/hdr-convert/srt-converter.ts
@@ -40,21 +40,34 @@ const FONT_NAME_SANITIZER = new RegExp(
   "gu"
 );
 
-// module-scope to match project convention
-// (FONT_NAME_SANITIZER above, plus every other named regex in
-// subtitle-parser.ts / ass-processor.ts). String.prototype.replace
-// doesn't share `lastIndex` across calls, so inline definitions
-// inside `preprocessSrtColors` were semantically equivalent — this
-// is purely a convention sweep so a future grep `^const \w+_RE` finds
-// every regex in the file in one place.
-//
-// Matches: <font color="#RRGGBB"> or <font color=#RRGGBB> with up
-// to 512 chars of other attributes before/after color (ReDoS guard).
-// The hex alternation requires a non-hex char immediately after the
-// 6- or 3-digit run so `#abcdef` is never parsed as 3-digit `abc`.
+// Matches a complete <font color="#RRGGBB"> or
+// <font color=#RRGGBB> opener with up to 512 chars of other attributes
+// before/after color. Anchoring lets the stateful scanner below identify
+// every <font> frame while this regex alone decides whether the opener may
+// inject a color override. The hex alternation requires a non-hex char
+// immediately after the 6- or 3-digit run so `#abcdef` is never parsed as
+// 3-digit `abc`.
 const SRT_COLOR_OPEN_RE =
-  /<font\b[^>]{0,512}\bcolor="?#([0-9a-fA-F]{6}(?![0-9a-fA-F])|[0-9a-fA-F]{3}(?![0-9a-fA-F]))"?[^>]{0,512}>/gi;
-const SRT_COLOR_CLOSE_RE = /<\/font>/gi;
+  /^<font\b[^>]{0,512}\bcolor="?#([0-9a-fA-F]{6}(?![0-9a-fA-F])|[0-9a-fA-F]{3}(?![0-9a-fA-F]))"?[^>]{0,512}>$/i;
+
+// The longest opener accepted by SRT_COLOR_OPEN_RE is 1,045 characters:
+// `<font` + two 512-character attribute windows + `color="#RRGGBB"` + `>`.
+// Longer tags remain ordinary HTML-like text and are stripped later by the
+// document builder; they never inject an ASS override.
+const MAX_SRT_FONT_TAG_LENGTH = 1_045;
+
+// Production cue text is already capped at 64,000 characters, but keep the
+// exported preprocessing helper safe when it is called directly. Overflow
+// nesting is counted separately so an ignored closer cannot pop a tracked
+// outer color frame early.
+const MAX_TRACKED_SRT_FONT_DEPTH = 256;
+
+type InlinePrimaryColor = string | null;
+
+interface SrtFontFrame {
+  previousColor: InlinePrimaryColor;
+  setsColor: boolean;
+}
 
 // ── Text Cue Color Preprocessing ─────────────────────────
 
@@ -81,6 +94,14 @@ export function escapeSrtUserText(text: string): string {
  * Convert HTML-style font color tags to ASS inline color overrides.
  * <font color="#RRGGBB">text</font>  →  {\1c&HBBGGRR&}text{\1c}
  *
+ * Every bounded <font> opener gets a stack frame, including openers without
+ * a supported color attribute. This preserves nesting: closing a non-color
+ * frame cannot reset or pop an outer color. A nested color close restores the
+ * previous inline color, while an outer color close uses bare `\1c` to restore
+ * only the current ASS style's primary color. It deliberately does not emit
+ * `\r`, because that would also erase bold, italic, underline, font, and other
+ * active styling.
+ *
  * CONTRACT: the `text` argument MUST have been passed through
  * `escapeSrtUserText` first. That's the only way to guarantee the `{…}`
  * sequences this function injects for color conversion are distinguishable
@@ -95,26 +116,96 @@ export function escapeSrtUserText(text: string): string {
  * @internal — production callers must use `processSrtUserText`.
  */
 export function preprocessSrtColors(text: string): string {
-  // Convert opening tags with color. SRT_COLOR_OPEN_RE /
-  // SRT_COLOR_CLOSE_RE are module-scope — see
-  // comment above the constants for the convention rationale.
-  let result = text.replace(SRT_COLOR_OPEN_RE, (_match, raw: string) => {
+  const output: string[] = [];
+  const frames: SrtFontFrame[] = [];
+  let currentColor: InlinePrimaryColor = null;
+  let overflowDepth = 0;
+  let cursor = 0;
+
+  while (cursor < text.length) {
+    const tagStart = text.indexOf("<", cursor);
+    if (tagStart < 0) {
+      output.push(text.slice(cursor));
+      break;
+    }
+
+    output.push(text.slice(cursor, tagStart));
+
+    if (text.slice(tagStart, tagStart + 7).toLowerCase() === "</font>") {
+      const closeTag = text.slice(tagStart, tagStart + 7);
+      cursor = tagStart + 7;
+
+      if (overflowDepth > 0) {
+        overflowDepth -= 1;
+        output.push(closeTag);
+        continue;
+      }
+
+      const frame = frames.pop();
+      if (!frame) {
+        output.push(closeTag);
+        continue;
+      }
+
+      if (!frame.setsColor) {
+        output.push(closeTag);
+        continue;
+      }
+
+      currentColor = frame.previousColor;
+      output.push(currentColor === null ? "{\\1c}" : `{\\1c&H${currentColor}&}`);
+      continue;
+    }
+
+    const openingPrefix = text.slice(tagStart, tagStart + 5).toLowerCase();
+    const boundary = text[tagStart + 5];
+    const isFontOpener =
+      openingPrefix === "<font" && (boundary === undefined || !/[a-zA-Z0-9_]/.test(boundary));
+    if (!isFontOpener) {
+      output.push("<");
+      cursor = tagStart + 1;
+      continue;
+    }
+
+    const tagEnd = text.indexOf(">", tagStart + 5);
+    if (tagEnd < 0) {
+      output.push(text.slice(tagStart));
+      break;
+    }
+
+    const openTag = text.slice(tagStart, tagEnd + 1);
+    cursor = tagEnd + 1;
+
+    if (openTag.length > MAX_SRT_FONT_TAG_LENGTH || overflowDepth > 0) {
+      overflowDepth += 1;
+      output.push(openTag);
+      continue;
+    }
+
+    if (frames.length >= MAX_TRACKED_SRT_FONT_DEPTH) {
+      overflowDepth = 1;
+      output.push(openTag);
+      continue;
+    }
+
+    const colorMatch = SRT_COLOR_OPEN_RE.exec(openTag);
+    frames.push({ previousColor: currentColor, setsColor: colorMatch !== null });
+    if (!colorMatch) {
+      output.push(openTag);
+      continue;
+    }
+
+    const raw = colorMatch[1]!;
     const hexRgb =
       raw.length === 3 ? raw[0]!.repeat(2) + raw[1]!.repeat(2) + raw[2]!.repeat(2) : raw;
     const r = hexRgb.slice(0, 2);
     const g = hexRgb.slice(2, 4);
     const b = hexRgb.slice(4, 6);
-    // Reverse to BGR for ASS format
-    return `{\\1c&H${b}${g}${r}&}`;
-  });
+    currentColor = `${b}${g}${r}`;
+    output.push(`{\\1c&H${currentColor}&}`);
+  }
 
-  // Convert ALL </font> to style resets — both color and non-color.
-  // Non-color <font> tags are stripped later by HTML tag removal in buildAssDocument,
-  // so their {\r} is harmless (resets to default which is the current state).
-  // This avoids positional mismatch when non-color </font> precedes color </font>.
-  result = result.replace(SRT_COLOR_CLOSE_RE, () => "{\\r}");
-
-  return result;
+  return output.join("");
 }
 
 /**

--- a/src/features/hdr-convert/srt-converter.ts
+++ b/src/features/hdr-convert/srt-converter.ts
@@ -10,7 +10,7 @@
  */
 
 import { ASCII_CONTROL_CHARS, BIDI_AND_ZERO_WIDTH_CHARS } from "../../lib/unicode-controls";
-import { safeMs } from "../../lib/subtitle-parser";
+import { parseSubtitle, safeMs } from "../../lib/subtitle-parser";
 
 // hoisted to module scope so the regex
 // compiles once instead of per buildAssFromSrtBlocks invocation.
@@ -138,7 +138,6 @@ export interface StyleConfig {
   outlineColor: string; // ASS format: &H00000000
   outlineWidth: number;
   shadowDepth: number;
-  fps: number; // only used for SUB (MicroDVD) format
 }
 
 export const DEFAULT_STYLE: StyleConfig = {
@@ -148,7 +147,6 @@ export const DEFAULT_STYLE: StyleConfig = {
   outlineColor: "&H00000000",
   outlineWidth: 2.0,
   shadowDepth: 1.0,
-  fps: 23.976,
 };
 
 // ── ASS Document Builder ─────────────────────────────────
@@ -157,9 +155,9 @@ export const DEFAULT_STYLE: StyleConfig = {
  * Build a minimal ASS document from parsed subtitle entries.
  * This creates a properly formatted ASS file with styles and events.
  *
- * CONTRACT: each `entries[i].text` MUST have flowed through
- * `escapeSrtUserText` → `preprocessSrtColors` → `parseSubtitle` on the way
- * in. This function does NOT re-escape `{`/`}`/`\` — doing so would silently
+ * CONTRACT: raw subtitle structure MUST be parsed first; each resulting cue
+ * body must then flow through `escapeSrtUserText` → `preprocessSrtColors` on
+ * the way in. This function does NOT re-escape `{`/`}`/`\` — doing so would silently
  * defeat our own injected color/bold/italic overrides and was the root of
  * a past regression. The integration tests in `srt-converter.test.ts`
  * guard against future callers dropping the escape step.
@@ -211,9 +209,9 @@ export function buildAssDocument(
     const startTime = msToAssTime(entry.start);
     const endTime = msToAssTime(entry.end);
     // IMPORTANT: we do NOT escape `{` / `}` / `\` here. Callers are
-    // expected to have already run `escapeSrtUserText` on the ORIGINAL
-    // SRT content before `preprocessSrtColors` injected our trusted color
-    // override tags. Re-escaping at this stage would turn those injected
+    // expected to have already run `processSrtUserText` on this parsed cue
+    // body. Whole-document escaping is forbidden because it corrupts
+    // MicroDVD timing syntax. Re-escaping at this stage would turn injected
     // `{\1c&H…}` tags into literal text, silently defeating SRT→HDR color
     // conversion. See escapeSrtUserText's docstring for the required
     // pipeline ordering.
@@ -260,10 +258,37 @@ export function buildAssDocumentFromCaptions(
       text: c.text,
     }));
 
+  if (entries.length === 0) {
+    throw new Error(
+      `No usable subtitle cues detected: all ${skippedCount} cue(s) exceeded the 64000-character limit`
+    );
+  }
+
   return {
     content: buildAssDocument(entries, style),
     skippedCount,
   };
+}
+
+/**
+ * Convert a raw SRT, WebVTT, or MicroDVD document into ASS.
+ *
+ * Parse structure before touching user text: whole-document escaping would
+ * corrupt MicroDVD `{start}{end}` fields. Only parsed cue bodies flow through
+ * the composed escape/color pipeline, keeping hostile ASS overrides inert
+ * without changing subtitle syntax. An explicit FPS is a manual MicroDVD
+ * override; absence means Auto (file declaration, then 23.976 fallback).
+ */
+export function convertTextCueSubtitleToAss(
+  rawContent: string,
+  style: StyleConfig = DEFAULT_STYLE,
+  fpsOverride?: number
+): { content: string; skippedCount: number } {
+  const { captions } = parseSubtitle(rawContent, fpsOverride);
+  const processedCaptions = captions.map((caption) =>
+    caption.skipped ? caption : { ...caption, text: processSrtUserText(caption.text) }
+  );
+  return buildAssDocumentFromCaptions(processedCaptions, style);
 }
 
 /**

--- a/src/features/style-edit/StyleEdit.tsx
+++ b/src/features/style-edit/StyleEdit.tsx
@@ -61,6 +61,11 @@ interface PreviewRow extends StyleEditRow {
   fileName: string;
 }
 
+interface PreviewError {
+  kind: "document" | "output";
+  reason: string;
+}
+
 type LastActionResult = "success" | "partial" | "error" | "cancelled" | "noop" | null;
 
 function hasAssExtension(path: string): boolean {
@@ -169,9 +174,17 @@ export default function StyleEdit() {
 
   const preview = useMemo(() => {
     const rows: PreviewRow[] = [];
-    const errors = new Map<string, string>();
-    if (!validation.valid) return { rows, errors };
+    const errors = new Map<string, PreviewError>();
+    const outputPaths = new Map<string, string>();
+    if (!validation.valid) return { rows, errors, outputPaths };
     for (const file of loadedFiles) {
+      let outputPath: string;
+      try {
+        outputPath = deriveStyledPath(file.path);
+      } catch (error) {
+        errors.set(file.path, { kind: "output", reason: sanitizeError(error) });
+        continue;
+      }
       try {
         const plan = file.planner.plan(operations);
         for (const row of plan.rows) {
@@ -182,11 +195,12 @@ export default function StyleEdit() {
             fileName: file.name,
           });
         }
+        outputPaths.set(file.path, outputPath);
       } catch (error) {
-        errors.set(file.path, sanitizeError(error));
+        errors.set(file.path, { kind: "document", reason: sanitizeError(error) });
       }
     }
-    return { rows, errors };
+    return { rows, errors, outputPaths };
   }, [loadedFiles, operations, validation.valid]);
 
   const changeableKeys = useMemo(
@@ -380,8 +394,10 @@ export default function StyleEdit() {
 
     try {
       if (preview.errors.size > 0) {
-        for (const [path, reason] of preview.errors) {
-          addLog(t("msg_style_parse_error", safeFileName(path), reason), "error");
+        for (const [path, error] of preview.errors) {
+          const key =
+            error.kind === "output" ? "msg_style_output_path_error" : "msg_style_parse_error";
+          addLog(t(key, safeFileName(path), error.reason), "error");
         }
         setLastActionResult("error");
         return;
@@ -391,8 +407,9 @@ export default function StyleEdit() {
         const selectedRowIds = preview.rows
           .filter((row) => row.filePath === file.path && selectedRows.has(row.key))
           .map((row) => row.id);
-        return selectedRowIds.length > 0
-          ? [{ file, outputPath: deriveStyledPath(file.path), selectedRowIds }]
+        const outputPath = preview.outputPaths.get(file.path);
+        return selectedRowIds.length > 0 && outputPath
+          ? [{ file, outputPath, selectedRowIds }]
           : [];
       });
 
@@ -928,9 +945,13 @@ export default function StyleEdit() {
 
       {preview.errors.size > 0 && (
         <div role="alert" className="space-y-1">
-          {Array.from(preview.errors, ([path, reason]) => (
+          {Array.from(preview.errors, ([path, error]) => (
             <p key={path} className="text-xs" style={{ color: "var(--error)" }}>
-              {t("msg_style_parse_error", safeFileName(path), reason)}
+              {t(
+                error.kind === "output" ? "msg_style_output_path_error" : "msg_style_parse_error",
+                safeFileName(path),
+                error.reason
+              )}
             </p>
           ))}
         </div>

--- a/src/features/timing-shift/TimingShift.tsx
+++ b/src/features/timing-shift/TimingShift.tsx
@@ -27,8 +27,12 @@ import { useLogPanel } from "../../lib/useLogPanel";
 import { LogPanel } from "../../lib/LogPanel";
 import { DropErrorBanner } from "../../lib/DropErrorBanner";
 import NumberInput from "../../lib/NumberInput";
-import { parseFiniteNumberText } from "../../lib/strict-number";
-import { isTimingOffsetInvalid, isTimingSaveDisabled } from "./timing-ui-state";
+import {
+  formatTimingOffsetMagnitude,
+  isTimingOffsetInvalid,
+  isTimingSaveDisabled,
+  parseTimingOffsetMagnitudeMs,
+} from "./timing-ui-state";
 import {
   buildConflictMessage,
   normalizeOutputKey,
@@ -137,13 +141,11 @@ export default function TimingShift() {
     previewTruncated,
     error: previewError,
   } = previewState;
-  // Two-slot shadow mirroring HdrConvert's `brightness` /
-  // `brightnessText`: `offsetValue` is the validated integer used by
-  // `effectiveOffsetMs` math; `offsetText` is the raw input string the
-  // user is typing. The pair lets NumberInput own clear-then-retype
-  // semantics (mid-type NaN states don't snap the visible field back to
-  // a stale number) while keeping the math path typed.
-  const [offsetValue, setOffsetValue] = useState(200);
+  // Keep the validated value in integer milliseconds regardless of the
+  // visible unit. offsetText remains the user's exact in-progress text, while
+  // invalid text disables preview/save instead of silently using an older
+  // magnitude. The separate direction control is the only source of sign.
+  const [offsetMagnitudeMs, setOffsetMagnitudeMs] = useState(200);
   const [offsetText, setOffsetText] = useState("200");
   const [unit, setUnit] = useState<Unit>("ms");
   const [direction, setDirection] = useState<Direction>("slower");
@@ -176,17 +178,9 @@ export default function TimingShift() {
   const fileContainerRef = useRef<HTMLDivElement>(null);
 
   const effectiveOffsetMs = useMemo(() => {
-    const base = unit === "s" ? offsetValue * 1000 : offsetValue;
-    // Math.round at the math boundary so
-    // fractional s-unit inputs (e.g. "2.5s" → 2500 ms) accepted by
-    // parseFloat below don't propagate sub-ms fractions into
-    // formatSrtTime, whose `ms % 1000` produces non-integer
-    // milliseconds that padStart can't format cleanly. Integer-ms is
-    // the downstream contract.
-    const rounded = Math.round(base);
-    const clamped = Math.max(-MAX_OFFSET_MS, Math.min(MAX_OFFSET_MS, rounded));
-    return direction === "faster" ? -clamped : clamped;
-  }, [unit, offsetValue, direction]);
+    if (direction === "faster" && offsetMagnitudeMs > 0) return -offsetMagnitudeMs;
+    return offsetMagnitudeMs;
+  }, [offsetMagnitudeMs, direction]);
 
   // Per-unit absolute bound used by NumberInput's min/max attributes and
   // the out-of-range derived signal below. In ms-unit the cap is the full
@@ -194,38 +188,22 @@ export default function TimingShift() {
   // visible value range stays user-friendly.
   const offsetMax = unit === "s" ? MAX_OFFSET_MS / 1000 : MAX_OFFSET_MS;
 
-  // Unit toggle preserves the intended shift duration: ms→s scales the
-  // value down by 1000 (1500 ms → 1.5 s), s→ms scales up (2.5 s →
-  // 2500 ms). Without this rescale, the displayed number stays the
-  // same while its semantic meaning shifts by 1000× — a no-silent-action
-  // violation the user only notices when subtitles end up minutes off.
-  // s-side text uses toFixed(3) + trailing-zero strip so floating-point
-  // noise like 0.7000000000000001 doesn't surface; ms-side rounds to
-  // integer because downstream math is integer ms anyway.
+  // Unit changes reformat the exact stored millisecond magnitude, so the
+  // number shown after the switch always describes the value the engine uses.
   const handleUnitChange = (newUnit: Unit) => {
     if (newUnit === unit) return;
-    if (newUnit === "s") {
-      const sVal = offsetValue / 1000;
-      setOffsetValue(sVal);
-      setOffsetText(sVal.toFixed(3).replace(/\.?0+$/, "") || "0");
-    } else {
-      const msVal = Math.round(offsetValue * 1000);
-      setOffsetValue(msVal);
-      setOffsetText(msVal.toString());
-    }
+    setOffsetText(formatTimingOffsetMagnitude(offsetMagnitudeMs, newUnit));
     setUnit(newUnit);
   };
   const handleOffsetChange = (value: string) => {
     setOffsetText(value);
-    const n = parseFiniteNumberText(value);
-    if (n !== null && Math.abs(n) <= offsetMax) {
-      setOffsetValue(n);
-    }
+    const magnitudeMs = parseTimingOffsetMagnitudeMs(value, unit, offsetMax);
+    if (magnitudeMs !== null) setOffsetMagnitudeMs(magnitudeMs);
   };
   // Derived: the visible input is not currently a finite in-range
   // number. Without this, Save can proceed against the prior valid
-  // `offsetValue` while the user sees a different value in the field.
-  const offsetInvalid = isTimingOffsetInvalid(offsetText, offsetMax);
+  // `offsetMagnitudeMs` while the user sees a different value in the field.
+  const offsetInvalid = isTimingOffsetInvalid(offsetText, unit, offsetMax);
 
   const thresholdMs = useMemo(
     () => (useThreshold ? parseDisplayTime(thresholdText) : null),
@@ -849,8 +827,9 @@ export default function TimingShift() {
             id="timing-offset-input"
             value={offsetText}
             onChange={handleOffsetChange}
-            min={-offsetMax}
+            min={0}
             max={offsetMax}
+            step={unit === "ms" ? 1 : "0.001"}
             disabled={busy}
             invalid={offsetInvalid}
             className="w-28"

--- a/src/features/timing-shift/timing-engine.test.ts
+++ b/src/features/timing-shift/timing-engine.test.ts
@@ -267,9 +267,28 @@ describe("parseTimingMapText", () => {
 
   it("rejects malformed timing-map imports before conversion", () => {
     expect(() => parseTimingMapText("")).toThrow(/empty/);
+    expect(() => parseTimingMapText("[]")).toThrow(/no rules/);
     expect(() => parseTimingMapText("[{}]")).toThrow(/start/);
     expect(() => parseTimingMapText("00:60:00.000,,+1s")).toThrow(/below 60/);
     expect(() => parseTimingMapText("00:00:00.000,,1s")).toThrow(/include \+ or -/);
+  });
+
+  it("accepts 10000 enabled rules and rejects 10001 in JSON and CSV", () => {
+    const makeJsonRules = (count: number) =>
+      Array.from({ length: count }, (_, index) => ({
+        startMs: index,
+        offsetMs: 0,
+        enabled: true,
+      }));
+    const makeCsvRules = (count: number) =>
+      Array.from({ length: count }, (_, index) => `${index},,+0ms,,true`).join("\n");
+
+    expect(parseTimingMapText(JSON.stringify(makeJsonRules(10_000))).rules).toHaveLength(10_000);
+    expect(parseTimingMapText(makeCsvRules(10_000)).rules).toHaveLength(10_000);
+    expect(() => parseTimingMapText(JSON.stringify(makeJsonRules(10_001)))).toThrow(
+      /too many rules; max 10000/
+    );
+    expect(() => parseTimingMapText(makeCsvRules(10_001))).toThrow(/too many rules; max 10000/);
   });
 });
 

--- a/src/features/timing-shift/timing-ui-state.test.ts
+++ b/src/features/timing-shift/timing-ui-state.test.ts
@@ -1,24 +1,36 @@
 import { describe, expect, it } from "vitest";
 
-import { isTimingOffsetInvalid, isTimingSaveDisabled } from "./timing-ui-state";
+import {
+  formatTimingOffsetMagnitude,
+  isTimingOffsetInvalid,
+  isTimingSaveDisabled,
+  parseTimingOffsetMagnitudeMs,
+} from "./timing-ui-state";
 
 describe("timing UI state guards", () => {
-  it("marks blank, non-finite, and out-of-range offsets invalid", () => {
-    expect(isTimingOffsetInvalid("", 1000)).toBe(true);
-    expect(isTimingOffsetInvalid("not a number", 1000)).toBe(true);
-    expect(isTimingOffsetInvalid("12abc", 1000)).toBe(true);
-    expect(isTimingOffsetInvalid("1e", 1000)).toBe(true);
-    expect(isTimingOffsetInvalid("1e+", 1000)).toBe(true);
-    expect(isTimingOffsetInvalid("1e-", 1000)).toBe(true);
-    expect(isTimingOffsetInvalid("1001", 1000)).toBe(true);
-    expect(isTimingOffsetInvalid("-1001", 1000)).toBe(true);
+  it("requires a nonnegative integer literal in millisecond mode", () => {
+    for (const text of ["", "not a number", "12abc", "1e2", "1.0", "0.5", "-1", "+1"]) {
+      expect(isTimingOffsetInvalid(text, "ms", 1000), text).toBe(true);
+    }
+    expect(parseTimingOffsetMagnitudeMs("0", "ms", 1000)).toBe(0);
+    expect(parseTimingOffsetMagnitudeMs("1000", "ms", 1000)).toBe(1000);
+    expect(isTimingOffsetInvalid("1001", "ms", 1000)).toBe(true);
   });
 
-  it("accepts finite offsets at the exact visible boundary", () => {
-    expect(isTimingOffsetInvalid("1000", 1000)).toBe(false);
-    expect(isTimingOffsetInvalid("-1000", 1000)).toBe(false);
-    expect(isTimingOffsetInvalid("2.5", 10)).toBe(false);
-    expect(isTimingOffsetInvalid("1e2", 1000)).toBe(false);
+  it("accepts seconds only when they resolve exactly to integer milliseconds", () => {
+    expect(parseTimingOffsetMagnitudeMs("2.5", "s", 10)).toBe(2500);
+    expect(parseTimingOffsetMagnitudeMs(".001", "s", 10)).toBe(1);
+    expect(parseTimingOffsetMagnitudeMs("10.000", "s", 10)).toBe(10000);
+    for (const text of ["-0.5", "0.0001", "1.2345", "1e2", "10.001"]) {
+      expect(isTimingOffsetInvalid(text, "s", 10), text).toBe(true);
+    }
+  });
+
+  it("formats unit switches without changing the effective magnitude", () => {
+    expect(formatTimingOffsetMagnitude(2500, "s")).toBe("2.5");
+    expect(formatTimingOffsetMagnitude(2500, "ms")).toBe("2500");
+    expect(formatTimingOffsetMagnitude(1, "s")).toBe("0.001");
+    expect(formatTimingOffsetMagnitude(0, "s")).toBe("0");
   });
 
   it("disables Save when the visible offset is invalid", () => {

--- a/src/features/timing-shift/timing-ui-state.ts
+++ b/src/features/timing-shift/timing-ui-state.ts
@@ -1,5 +1,3 @@
-import { parseFiniteNumberText } from "../../lib/strict-number";
-
 export interface TimingSaveDisabledState {
   fileCount: number;
   thresholdInvalid: boolean;
@@ -7,9 +5,46 @@ export interface TimingSaveDisabledState {
   busy: boolean;
 }
 
-export function isTimingOffsetInvalid(offsetText: string, offsetMax: number): boolean {
-  const value = parseFiniteNumberText(offsetText);
-  return value === null || Math.abs(value) > offsetMax;
+export type TimingOffsetUnit = "ms" | "s";
+
+/** Parse a nonnegative displayed magnitude into exact integer milliseconds.
+ * The direction control owns the sign. Millisecond input is integer-only;
+ * seconds can use at most three decimals, which maps exactly to milliseconds. */
+export function parseTimingOffsetMagnitudeMs(
+  offsetText: string,
+  unit: TimingOffsetUnit,
+  offsetMax: number
+): number | null {
+  if (offsetText !== offsetText.trim() || offsetText.length === 0) return null;
+  const pattern = unit === "ms" ? /^\d+$/ : /^(?:\d+(?:\.\d{0,3})?|\.\d{1,3})$/;
+  if (!pattern.test(offsetText)) return null;
+
+  const value = Number(offsetText);
+  if (!Number.isFinite(value) || value < 0 || value > offsetMax) return null;
+  if (unit === "ms") return Number.isSafeInteger(value) ? value : null;
+
+  const [wholeText, fractionText = ""] = offsetText.split(".");
+  const wholeSeconds = Number(wholeText || "0");
+  const fractionalMs = Number(fractionText.padEnd(3, "0") || "0");
+  const milliseconds = wholeSeconds * 1000 + fractionalMs;
+  return Number.isSafeInteger(milliseconds) ? milliseconds : null;
+}
+
+export function formatTimingOffsetMagnitude(magnitudeMs: number, unit: TimingOffsetUnit): string {
+  if (unit === "ms") return magnitudeMs.toString();
+  const wholeSeconds = Math.floor(magnitudeMs / 1000);
+  const fraction = String(magnitudeMs % 1000)
+    .padStart(3, "0")
+    .replace(/0+$/, "");
+  return fraction ? `${wholeSeconds}.${fraction}` : wholeSeconds.toString();
+}
+
+export function isTimingOffsetInvalid(
+  offsetText: string,
+  unit: TimingOffsetUnit,
+  offsetMax: number
+): boolean {
+  return parseTimingOffsetMagnitudeMs(offsetText, unit, offsetMax) === null;
 }
 
 export function isTimingSaveDisabled(state: TimingSaveDisabledState): boolean {

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -40,7 +40,6 @@ export const strings: Record<string, StringEntry> = {
   },
   status_fonts_busy: { en: "Embedding…", zh: "嵌入中…" },
   status_fonts_done: { en: "Fonts embedded", zh: "字体已嵌入" },
-  status_fonts_noop: { en: "Nothing to embed", zh: "无需嵌入" },
   status_fonts_partial: { en: "Fonts embedded with warnings", zh: "字体已嵌入，但有警告" },
   status_fonts_error: { en: "Embed failed", zh: "嵌入失败" },
   status_fonts_cancelled: { en: "Embed cancelled", zh: "已取消嵌入" },
@@ -395,17 +394,9 @@ export const strings: Record<string, StringEntry> = {
     en: "Embed complete: {0}/{1} file(s) processed",
     zh: "嵌入完成：已处理 {0}/{1} 个文件",
   },
-  msg_fonts_complete_mixed: {
-    en: "Embed complete: {0} file(s) written, {1} unchanged",
-    zh: "嵌入完成：已写入 {0} 个文件，{1} 个文件无需更改",
-  },
   msg_fonts_complete_partial: {
     en: "Embed incomplete: {0}/{1} file(s) written, {2} issue(s)",
     zh: "嵌入不完整：已写入 {0}/{1} 个文件，{2} 个问题",
-  },
-  msg_fonts_complete_partial_mixed: {
-    en: "Embed incomplete: {0} file(s) written, {1} unchanged, {2} issue(s)",
-    zh: "嵌入不完整：已写入 {0} 个文件，{1} 个文件无需更改，{2} 个问题",
   },
   msg_fonts_skipped_count: {
     en: "Note: {0} file(s) were skipped before this prompt (see log).",
@@ -415,12 +406,12 @@ export const strings: Record<string, StringEntry> = {
     en: "Embed failed on all {0} file(s); see errors above",
     zh: "全部 {0} 个文件嵌入失败，详见上方错误",
   },
-  msg_fonts_all_no_change: {
-    en: "Nothing to embed — all referenced fonts are already present in {0} file(s)",
-    zh: "无需嵌入 —— {0} 个文件引用的字体均已存在",
-  },
   msg_fonts_cancelled: { en: "Embed cancelled.", zh: "已取消嵌入。" },
   msg_fonts_error: { en: "Error embedding {0}: {1}", zh: "嵌入 {0} 出错：{1}" },
+  msg_fonts_input_conflict: {
+    en: "Skipped {0} — its output path matches another selected input",
+    zh: "已跳过 {0} —— 其输出路径与另一个已选输入文件相同",
+  },
   msg_fonts_analysis_unavailable: {
     en: "Analysis data is unavailable. Select the files again.",
     zh: "分析数据已不可用，请重新选择文件。",
@@ -460,8 +451,8 @@ export const strings: Record<string, StringEntry> = {
     zh: "已保存但有警告：{0}（已嵌入 {1} 个字体，{2} 条警告）",
   },
   msg_embed_no_change: {
-    en: "Skipped {0} — no fonts were embedded (output would equal input)",
-    zh: "跳过 {0} — 未嵌入任何字体（输出与输入相同，未写文件）",
+    en: "Skipped {0} — none of the selected fonts could be embedded; see warnings above",
+    zh: "已跳过 {0} —— 所选字体均无法嵌入；请查看上方警告",
   },
   fonts_full_embed_warning: {
     en: "Fonts are subset to only the glyphs used in this subtitle. Safety padding (ASCII + CJK fullwidth) is included automatically.",
@@ -628,6 +619,14 @@ export const strings: Record<string, StringEntry> = {
   font_cache_drift_btn_rescan: { en: "Rescan now", zh: "立即重新扫描" },
   font_cache_drift_btn_use_as_is: { en: "Use as-is", zh: "保持原样使用" },
   font_cache_drift_btn_clear: { en: "Clear cache", zh: "清除缓存" },
+  font_cache_close_busy_rescan: {
+    en: "Cannot close while the font cache is being rescanned",
+    zh: "字体缓存重新扫描期间无法关闭",
+  },
+  font_cache_close_busy_clear: {
+    en: "Cannot close while the font cache is being cleared",
+    zh: "字体缓存清除期间无法关闭",
+  },
   font_cache_rescanning: { en: "Rescanning font cache…", zh: "正在重新扫描字体缓存…" },
   font_cache_clearing: { en: "Clearing cache…", zh: "正在清除缓存…" },
   font_cache_rescan_done: {
@@ -681,6 +680,10 @@ export const strings: Record<string, StringEntry> = {
   },
   status_rename_busy: { en: "Renaming…", zh: "重命名中…" },
   status_rename_done: { en: "Rename complete", zh: "重命名完成" },
+  status_rename_partial: {
+    en: "Rename completed with issues",
+    zh: "重命名已完成，但有问题",
+  },
   status_rename_error: { en: "Rename failed", zh: "重命名失败" },
   status_rename_cancelled: { en: "Rename cancelled", zh: "已取消重命名" },
   status_rename_noop: {
@@ -733,6 +736,10 @@ export const strings: Record<string, StringEntry> = {
   rename_grid_title: {
     en: "Pairing preview · {0} row(s)",
     zh: "配对预览 · {0} 行",
+  },
+  rename_grid_unpaired_subtitle_suffix: {
+    en: " · Unpaired subtitles: {0}",
+    zh: " · 未配对字幕：{0}",
   },
   rename_grid_warning_suffix: {
     en: "{0} warning(s)",
@@ -957,6 +964,10 @@ export const strings: Record<string, StringEntry> = {
   msg_style_parse_error: {
     en: "Cannot analyze {0}: {1}",
     zh: "无法分析 {0}：{1}",
+  },
+  msg_style_output_path_error: {
+    en: "Cannot plan an output for {0}: {1}",
+    zh: "无法为 {0} 规划输出路径：{1}",
   },
   msg_style_outputs_exist: {
     en: "{0} output file(s) already exist. No files were written; remove or rename those outputs first.",

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -786,13 +786,16 @@ export const strings: Record<string, StringEntry> = {
     en: "Skipped {0}: {1}",
     zh: "已跳过 {0}：{1}",
   },
+  msg_rename_input_conflict: {
+    en: "Blocked {0}: it is part of a planned conflict where an output targets a loaded subtitle input. No files in that conflicting chain were changed.",
+    zh: "已阻止 {0}：该字幕涉及计划批次中的冲突，其中一个输出指向已加载的字幕输入。该冲突链中的文件均未更改。",
+  },
   msg_rename_skipped_count: {
-    // Pinpointed to derive-time pairing failures specifically — not
-    // covering noopTargets (already-correctly-named subs), within-batch
-    // dedup skips, or loop-time copy/rename errors. Those happen before
-    // or after this dialog is shown.
-    en: "Note: {0} pairing(s) failed earlier and won't run (see log).",
-    zh: "注意：另有 {0} 对配对早前失败、不会执行（见日志）。",
+    // Covers path-derivation failures and output-to-loaded-input
+    // conflicts found before confirmation. No-op targets, duplicate outputs,
+    // and loop-time copy/rename errors have their own reporting paths.
+    en: "Note: {0} pairing(s) failed preflight and won't run (see log).",
+    zh: "注意：另有 {0} 对配对未通过预检、不会执行（见日志）。",
   },
   msg_rename_nothing_to_do: {
     en: "Nothing to do — all selected rows produced invalid output paths.",

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -196,6 +196,17 @@ export const strings: Record<string, StringEntry> = {
   style_outline_width: { en: "Outline Width", zh: "描边宽度" },
   style_shadow_depth: { en: "Shadow Depth", zh: "阴影深度" },
   style_fps: { en: "FPS (SUB only)", zh: "帧率（仅 SUB）" },
+  style_fps_auto: {
+    en: "Auto (file declaration or 23.976)",
+    zh: "自动（文件声明或 23.976）",
+  },
+  style_fps_manual: { en: "Manual override", zh: "手动指定" },
+  style_fps_value: { en: "Manual FPS", zh: "手动帧率" },
+  style_fps_invalid: {
+    en: "Enter an FPS greater than 3 and no more than 120.",
+    zh: "请输入大于 3 且不超过 120 的帧率。",
+  },
+  style_fps_invalid_summary: { en: "Invalid SUB FPS", zh: "SUB 帧率无效" },
   style_font_custom: { en: "Custom…", zh: "自定义…" },
   btn_select_files: { en: "Select Subtitle File(s)", zh: "选择字幕文件（可多选）" },
   btn_convert: { en: "Convert", zh: "转换" },

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -985,10 +985,6 @@ export const strings: Record<string, StringEntry> = {
     en: "Written: {0} ({1} Style row(s) changed)",
     zh: "已写入：{0}（更改了 {1} 个 Style 行）",
   },
-  msg_style_file_noop: {
-    en: "Skipped {0}: no selected Style rows would change",
-    zh: "已跳过 {0}：所选 Style 行无需更改",
-  },
   msg_style_write_error: {
     en: "Error writing {0}: {1}",
     zh: "写入 {0} 出错：{1}",
@@ -996,10 +992,6 @@ export const strings: Record<string, StringEntry> = {
   msg_style_complete: {
     en: "Style edit complete: {0} written, {1} unchanged, {2} failed",
     zh: "样式编辑完成：写入 {0} 个，未更改 {1} 个，失败 {2} 个",
-  },
-  msg_style_all_failed: {
-    en: "Style edit failed on all {0} writable file(s)",
-    zh: "全部 {0} 个可写文件均编辑失败",
   },
   msg_style_all_noop: {
     en: "Nothing to write — no selected Style rows would change.",

--- a/src/lib/font-cache-ui-state.test.ts
+++ b/src/lib/font-cache-ui-state.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+
+import { completeFontCacheProbe, isFontCacheUnavailable } from "./font-cache-ui-state";
+
+describe("font cache UI state", () => {
+  it("does not let StrictMode's cancelled first setup suppress the live retry", () => {
+    const checked = { current: false };
+
+    completeFontCacheProbe(checked, true);
+    expect(checked.current).toBe(false);
+
+    completeFontCacheProbe(checked, false);
+    expect(checked.current).toBe(true);
+  });
+
+  it("distinguishes unavailable cache state from schema recovery", () => {
+    expect(isFontCacheUnavailable(null, false)).toBe(false);
+    expect(isFontCacheUnavailable(null, true)).toBe(true);
+    expect(
+      isFontCacheUnavailable(
+        { available: false, schemaMismatch: false, path: "cache.sqlite" },
+        false
+      )
+    ).toBe(true);
+    expect(
+      isFontCacheUnavailable(
+        { available: false, schemaMismatch: true, path: "cache.sqlite" },
+        false
+      )
+    ).toBe(false);
+    expect(
+      isFontCacheUnavailable(
+        { available: true, schemaMismatch: false, path: "cache.sqlite" },
+        false
+      )
+    ).toBe(false);
+  });
+});

--- a/src/lib/font-cache-ui-state.ts
+++ b/src/lib/font-cache-ui-state.ts
@@ -1,0 +1,25 @@
+import type { FontCacheStatus } from "./tauri-api";
+
+interface MutableBooleanRef {
+  current: boolean;
+}
+
+/**
+ * Mark a launch-time cache probe complete only when its effect instance is
+ * still active. React StrictMode cleans up the first development-only setup
+ * before running the second; a cancelled first setup must not latch the probe
+ * as complete and suppress that live retry.
+ */
+export function completeFontCacheProbe(cacheChecked: MutableBooleanRef, cancelled: boolean): void {
+  if (!cancelled) cacheChecked.current = true;
+}
+
+/** Schema mismatch has its own recovery modal, so it is not also an
+ * "unavailable" banner state. A rejected probe is unavailable even though no
+ * FontCacheStatus value was returned. */
+export function isFontCacheUnavailable(
+  status: FontCacheStatus | null,
+  probeFailed: boolean
+): boolean {
+  return probeFailed || (status !== null && !status.available && !status.schemaMismatch);
+}

--- a/src/lib/subtitle-parser.test.ts
+++ b/src/lib/subtitle-parser.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   formatDisplayTime,
+  inspectMicroDvdFpsDeclarations,
   parseDisplayTime,
   parseSubtitle,
   safeMs,
@@ -192,11 +193,9 @@ describe("parseSubtitle", () => {
     );
   });
 
-  it("clamps an out-of-range MicroDVD fps to the default", () => {
-    // clampFps guards parse/build against a crafted `{1}{1}<fps>` header or a
-    // bad caller-supplied fps drifting every timestamp. It is reachable via
-    // the public parseSubtitle(content, fps); each invalid value
-    // (0 / negative / NaN / Infinity / >1000) must fall back to DEFAULT_FPS.
+  it("falls back from an invalid MicroDVD FPS override", () => {
+    // Invalid explicit values must not drift timestamps. With no recognized
+    // declaration, parseSubtitle(content, fps) falls back to 23.976.
     const sub = "{0}{25}Hello\n{26}{50}World";
     const baseline = parseSubtitle(sub).captions; // default fps
     for (const badFps of [0, -5, NaN, Infinity, 2000]) {
@@ -328,6 +327,102 @@ describe("parseSubtitle", () => {
     const result = parseSubtitle(ass);
     expect(result.format).toBe("ass");
     expect(result.captions).toHaveLength(1);
+  });
+});
+
+describe("MicroDVD FPS declarations", () => {
+  it.each([
+    ["{0}{}3.0001\n{25}{50}Hello\n", 3.0001],
+    ["{1}{1}25.000\n{25}{50}Hello\n", 25],
+    ["{0}{999999999999}120\n{120}{240}Hello\n", 120],
+  ])("recognizes bounded declaration grammar and excludes it from captions", (content, fps) => {
+    const inspection = inspectMicroDvdFpsDeclarations(content);
+    const parsed = parseSubtitle(content);
+
+    expect(inspection.declaredFps).toBe(fps);
+    expect(inspection.declarations).toHaveLength(1);
+    expect(parsed.format).toBe("sub");
+    expect(parsed.captions).toHaveLength(1);
+    expect(parsed.captions[0]!.text).toBe("Hello");
+  });
+
+  it("scans exactly the first three nonempty lines after a BOM and lets the last valid declaration win", () => {
+    const content = "\uFEFF\r\n{1}{1}24\r\n\r\n{0}{}25.000\r\n{25}{50}Hello\r\n{1}{1}30\r\n";
+    const inspection = inspectMicroDvdFpsDeclarations(content);
+    const parsed = parseSubtitle(content);
+
+    expect(inspection.declarations.map((entry) => entry.fps)).toEqual([24, 25]);
+    expect(inspection.declaredFps).toBe(25);
+    expect(parsed.captions.map((caption) => caption.text)).toEqual(["Hello", "30"]);
+    expect(parsed.captions[0]).toMatchObject({ start: 1000, end: 2000 });
+  });
+
+  it.each([
+    "{1}{1}3",
+    "{1}{1}120.001",
+    "{1}{1}25fps",
+    "{1}{1}25.0junk",
+    "{1}{1}1e2",
+    "{1}{1}Infinity",
+    "{1}{1}NaN",
+    "{2}{2}25",
+  ])("keeps declaration near-miss as an ordinary cue: %s", (line) => {
+    expect(inspectMicroDvdFpsDeclarations(`${line}\n{24}{48}Hello\n`).declarations).toHaveLength(0);
+    const parsed = parseSubtitle(`${line}\n{24}{48}Hello\n`);
+    expect(parsed.captions[0]!.text).toBe(line.slice(line.lastIndexOf("}") + 1));
+  });
+
+  it.each(["{1}{1234567890123}25", "{1}{broken}25", "{1}{1 25"])(
+    "does not accept malformed declaration syntax: %s",
+    (line) => {
+      expect(inspectMicroDvdFpsDeclarations(`${line}\n{24}{48}Hello\n`).declarations).toHaveLength(
+        0
+      );
+      expect(
+        parseSubtitle(`${line}\n{24}{48}Hello\n`).captions.map((caption) => caption.text)
+      ).toEqual(["Hello"]);
+    }
+  );
+
+  it("does not let metadata alone outrank a later ASS header", () => {
+    const parsed = parseSubtitle("{0}{}25\n[Script Info]\n[Events]\n");
+    expect(parsed.format).toBe("ass");
+    expect(parsed.captions).toHaveLength(0);
+  });
+
+  it("rejects a declaration-only document because metadata is not a cue", () => {
+    expect(() => parseSubtitle("{1}{1}25.000\n")).toThrow(/Could not detect subtitle format/);
+  });
+
+  it("preserves BOM, declarations, non-cue lines, blank lines, and CRLF in Auto shift", () => {
+    const input = "\uFEFF{1}{1}24.000\r\n\r\n{0}{}25.000\r\ncomment\r\n{25}{50}Hello|world\r\n";
+    const output = shiftSubtitle(input, 1000).output;
+
+    expect(output).toBe(
+      "\uFEFF{1}{1}24.000\r\n\r\n{0}{}25.000\r\ncomment\r\n{50}{75}Hello|world\r\n"
+    );
+  });
+
+  it("rewrites recognized declarations and cue frames only for an explicit valid override", () => {
+    const input = "{1}{1}24.000\n{0}{}25.000\n{25}{50}Hello\n";
+    expect(shiftSubtitle(input, 1000, undefined, 30).output).toBe(
+      // Manual 30 FPS wins during parse: frames 25..50 are 833..1667 ms;
+      // after +1000 ms they serialize to frames 55..80 at the same rate.
+      "{1}{1}30\n{0}{}30\n{55}{80}Hello\n"
+    );
+  });
+
+  it("serializes a long valid override into declaration grammar that re-inspects cleanly", () => {
+    const input = "{1}{1}25\n{25}{50}Hello\n";
+    const output = shiftSubtitle(input, 0, undefined, Number("23.976000000000004")).output;
+
+    expect(output).toContain("{1}{1}23.976\n");
+    expect(inspectMicroDvdFpsDeclarations(output).declaredFps).toBe(23.976);
+  });
+
+  it("parses and rebuilds a BOM-prefixed first cue without source drift", () => {
+    const input = "\uFEFF{24}{48}Hello\r\n";
+    expect(shiftSubtitle(input, 1000).output).toBe("\uFEFF{48}{72}Hello\r\n");
   });
 });
 

--- a/src/lib/subtitle-parser.ts
+++ b/src/lib/subtitle-parser.ts
@@ -169,9 +169,14 @@ function firstSrtCueCandidate(content: string): CueCandidate | undefined {
   );
 }
 
-function firstSubCueCandidate(content: string): CueCandidate | undefined {
+function firstSubCueCandidate(
+  content: string,
+  declarationStarts: ReadonlySet<number>
+): CueCandidate | undefined {
   return findFirstCueCandidate(content, (line, _lineIndex, _firstLine, lineStart) => {
-    const match = line.match(SUB_LINE_SINGLE);
+    if (declarationStarts.has(lineStart)) return undefined;
+    const candidateLine = lineStart === 0 && line.startsWith("\uFEFF") ? line.slice(1) : line;
+    const match = candidateLine.match(SUB_LINE_SINGLE);
     if (!match) return undefined;
     return { index: lineStart, hasText: match[1]!.trim().length > 0 };
   });
@@ -188,7 +193,11 @@ export function detectFormat(content: string): SubtitleFormat {
   );
   const hasHeaderCandidate = headerCandidates.length > 0;
   const srtCue = firstSrtCueCandidate(normalized);
-  const subCue = firstSubCueCandidate(normalized);
+  const subInspection = inspectMicroDvdFpsDeclarations(normalized);
+  const subCue = firstSubCueCandidate(
+    normalized,
+    new Set(subInspection.declarations.map((entry) => entry.lineStart))
+  );
 
   // Keep the full-content scan so a long benign preamble does not hide a real
   // header, but cue-based formats must prove a cue-shaped block before they can
@@ -762,40 +771,150 @@ function buildAss(content: string, captions: Caption[]): string {
 
 // ── SUB (MicroDVD) Parser ─────────────────────────────────
 
-const DEFAULT_FPS = 23.976;
+export const MICRODVD_DEFAULT_FPS = 23.976;
+export const MICRODVD_MIN_FPS_EXCLUSIVE = 3;
+export const MICRODVD_MAX_FPS = 120;
 
-/**
- * Clamp MicroDVD fps to a real-world range.
- *
- * Real-world fps is 23.976 / 24 / 25 / 29.97 / 30 / 50 / 60, occasionally
- * up to 120 for variable-frame content. Anything outside [1, 1000] is
- * either parser noise (a crafted MicroDVD `{1}{1}<fps>` line) or
- * hostile input — fall back to DEFAULT_FPS.
- *
- * Shared helper consumed by both parseSub and buildSub. An earlier
- * version had parseSub clamp to [1, 1000] while buildSub only
- * rejected `<= 0`; a round-trip with parser-supplied fps=50 +
- * caller-passed fps=2000 to buildSub silently drifted timestamps.
- * Single source of validation keeps both halves of the round-trip
- * aligned.
- */
-function clampFps(fps: number | undefined): number {
-  if (fps === undefined) return DEFAULT_FPS;
-  if (!Number.isFinite(fps) || fps < 1 || fps > 1000) return DEFAULT_FPS;
-  return fps;
+interface SourceLine {
+  start: number;
+  end: number;
+  body: string;
+  ending: string;
 }
 
-function parseSub(content: string, fps: number = DEFAULT_FPS): Caption[] {
-  fps = clampFps(fps);
+export interface MicroDvdFpsDeclaration {
+  /** Offset of the physical line in the original source string. */
+  lineStart: number;
+  /** Offset immediately after the physical line, including its terminator. */
+  lineEnd: number;
+  fps: number;
+}
+
+export interface MicroDvdFpsInspection {
+  declarations: MicroDvdFpsDeclaration[];
+  /** Last valid declaration among the first three nonempty lines. */
+  declaredFps?: number;
+}
+
+function* iterateSourceLines(content: string): Generator<SourceLine> {
+  let start = 0;
+  while (start < content.length) {
+    let bodyEnd = start;
+    while (bodyEnd < content.length && content[bodyEnd] !== "\r" && content[bodyEnd] !== "\n") {
+      bodyEnd += 1;
+    }
+
+    let end = bodyEnd;
+    if (content[end] === "\r") {
+      end += 1;
+      if (content[end] === "\n") end += 1;
+    } else if (content[end] === "\n") {
+      end += 1;
+    }
+
+    yield {
+      start,
+      end,
+      body: content.slice(start, bodyEnd),
+      ending: content.slice(bodyEnd, end),
+    };
+    start = end;
+  }
+}
+
+// A MicroDVD declaration is syntax, not a caption. Keep this expression
+// deliberately narrower than the ordinary cue expression: only start frame
+// 0/1, an empty or bounded numeric end field, and a complete decimal FPS
+// payload are metadata. Near-misses remain ordinary cue text.
+const MICRODVD_FPS_DECLARATION_RE = /^(\{[01]\}\{(?:\d{1,12})?\})(\d{1,12}(?:\.\d{1,12})?)$/;
+const MICRODVD_CUE_LINE_RE = /^\{(\d{1,12})\}\{(\d{1,12})\}(.*)$/;
+
+function formatMicroDvdFps(fps: number): string {
+  return fps.toFixed(12).replace(/\.?0+$/, "");
+}
+
+export function isValidMicroDvdFps(fps: number): boolean {
+  if (!Number.isFinite(fps) || fps <= MICRODVD_MIN_FPS_EXCLUSIVE || fps > MICRODVD_MAX_FPS) {
+    return false;
+  }
+  // An override must survive serialization back into the bounded declaration
+  // grammar. Values closer to 3 than its 12-decimal precision are rejected
+  // rather than being rewritten as the invalid declaration `3`.
+  return Number(formatMicroDvdFps(fps)) > MICRODVD_MIN_FPS_EXCLUSIVE;
+}
+
+/**
+ * Inspect the first three nonempty physical lines for MicroDVD FPS metadata.
+ *
+ * FFmpeg-compatible files commonly use `{1}{1}25.000`, while other writers
+ * use start frame 0 or an empty second field. All valid declarations in the
+ * bounded window are metadata (never captions); the last one wins. The line
+ * offsets let the source-preserving SUB rebuilder keep Auto-mode bytes and
+ * line endings intact.
+ */
+export function inspectMicroDvdFpsDeclarations(content: string): MicroDvdFpsInspection {
+  const declarations: MicroDvdFpsDeclaration[] = [];
+  let nonemptyCount = 0;
+
+  for (const line of iterateSourceLines(content)) {
+    const body =
+      line.start === 0 && line.body.startsWith("\uFEFF") ? line.body.slice(1) : line.body;
+    if (body.trim().length === 0) continue;
+    nonemptyCount += 1;
+    if (nonemptyCount > 3) break;
+
+    const match = body.match(MICRODVD_FPS_DECLARATION_RE);
+    if (!match) continue;
+    const fps = Number(match[2]);
+    if (!isValidMicroDvdFps(fps)) continue;
+    declarations.push({ lineStart: line.start, lineEnd: line.end, fps });
+  }
+
+  const declaredFps = declarations.at(-1)?.fps;
+  return {
+    declarations,
+    ...(declaredFps !== undefined && { declaredFps }),
+  };
+}
+
+function validFpsOverride(fps: number | undefined): number | undefined {
+  return fps !== undefined && isValidMicroDvdFps(fps) ? fps : undefined;
+}
+
+function resolveMicroDvdFps(content: string, fpsOverride: number | undefined): number {
+  return (
+    validFpsOverride(fpsOverride) ??
+    inspectMicroDvdFpsDeclarations(content).declaredFps ??
+    MICRODVD_DEFAULT_FPS
+  );
+}
+
+/**
+ * Resolve MicroDVD fps to a real-world range.
+ *
+ * Real-world fps is 23.976 / 24 / 25 / 29.97 / 30 / 50 / 60, occasionally
+ * up to 120 for high-frame-rate content. A valid explicit override wins,
+ * followed by an in-file declaration, followed by 23.976.
+ *
+ * Shared resolution is consumed by both parseSub and buildSub so an Auto
+ * round-trip cannot parse at the declared rate and serialize at a fallback.
+ */
+function parseSub(content: string, fpsOverride?: number): Caption[] {
+  const inspection = inspectMicroDvdFpsDeclarations(content);
+  const declarationStarts = new Set(inspection.declarations.map((entry) => entry.lineStart));
+  const fps = validFpsOverride(fpsOverride) ?? inspection.declaredFps ?? MICRODVD_DEFAULT_FPS;
   const captions: Caption[] = [];
   // Frame numbers are bounded to 12 digits — 12 ASCII chars fits ~31000
   // years of milliseconds at 60 fps, far past anything legitimate, and
   // rejects pathological `{99...9}` inputs that would otherwise saturate
   // parseInt to Infinity. Matches the time-regex bound below.
-  const subLineRe = /^\{(\d{1,12})\}\{(\d{1,12})\}(.*)$/gm;
-  let match;
   let count = 0;
-  while ((match = subLineRe.exec(content)) !== null) {
+  for (const line of iterateSourceLines(content)) {
+    if (declarationStarts.has(line.start)) continue;
+    const body =
+      line.start === 0 && line.body.startsWith("\uFEFF") ? line.body.slice(1) : line.body;
+    const match = body.match(MICRODVD_CUE_LINE_RE);
+    if (!match) continue;
     // Per-caption count cap moved BEFORE the push so the throw fires
     // WHEN refusing the entry, matching the SRT/VTT/ASS pattern. An
     // earlier version had the cap as `count += 1; if (count > MAX)
@@ -819,7 +938,7 @@ function parseSub(content: string, fps: number = DEFAULT_FPS): Caption[] {
     if (text.length > MAX_CAPTION_TEXT_LEN) {
       count += 1;
       captions.push({
-        raw: match[0],
+        raw: body,
         start: Math.round((parseInt(match[1]!, 10) / fps) * 1000),
         end: Math.round((parseInt(match[2]!, 10) / fps) * 1000),
         text: "",
@@ -829,7 +948,7 @@ function parseSub(content: string, fps: number = DEFAULT_FPS): Caption[] {
     }
     count += 1;
     captions.push({
-      raw: match[0],
+      raw: body,
       start: Math.round((parseInt(match[1]!, 10) / fps) * 1000),
       end: Math.round((parseInt(match[2]!, 10) / fps) * 1000),
       text: text.replace(/\|/g, "\n"),
@@ -838,34 +957,64 @@ function parseSub(content: string, fps: number = DEFAULT_FPS): Caption[] {
   return captions;
 }
 
-function buildSub(captions: Caption[], fps: number = DEFAULT_FPS): string {
-  // Shared clampFps — see helper docblock for the parse/build
-  // round-trip asymmetry rationale.
-  fps = clampFps(fps);
-  return (
-    captions
-      // parseSub pushes a skipped placeholder for oversized text to
-      // bound iteration cost via MAX_PARSED_ENTRIES.
-      // Filter those out here so the disk output mirrors the legitimate
-      // captions only (placeholders carry empty text and would otherwise
-      // emit `{f}{f}` lines with no body, polluting the file).
-      .filter((c) => !c.skipped)
-      .map((c) => {
-        // Clamp non-finite / negative timestamps to 0 for parity with
-        // formatSrtTime / formatAssTime / msToAssTime.
-        // After a Time Shift with `--offset` large enough to push captions
-        // before t=0, c.start / c.end can land negative; without clamping
-        // they produce negative frame counts (`{-23}{15}`) that downstream
-        // SUB consumers reject. Same defensive shape the SRT / ASS / VTT
-        // builders already use; buildSub was the lone outlier.
-        const start = Number.isFinite(c.start) ? Math.max(0, c.start) : 0;
-        const end = Number.isFinite(c.end) ? Math.max(0, c.end) : 0;
-        const startFrame = Math.round((start / 1000) * fps);
-        const endFrame = Math.round((end / 1000) * fps);
-        return `{${startFrame}}{${endFrame}}${c.text.replace(/\n/g, "|")}`;
-      })
-      .join("\n") + "\n"
+function buildSub(content: string, captions: Caption[], fpsOverride?: number): string {
+  const inspection = inspectMicroDvdFpsDeclarations(content);
+  const declarationsByStart = new Map(
+    inspection.declarations.map((declaration) => [declaration.lineStart, declaration])
   );
+  const explicitFps = validFpsOverride(fpsOverride);
+  const fps = resolveMicroDvdFps(content, fpsOverride);
+  let captionIndex = 0;
+  let output = "";
+
+  for (const line of iterateSourceLines(content)) {
+    const hasBom = line.start === 0 && line.body.startsWith("\uFEFF");
+    const bom = hasBom ? "\uFEFF" : "";
+    const body = hasBom ? line.body.slice(1) : line.body;
+    const declaration = declarationsByStart.get(line.start);
+    if (declaration) {
+      if (explicitFps === undefined) {
+        output += content.slice(line.start, line.end);
+      } else {
+        const match = body.match(MICRODVD_FPS_DECLARATION_RE);
+        if (!match) {
+          throw new Error("buildSub/MicroDVD declaration drift");
+        }
+        output += `${bom}${match[1]}${formatMicroDvdFps(explicitFps)}${line.ending}`;
+      }
+      continue;
+    }
+
+    const cueMatch = body.match(MICRODVD_CUE_LINE_RE);
+    if (!cueMatch) {
+      output += content.slice(line.start, line.end);
+      continue;
+    }
+
+    const caption = captions[captionIndex];
+    if (!caption) {
+      throw new Error(
+        `buildSub/parseSub drift: found more source cues than parsed captions at index ${captionIndex}`
+      );
+    }
+    captionIndex += 1;
+    if (caption.skipped) continue;
+
+    // Preserve the source line terminator rather than normalizing the whole
+    // file, so Auto mode changes only cue timing fields.
+    const start = Number.isFinite(caption.start) ? Math.max(0, caption.start) : 0;
+    const end = Number.isFinite(caption.end) ? Math.max(0, caption.end) : 0;
+    const startFrame = Math.round((start / 1000) * fps);
+    const endFrame = Math.round((end / 1000) * fps);
+    output += `${bom}{${startFrame}}{${endFrame}}${caption.text.replace(/\n/g, "|")}${line.ending}`;
+  }
+
+  if (captionIndex !== captions.length) {
+    throw new Error(
+      `buildSub/parseSub drift: consumed ${captionIndex}/${captions.length} parsed captions`
+    );
+  }
+  return output;
 }
 
 // ── Public API ────────────────────────────────────────────
@@ -918,7 +1067,7 @@ function rebuildSubtitle(
     case "ass":
       return buildAss(content, captions);
     case "sub":
-      return buildSub(captions, fps);
+      return buildSub(content, captions, fps);
     default:
       throw new Error(`Cannot rebuild format: ${format}`);
   }

--- a/src/lib/useFolderDrop.test.ts
+++ b/src/lib/useFolderDrop.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { isDropPositionInsideRect } from "./useFolderDrop";
+
+const visibleRect = {
+  left: 10,
+  right: 110,
+  top: 20,
+  bottom: 70,
+  width: 100,
+  height: 50,
+};
+
+describe("drop-zone hit testing", () => {
+  it("converts physical cursor coordinates to CSS pixels", () => {
+    expect(isDropPositionInsideRect({ x: 40, y: 60 }, visibleRect, 2)).toBe(true);
+    expect(isDropPositionInsideRect({ x: 10, y: 60 }, visibleRect, 2)).toBe(false);
+  });
+
+  it("rejects zero-area hidden tab drop zones, including at the origin", () => {
+    const hiddenRect = { left: 0, right: 0, top: 0, bottom: 0, width: 0, height: 0 };
+    expect(isDropPositionInsideRect({ x: 0, y: 0 }, hiddenRect, 1)).toBe(false);
+  });
+
+  it("keeps inclusive edge hits for a visible drop zone", () => {
+    expect(isDropPositionInsideRect({ x: 10, y: 20 }, visibleRect, 1)).toBe(true);
+    expect(isDropPositionInsideRect({ x: 110, y: 70 }, visibleRect, 1)).toBe(true);
+  });
+});

--- a/src/lib/useFolderDrop.ts
+++ b/src/lib/useFolderDrop.ts
@@ -44,6 +44,25 @@ export interface UseFolderDropOptions {
   t?: (key: string, ...args: (string | number)[]) => string;
 }
 
+type DropRect = Pick<DOMRect, "left" | "right" | "top" | "bottom" | "width" | "height">;
+
+/** Match a physical-pixel Tauri cursor position against a CSS-pixel drop zone.
+ * Hidden tab panels report a zero-area rect at the origin; reject those before
+ * the inclusive edge comparison so a drop at (0, 0) cannot activate them. */
+export function isDropPositionInsideRect(
+  position: { x: number; y: number },
+  rect: DropRect,
+  devicePixelRatio: number
+): boolean {
+  if (rect.width <= 0 || rect.height <= 0 || rect.right <= rect.left || rect.bottom <= rect.top) {
+    return false;
+  }
+  const scale = Number.isFinite(devicePixelRatio) && devicePixelRatio > 0 ? devicePixelRatio : 1;
+  const x = position.x / scale;
+  const y = position.y / scale;
+  return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
+}
+
 /** Subscribe to drag-drop events scoped to a ref'd drop zone element. */
 export function useFolderDrop({
   ref,
@@ -132,11 +151,8 @@ export function useFolderDrop({
           // Tauri reports the cursor position in physical pixels relative
           // to the webview's top-left. getBoundingClientRect is in CSS
           // (logical) pixels, so divide by DPR before comparing.
-          const inRect = (pos: { x: number; y: number }): boolean => {
-            const x = pos.x / dpr;
-            const y = pos.y / dpr;
-            return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;
-          };
+          const inRect = (pos: { x: number; y: number }): boolean =>
+            isDropPositionInsideRect(pos, rect, dpr);
 
           switch (event.payload.type) {
             case "enter":


### PR DESCRIPTION
## Summary

- Prevent Batch Rename output plans from overwriting loaded subtitle inputs, including swaps, rename dependency chains, fail-fast execution, and files loaded in other tabs.
- Correct MicroDVD FPS metadata, HDR empty-output handling, HTML color restoration, and libass-aligned font override/reset handling.
- Harden CLI path, cache, reporting, UTF-32, and timing-map boundaries.
- Fix GUI cache/status lifecycles, timing input validation, multi-subtitle pairing, and partial-result reporting.
- Retire production use of legacy shallow cache adapters and improve cache/write recovery guidance.

## Why

A broad review found several cases where valid edge inputs could be misinterpreted, stale UI state could remain visible, or a batch plan could report a misleading result. The fixes preserve existing workflows while tightening the boundaries before any file write, cache publication, or user-facing success report.

## Impact

- Safer batch file operations and clearer partial/failure results.
- More faithful ASS/libass and MicroDVD behavior.
- Better path, encoding, cache, and resource-limit diagnostics.
- No package version, release tag, binary, or published release change.

## Validation

- Frontend: 36 files / 806 tests
- TypeScript 7 and TypeScript 6 compatibility checks
- Full ESLint and Prettier
- Production frontend build
- Rust at `1e70688`: 484 passed, 8 intentional real-font fixture ignores, 0 failed
- `cargo check --all-targets`
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- Public-diff privacy and accidental-artifact scan