### PR TITLE
刷新发布前依赖与工具链

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SSA HDRify
 
-[![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](LICENSE) [![GitHub release](https://img.shields.io/github/v/release/koagaroon/ssaHdrify-tauri)](https://github.com/koagaroon/ssaHdrify-tauri/releases) ![Platform](https://img.shields.io/badge/platform-Windows%20%7C%20macOS%20%7C%20Linux-blue)
+[![License: GPL v3](https://img.shields.io/badge/License-GPL%20v3-blue.svg)](LICENSE) [![GitHub release](https://img.shields.io/github/v/release/koagaroon/ssaHdrify-tauri)](https://github.com/koagaroon/ssaHdrify-tauri/releases) ![Platform](https://img.shields.io/badge/release%20platform-Windows-blue)
 
 > **SSA HDRify 是一款桌面工具，能将 SSA/ASS 字幕的颜色转换为适合 HDR 播放的值，同时提供时间轴偏移、字体嵌入和批量重命名等辅助功能。** 它是 [gky99/ssaHdrify](https://github.com/gky99/ssaHdrify)（Python 原版）的 Tauri 桌面重写版。
 >
@@ -54,7 +54,7 @@ Windows 用户可从 [Releases](https://github.com/koagaroon/ssaHdrify-tauri/rel
 - **`ssahdrify*.exe`** — 图形界面（GUI），适合手动操作
 - **`ssahdrify-cli*.exe`** — 命令行（CLI），适合自动化流水线、批处理和脚本化场景
 
-macOS / Linux 用户请参考下方「从源码构建」。
+macOS / Linux 仅可尝试下方的源码构建流程；项目尚未在这些平台上验证文件对话框、文件系统行为、完整构建或发布产物，因此不属于官方支持的发布平台。
 
 Windows users can download portable, no-install exe files from [Releases](https://github.com/koagaroon/ssaHdrify-tauri/releases). Use the latest stable build by default; preview builds remain listed on the same page for testing features that have not entered a stable release yet.
 
@@ -64,7 +64,7 @@ Windows users can download portable, no-install exe files from [Releases](https:
 - **`ssahdrify*.exe`** — graphical interface (GUI), for manual use
 - **`ssahdrify-cli*.exe`** — command line (CLI), for automation pipelines, batch jobs, and scripts
 
-macOS / Linux users, see "Build from Source" below.
+macOS / Linux users may attempt the source-build workflow below. File dialogs, filesystem behavior, complete builds, and release artifacts have not been validated on those platforms, so they are not officially supported release targets.
 
 ---
 
@@ -465,6 +465,11 @@ Due to the complexity of subtitle blending pipelines and HDR display environment
 ---
 
 ## 从源码构建 | Build from Source
+
+> [!IMPORTANT]
+> 官方发布和发布前验证目前仅覆盖 Windows。macOS / Linux 的源码构建仅作为尚未验证的自行构建路径；项目不提供这些平台的预构建二进制文件。
+>
+> Official releases and release validation currently cover Windows only. macOS and Linux source builds are unvalidated self-build paths; the project does not provide prebuilt binaries for those platforms.
 
 ### 前置条件 | Prerequisites
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.5",
         "@typescript/native": "npm:typescript@~7.0.2",
-        "@vitejs/plugin-react": "^6.1.0",
+        "@vitejs/plugin-react": "^6.1.1",
         "esbuild": "^0.28.2",
         "eslint": "^10.9.1",
         "eslint-plugin-react-hooks": "^7.1.1",
@@ -2854,9 +2854,9 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.1.0.tgz",
-      "integrity": "sha512-qd2BzUBehkov86WFhg0JkEFEYyCLG9uPCe6qWTY/kRlss9OvJrOF2UbIWT7p+8IzZHkEu0DNGHc4HSv+JdDLsw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.1.1.tgz",
+      "integrity": "sha512-yxLaQV9gkhS8ezJqCM6+ndU7mDY6gqAg75NQ+0IjwEI8IYOmQCgkRwHKVSfWXW076DsqMo0Dk+0FK1U+M5RgFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.5",
     "@typescript/native": "npm:typescript@~7.0.2",
-    "@vitejs/plugin-react": "^6.1.0",
+    "@vitejs/plugin-react": "^6.1.1",
     "esbuild": "^0.28.2",
     "eslint": "^10.9.1",
     "eslint-plugin-react-hooks": "^7.1.1",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.97.1"
+channel = "1.98.0"
 profile = "minimal"
 components = ["clippy", "rustfmt"]

--- a/scripts/check-dependency-currency.mjs
+++ b/scripts/check-dependency-currency.mjs
@@ -83,7 +83,7 @@ const cargoPolicies = {
     mode: /** @type {const} */ ("manual"),
     reason:
       "Every deno_core release requires a manual V8, API, and runtime audit before updating the exact pin.",
-    reviewedThrough: "0.410.0",
+    reviewedThrough: "0.411.0",
   },
   rusqlite: {
     mode: /** @type {const} */ ("hold-line"),

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -293,12 +293,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "az"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be5eb007b7cacc6c660343e96f650fedf4b5a77512399eb952ca6642cf8d13f7"
-
-[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,15 +318,6 @@ checksum = "339abbe78e73178762e23bea9dfd08e697eb3f3301cd4be981c0f78ba5859195"
 dependencies = [
  "outref",
  "vsimd",
-]
-
-[[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
 ]
 
 [[package]]
@@ -601,26 +586,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb1307f12aa967b5a58416e87b3653360e0fd614a016b6e970db08fecbb1b80d"
 dependencies = [
  "serde_core",
-]
-
-[[package]]
-name = "capacity_builder"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f2d24a6dcf0cd402a21b65d35340f3a49ff3475dc5fdac91d22d2733e6641c6"
-dependencies = [
- "capacity_builder_macros",
- "itoa",
-]
-
-[[package]]
-name = "capacity_builder_macros"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b4a6cae9efc04cc6cbb8faf338d2c497c165c83e74509cf4dbedea948bbf6e5"
-dependencies = [
- "quote",
- "syn 2.0.119",
 ]
 
 [[package]]
@@ -1118,19 +1083,16 @@ dependencies = [
 
 [[package]]
 name = "deno_core"
-version = "0.410.0"
+version = "0.411.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04d1a43a2716c6818a845f2449ae659da547687c0c4b27c34d242469dd5912bb"
+checksum = "8240c244a4643b8df55e5bef415af26581f3bb06101f3c26c9738f0275c36cc3"
 dependencies = [
  "anyhow",
- "az",
  "base64 0.22.1",
- "bincode",
  "bit-set",
  "bit-vec",
  "boxed_error",
  "bytes",
- "capacity_builder",
  "cooked-waker",
  "deno_error",
  "deno_ops",
@@ -1187,9 +1149,9 @@ dependencies = [
 
 [[package]]
 name = "deno_ops"
-version = "0.286.0"
+version = "0.287.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f62761c3d2e7d1e191d6c5df262a13cd551551188bd4eddd03942e1380b4f98d"
+checksum = "7863f32e66f4ead7146c91c56baf2b85610479e5c205ce46f2a86626f378e579"
 dependencies = [
  "indexmap 2.14.0",
  "proc-macro2",
@@ -1228,9 +1190,9 @@ dependencies = [
 
 [[package]]
 name = "deno_v8"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6cc60d688463f27ab0ced89e6f22ffd1a41633024c43bc34c93a274f2801037"
+checksum = "ec1e313db023bc34346611a555c19be6dd91ff0676dc11099334c8e53e15499b"
 dependencies = [
  "v8",
  "v8x",
@@ -3123,7 +3085,6 @@ checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
 dependencies = [
  "num-integer",
  "num-traits",
- "rand",
 ]
 
 [[package]]
@@ -3166,7 +3127,7 @@ version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
 dependencies = [
- "proc-macro-crate 2.0.2",
+ "proc-macro-crate 3.5.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -3792,21 +3753,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
-name = "rand"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-
-[[package]]
 name = "raw-window-handle"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4220,9 +4166,9 @@ dependencies = [
 
 [[package]]
 name = "serde_v8"
-version = "0.319.0"
+version = "0.320.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50ef084e1f17b765a796023df431c02c00f57e0ad4366b71f7a5141e5047c8fa"
+checksum = "f60d33fe848b2dabcd7c2ac8b515d4023dc459390af641df81ed539fdddda2f6"
 dependencies = [
  "deno_error",
  "deno_v8",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -60,7 +60,7 @@ tauri-plugin-fs = "2.5.1"
 # Rationale documented so a future
 # `cargo update`-style "just bump the pin" decision pauses for the
 # binding audit first.
-deno_core = "=0.410.0"
+deno_core = "=0.411.0"
 clap = { version = "4.6.4", features = ["derive"] }
 tokio = { version = "1.53.1", features = ["rt-multi-thread", "time"] }
 font-kit = "0.14"

--- a/src-tauri/src/bin/cli/engine.rs
+++ b/src-tauri/src/bin/cli/engine.rs
@@ -288,7 +288,7 @@ impl CliEngine {
         // become available here. Re-audit `RuntimeOptions`'s field
         // list on every deno_core bump alongside the API-binding
         // audit pinned in Cargo.toml's deno_core pin WHY.
-        // In 0.410, both residual lazy-source tables default to empty,
+        // In 0.411, both residual lazy-source tables default to empty,
         // and the default module loader remains capability-free.
         let mut runtime = JsRuntime::new(RuntimeOptions {
             extensions: vec![],
@@ -540,7 +540,7 @@ impl CliEngine {
         //      subset of valid JS expression syntax (escapes ", \, and
         //      control chars; emits U+2028/U+2029 as literal bytes,
         //      legal inside JS string literals since ES2019).
-        //   2. V8 15.0 (deno_core 0.410) is well past ES2019.
+        //   2. V8 15.0 (deno_core 0.411) is well past ES2019.
         //   3. function_name comes from a hardcoded &'static str at
         //      every call site — never user-controlled.
         // If any invariant shifts, move to a v8 function-call path

--- a/src-tauri/src/encoding.rs
+++ b/src-tauri/src/encoding.rs
@@ -540,7 +540,7 @@ fn looks_like_cjk_utf32_scalar_text(probes: &[&[u8]], little_endian: bool) -> bo
     let mut cjk = 0usize;
     let mut line_breaks = 0usize;
 
-    for unit in probes.iter().flat_map(|probe| probe.chunks_exact(4)) {
+    for unit in probes.iter().flat_map(|probe| probe.as_chunks::<4>().0) {
         let value = if little_endian {
             u32::from_le_bytes([unit[0], unit[1], unit[2], unit[3]])
         } else {
@@ -596,7 +596,9 @@ fn looks_like_bomless_utf32(bytes: &[u8]) -> bool {
 
 fn decode_utf32_probe(bytes: &[u8], little_endian: bool) -> Option<String> {
     bytes
-        .chunks_exact(4)
+        .as_chunks::<4>()
+        .0
+        .iter()
         .map(|unit| {
             let value = if little_endian {
                 u32::from_le_bytes([unit[0], unit[1], unit[2], unit[3]])

--- a/src-tauri/src/fonts.rs
+++ b/src-tauri/src/fonts.rs
@@ -1637,14 +1637,18 @@ fn decode_utf16be_name(raw: &[u8]) -> Option<String> {
         return None;
     }
     let code_units: Vec<u16> = raw
-        .chunks_exact(2)
+        .as_chunks::<2>()
+        .0
+        .iter()
         .map(|chunk| u16::from_be_bytes([chunk[0], chunk[1]]))
         .collect();
     String::from_utf16(&code_units).ok()
 }
 
 fn raw_looks_utf16be_ascii(raw: &[u8]) -> bool {
-    raw.len() >= 4 && raw.len().is_multiple_of(2) && raw.chunks_exact(2).all(|chunk| chunk[0] == 0)
+    raw.len() >= 4
+        && raw.len().is_multiple_of(2)
+        && raw.as_chunks::<2>().0.iter().all(|chunk| chunk[0] == 0)
 }
 
 fn clean_legacy_name(decoded: String) -> Option<String> {


### PR DESCRIPTION
## Summary
- update @vitejs/plugin-react to 6.1.1 and the tested Rust toolchain to 1.98.0
- update deno_core to 0.411.0 after the required V8/API/runtime/MSRV audit
- preserve V8 150.4.0, Rust 1.91 compatibility, and the three existing policy holds
- apply behavior-equivalent Rust 1.98 lint fixes
- clarify that official release support and prebuilt binaries are Windows-only
- record the completed deno_core audit through 0.411.0

## Validation
- npm audit: 0 vulnerabilities; authenticated watch: 60 current, 0 updates, 0 manual, 3 holds, 0 errors
- TypeScript 6/7, 808 frontend tests, JS/CSS lint, frontend and CLI-engine builds
- locked Cargo metadata, fmt, strict Clippy, full Rust tests, Rust 1.91 all-target compatibility
- Tauri GUI and CLI release-build smokes using the hash-verified V8 150.4.0 library
- independent review completed; the only finding was fixed and re-reviewed