### PR TITLE
Prepare v1.7.0-preview.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssahdrify-tauri",
-  "version": "1.7.0-preview.1",
+  "version": "1.7.0-preview.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssahdrify-tauri",
-      "version": "1.7.0-preview.1",
+      "version": "1.7.0-preview.2",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tauri-apps/api": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssahdrify-tauri",
   "private": true,
-  "version": "1.7.0-preview.1",
+  "version": "1.7.0-preview.2",
   "license": "GPL-3.0-or-later",
   "packageManager": "npm@11.19.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4453,7 +4453,7 @@ dependencies = [
 
 [[package]]
 name = "ssahdrify"
-version = "1.7.0-preview.1"
+version = "1.7.0-preview.2"
 dependencies = [
  "base64 0.23.1",
  "chardetng",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssahdrify"
-version = "1.7.0-preview.1"
+version = "1.7.0-preview.2"
 description = "SDR subtitle to HDR color space converter with font embedding and timing tools"
 authors = ["koagaroon"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary

- Synchronize the npm and Cargo package versions at `1.7.0-preview.2`.
- Prepare the next prerelease in the existing 1.7.0 preview line; stable `v1.6.0` remains the day-to-day recommendation.
- Keep the public patch limited to the four version authorities. Release notes and portable executables are published through the release process after this commit is merged and tagged.

## Validation

- Frontend tests: 36 files / 806 tests passed
- TypeScript 7 release and TypeScript 6 compatibility checks passed
- ESLint, Prettier, Stylelint, rustfmt, and warning-denied Clippy passed
- Rust tests: 484 passed, 8 environment-fixture tests ignored, 0 failed
- npm audit: 0 vulnerabilities
- Full pre-tag portable GUI and CLI build path passed with the verified V8 150.4 library
- Pre-tag CLI reports `ssahdrify-cli 1.7.0-preview.2`

The final upload binaries will be rebuilt from the exact annotated release tag; no generated binary or release artifact is included in this pull request.