### PR TITLE
Prepare v1.7.0 stable release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssahdrify-tauri",
-  "version": "1.7.0-preview.2",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssahdrify-tauri",
-      "version": "1.7.0-preview.2",
+      "version": "1.7.0",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tauri-apps/api": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssahdrify-tauri",
   "private": true,
-  "version": "1.7.0-preview.2",
+  "version": "1.7.0",
   "license": "GPL-3.0-or-later",
   "packageManager": "npm@11.19.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4399,7 +4399,7 @@ dependencies = [
 
 [[package]]
 name = "ssahdrify"
-version = "1.7.0-preview.2"
+version = "1.7.0"
 dependencies = [
  "base64 0.23.1",
  "chardetng",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssahdrify"
-version = "1.7.0-preview.2"
+version = "1.7.0"
 description = "SDR subtitle to HDR color space converter with font embedding and timing tools"
 authors = ["koagaroon"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary

- promote the validated 1.7 preview line to stable 1.7.0
- synchronize all five documented version fields
- preserve tag-derived GUI identity for the exact-tag build

## Validation

- release-contract tests, TypeScript 6/7 checks, 808 frontend tests, lint and audit
- engine and frontend production builds
- Rust format, all-target Clippy and tests
- Rust 1.91 MSRV check and authenticated dependency watch
- two-binary release build with verified V8 150.4.0 archive