### PR TITLE
[codex] 加固 Windows 输出路径校验

### DIFF
--- a/src-tauri/src/bin/cli/main.rs
+++ b/src-tauri/src/bin/cli/main.rs
@@ -1942,7 +1942,7 @@ fn run_chain(globals: &GlobalOptions, args: ChainArgs) -> Result<ExitCode, Strin
     }
 
     if globals.dry_run {
-        emit_chain_dry_run(&plan, globals);
+        emit_chain_dry_run(&plan, globals)?;
         return Ok(ExitCode::SUCCESS);
     }
 
@@ -2381,15 +2381,10 @@ fn predict_chain_output_path(
     // LPT0-LPT9, AND Unicode superscript variants COM¹/²/³ + LPT¹/²/³
     // — parity with TS `assertSafeOutputFilename` +
     // `util.rs::validate_ipc_path`. The
-    // remaining asymmetry vs TS is the trailing-whitespace / dot strip
-    // before the reserved-name check (`CON ` and `CON.` resolve to the
-    // device on Windows). The Rust pre-check intentionally omits the
-    // strip — Windows refuses to create files with those names, so
-    // the predicted path can never exist on disk →
-    // `predicted.exists()` returns false → prediction returns Some →
-    // V8 runs → TS rejects authoritatively. The harmless-slip set is
-    // closed-form because the Win32 device-namespace gate at the OS
-    // layer is the final arbiter.
+    // Trailing ASCII space/dot output names are rejected below under the
+    // shared product contract, mirroring TS filename validation on every OS.
+    // Returning None preserves predictor abstention: V8 + TS supplies the
+    // authoritative user-facing rejection instead of using a guessed path.
     //
     // Cross-platform asymmetry note : on Linux/macOS
     // the TS-side reserved-name check still rejects `COM¹.ass` etc.,
@@ -2443,6 +2438,9 @@ fn predict_chain_output_path(
     // message. TS-side `assertSafeOutputFilename` rejects them via the
     // empty-stem and traversal gates; mirror at the prediction layer.
     if output_name == "." || output_name == ".." {
+        return None;
+    }
+    if output_name.ends_with(' ') || output_name.ends_with('.') {
         return None;
     }
     let illegal_in_filename = output_name.chars().any(|c| {
@@ -2848,9 +2846,23 @@ fn process_one_chain_input(
     builder.into_written(output_path)
 }
 
-fn emit_chain_dry_run(plan: &chain::ChainPlan, globals: &GlobalOptions) {
+fn emit_chain_dry_run(plan: &chain::ChainPlan, globals: &GlobalOptions) -> Result<(), String> {
+    // Dry-run normally treats predictor abstention as non-fatal, but a concrete
+    // predicted filename plus an invalid relocation is not abstention. Validate
+    // that final relocated path before printing a plan so output-directory
+    // errors cannot be collapsed to None by predict_chain_output_path's `.ok()`.
+    for input in &plan.input_files {
+        if let Ok(absolute) = absolute_path(input) {
+            if let Some(predicted) =
+                predict_chain_output_path(&absolute, &plan.output_template, None)
+            {
+                relocate_output_path(&predicted.to_string_lossy(), globals.output_dir.as_deref())?;
+            }
+        }
+    }
+
     if globals.quiet {
-        return;
+        return Ok(());
     }
     println!("Plan (no files written):");
     println!();
@@ -2927,6 +2939,7 @@ fn emit_chain_dry_run(plan: &chain::ChainPlan, globals: &GlobalOptions) {
             println!("    {}. {}", i + 1, step.kind_name());
         }
     }
+    Ok(())
 }
 
 fn run_hdr(
@@ -6938,7 +6951,7 @@ fn absolute_path(path: &Path) -> Result<PathBuf, String> {
 // Cap on the relocated output path — Windows MAX_PATH minus one.
 // Windows-only: POSIX has PATH_MAX 4096 (Linux) / 1024 (macOS), so
 // applying 259 there over-restricts legitimate long paths
-// . Long-local paths (`\\?\C:\...`) get the extended
+// . Long-local paths (`\\\\?\\C:\\...`) get the extended
 // cap on Windows. UNC long paths keep the standard cap because the
 // server side may not honor the extended namespace.
 #[cfg(target_os = "windows")]
@@ -6955,23 +6968,23 @@ const RELOCATED_LONG_PATH_MAX_LEN: usize = 4096;
 
 fn relocate_output_path(path: &str, output_dir: Option<&Path>) -> Result<PathBuf, String> {
     let path = PathBuf::from(path);
-    let Some(output_dir) = output_dir else {
-        return Ok(path);
+    let relocated = if let Some(output_dir) = output_dir {
+        // `path.file_name()` strips ALL path components from the
+        // engine-returned output path, keeping only the final segment.
+        // Contract : the engine's TS-side
+        // `assertSafeOutputFilename` guarantees the returned `path` is a
+        // flat filename — no path separators, no `..`, no drive letters.
+        // If a future engine change relaxes that invariant, the
+        // file_name() flattening here would silently mask the violation
+        // (we'd just drop the directory prefix instead of erroring). Keep
+        // assertSafeOutputFilename strict.
+        let file_name = path
+            .file_name()
+            .ok_or_else(|| "engine returned an output path without a filename".to_string())?;
+        output_dir.join(file_name)
+    } else {
+        path
     };
-
-    // `path.file_name()` strips ALL path components from the
-    // engine-returned output path, keeping only the final segment.
-    // Contract : the engine's TS-side
-    // `assertSafeOutputFilename` guarantees the returned `path` is a
-    // flat filename — no path separators, no `..`, no drive letters.
-    // If a future engine change relaxes that invariant, the
-    // file_name() flattening here would silently mask the violation
-    // (we'd just drop the directory prefix instead of erroring). Keep
-    // assertSafeOutputFilename strict.
-    let file_name = path
-        .file_name()
-        .ok_or_else(|| "engine returned an output path without a filename".to_string())?;
-    let relocated = output_dir.join(file_name);
 
     // Re-validate length on the relocated path. The JS validators saw
     // the pre-relocation path and signed off; relocation can grow it
@@ -6982,6 +6995,7 @@ fn relocate_output_path(path: &str, output_dir: Option<&Path>) -> Result<PathBuf
     // typically 1 UTF-16 code unit, so a `display.len()` (byte count)
     // would over-restrict CJK paths the OS would happily accept.
     let display = relocated.to_string_lossy();
+    app_lib::util::validate_output_path_shape(&relocated, "Output")?;
     let lower = display.to_lowercase();
     let is_long_local = (lower.starts_with("\\\\?\\") && !lower.starts_with("\\\\?\\unc\\"))
         || (lower.starts_with("//?/") && !lower.starts_with("//?/unc/"));
@@ -8607,6 +8621,29 @@ mod tests {
         assert_eq!(result, out_dir.join("episode.shifted.ass"));
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn relocate_output_path_rejects_intermediate_trailing_ascii_dot() {
+        let out_dir = PathBuf::from(r"D:\real-output.");
+        let err = relocate_output_path(r"C:\subs\episode.shifted.ass", Some(&out_dir)).unwrap_err();
+        assert!(
+            err.contains("directory component ending in an unsupported ASCII dot"),
+            "got: {err}"
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn relocate_output_path_preserves_verbatim_intermediate_trailing_dot() {
+        let out_dir = PathBuf::from(r"\\?\C:\real-output.");
+        let result = relocate_output_path(r"C:\subs\episode.shifted.ass", Some(&out_dir));
+        assert_eq!(result.unwrap(), out_dir.join("episode.shifted.ass"));
+
+        let slash_out_dir = PathBuf::from(r"//?/C:/real-output.");
+        let result = relocate_output_path(r"C:\subs\episode.shifted.ass", Some(&slash_out_dir));
+        assert_eq!(result.unwrap(), slash_out_dir.join("episode.shifted.ass"));
+    }
+
     #[test]
     fn relocate_output_path_accepts_ramdisk_shaped_output_dirs() {
         let drive_root = PathBuf::from("R:\\");
@@ -8937,6 +8974,19 @@ mod tests {
             predicted.is_none(),
             "bare `..` template should reject; got {predicted:?}"
         );
+    }
+
+    #[test]
+    fn predict_chain_output_path_abstains_on_trailing_ascii_dot_or_space() {
+        let input = PathBuf::from("/subs/Show.ass");
+        for output_template in ["{name}{ext}.", "{name}{ext} "] {
+            let predicted = predict_chain_output_path(&input, output_template, None);
+            assert!(
+                predicted.is_none(),
+                "Trailing ASCII dot/space template should defer to V8/TS; \
+                 template={output_template:?}, got {predicted:?}"
+            );
+        }
     }
 
     #[test]

--- a/src-tauri/src/fs_policy.rs
+++ b/src-tauri/src/fs_policy.rs
@@ -223,4 +223,30 @@ mod tests {
             );
         }
     }
+
+    #[cfg(windows)]
+    #[test]
+    fn locked_tauri_glob_matcher_contract_is_case_insensitive_on_windows() {
+        // Dependency contract audit, not an end-to-end application Scope test:
+        // Tauri 2.11.5 constructs its filesystem scope with these explicit
+        // fields plus `MatchOptions::default()`, and locked glob 0.3.4 derives
+        // that default with `case_sensitive == false`.
+        let match_options = glob::MatchOptions {
+            require_literal_separator: true,
+            require_literal_leading_dot: false,
+            ..Default::default()
+        };
+        assert!(!match_options.case_sensitive);
+
+        let denied_pattern = tauri::fs::Pattern::new(r"C:\scope-root\.ssh\**").unwrap();
+        let case_variant: PathBuf = std::path::Path::new(r"C:\scope-root\.SSH\payload.ass")
+            .components()
+            .collect();
+        let near_miss: PathBuf = std::path::Path::new(r"C:\scope-root\.ssh-safe\payload.ass")
+            .components()
+            .collect();
+
+        assert!(denied_pattern.matches_path_with(&case_variant, match_options));
+        assert!(!denied_pattern.matches_path_with(&near_miss, match_options));
+    }
 }

--- a/src-tauri/src/safe_io.rs
+++ b/src-tauri/src/safe_io.rs
@@ -55,7 +55,7 @@
 //! instead of needing parallel fixes in each.
 
 use crate::encoding::{read_text_detect_encoding_inner, ALLOWED_TEXT_EXTENSIONS, MAX_TEXT_SIZE};
-use crate::util::{is_reparse_point, validate_ipc_path};
+use crate::util::{is_reparse_point, validate_ipc_path, validate_output_path};
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -609,7 +609,7 @@ pub fn safe_output_path_exists_inner(
     path: &str,
     is_allowed: impl Fn(&Path) -> bool,
 ) -> Result<bool, String> {
-    validate_ipc_path(path, "Output")?;
+    validate_output_path(path, "Output")?;
     let path_ref = Path::new(path);
     check_output_probe_extension(path_ref, "Output")?;
     check_scope_allows(&is_allowed, path_ref, "Output")?;
@@ -630,7 +630,7 @@ pub fn safe_write_text_file_inner(
     overwrite: bool,
     is_allowed: impl Fn(&Path) -> bool,
 ) -> Result<(), String> {
-    validate_ipc_path(path, "Output")?;
+    validate_output_path(path, "Output")?;
     let path_ref = Path::new(path);
     check_subtitle_extension(path_ref, "Output")?;
     check_scope_allows(&is_allowed, path_ref, "Output")?;
@@ -660,7 +660,7 @@ pub fn safe_write_style_edit_output_inner(
     }
 
     validate_ipc_path(source_path, "Source")?;
-    validate_ipc_path(output_path, "Output")?;
+    validate_output_path(output_path, "Output")?;
     let source_ref = Path::new(source_path);
     let output_ref = Path::new(output_path);
     let source_ext = check_ass_style_extension(source_ref, "Source")?;
@@ -747,7 +747,7 @@ pub fn safe_copy_file_inner(
     is_allowed: impl Fn(&Path) -> bool,
 ) -> Result<(), String> {
     validate_ipc_path(src, "Source")?;
-    validate_ipc_path(dst, "Destination")?;
+    validate_output_path(dst, "Destination")?;
     let src_ref = Path::new(src);
     let dst_ref = Path::new(dst);
     check_copy_rename_extensions(src_ref, dst_ref)?;
@@ -823,7 +823,7 @@ fn safe_rename_file_inner_with_rename(
     rename_file: impl FnOnce(&Path, &Path) -> std::io::Result<()>,
 ) -> Result<(), String> {
     validate_ipc_path(src, "Source")?;
-    validate_ipc_path(dst, "Destination")?;
+    validate_output_path(dst, "Destination")?;
     let src_ref = Path::new(src);
     let dst_ref = Path::new(dst);
     check_copy_rename_extensions(src_ref, dst_ref)?;
@@ -1129,6 +1129,65 @@ mod tests {
         .unwrap_err();
         assert!(err.contains("subtitle extension"));
         assert!(!path.exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn write_rejects_windows_trailing_ascii_dot_space_aliases_before_overwrite() {
+        let dir = temp_dir("write_windows_trailing_alias");
+        let canonical_dir = dir.canonicalize().expect("canonicalize test temp root");
+        let original = dir.join("episode.ass");
+        const ORIGINAL_BYTES: &[u8] = b"known original subtitle bytes";
+        fs::write(&original, ORIGINAL_BYTES).unwrap();
+
+        for alias_name in ["episode.ass.", "episode.ass "] {
+            let alias = dir.join(alias_name);
+            let raw_root = dir.clone();
+            let resolved_root = canonical_dir.clone();
+            let err = safe_write_text_file_inner(
+                &alias.to_string_lossy(),
+                "replacement",
+                true,
+                move |path| path.starts_with(&raw_root) || path.starts_with(&resolved_root),
+            )
+            .unwrap_err();
+
+            assert!(err.contains("subtitle extension"), "got: {err}");
+            assert_eq!(
+                fs::read(&original).unwrap(),
+                ORIGINAL_BYTES,
+                "rejected alias {alias_name:?} must not change the original"
+            );
+        }
+
+        let _ = fs::remove_dir_all(dir);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn write_rejects_windows_intermediate_trailing_dot_alias_before_overwrite() {
+        let dir = temp_dir("write_windows_intermediate_trailing_dot");
+        let canonical_dir = dir.canonicalize().expect("canonicalize test temp root");
+        let real_output_dir = dir.join("real-output");
+        fs::create_dir_all(&real_output_dir).unwrap();
+        let sentinel = real_output_dir.join("episode.ass");
+        const ORIGINAL_BYTES: &[u8] = b"known destination bytes";
+        fs::write(&sentinel, ORIGINAL_BYTES).unwrap();
+
+        let alias_output = dir.join("real-output.").join("episode.ass");
+        let raw_root = dir.clone();
+        let resolved_root = canonical_dir;
+        let err = safe_write_text_file_inner(
+            &alias_output.to_string_lossy(),
+            "replacement",
+            true,
+            move |path| path.starts_with(&raw_root) || path.starts_with(&resolved_root),
+        )
+        .unwrap_err();
+
+        assert!(err.contains("unsupported ASCII dot"), "got: {err}");
+        assert_eq!(fs::read(&sentinel).unwrap(), ORIGINAL_BYTES);
+        let _ = fs::remove_dir_all(dir);
     }
 
     #[test]

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -60,6 +60,14 @@ pub const MAX_IPC_PATH_LEN: usize = 4096;
 /// which input was bad ("Directory path must be 1-4096 bytes", etc.).
 /// Keep this the SINGLE definition; each module previously had its own
 /// copy and they drifted.
+fn uses_reserved_path_namespace(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    let starts_ci = |needle: &[u8]| {
+        bytes.len() >= needle.len() && bytes[..needle.len()].eq_ignore_ascii_case(needle)
+    };
+    starts_ci(br"\\.\") || starts_ci(b"//./") || starts_ci(br"\\?\") || starts_ci(b"//?/")
+}
+
 pub fn validate_ipc_path(path: &str, label: &str) -> Result<(), String> {
     if path.is_empty() || path.len() > MAX_IPC_PATH_LEN {
         return Err(format!("{label} path must be 1-{MAX_IPC_PATH_LEN} bytes"));
@@ -128,13 +136,7 @@ pub fn validate_ipc_path(path: &str, label: &str) -> Result<(), String> {
     // ASCII case folding in place. Lossless: every prefix listed below
     // is pure ASCII, so byte-level case folding is byte-equivalent to
     // the prior char-level fold.
-    let bytes = path.as_bytes();
-    let starts_ci = |needle: &[u8]| {
-        bytes.len() >= needle.len() && bytes[..needle.len()].eq_ignore_ascii_case(needle)
-    };
-    let is_dos_device = starts_ci(br"\\.\") || starts_ci(b"//./");
-    let is_verbatim_drive = starts_ci(br"\\?\") || starts_ci(b"//?/");
-    if is_dos_device || is_verbatim_drive {
+    if uses_reserved_path_namespace(path) {
         return Err(format!("{label} path uses a reserved device namespace"));
     }
     // On Windows, a colon is only valid as the separator in the first
@@ -253,6 +255,110 @@ pub fn validate_ipc_path(path: &str, label: &str) -> Result<(), String> {
         ));
     }
     Ok(())
+}
+
+#[cfg(windows)]
+fn output_directory_component_has_unsupported_trailing_dot(component: &std::ffi::OsStr) -> bool {
+    let bytes = component.as_encoded_bytes();
+    bytes.len() >= 2 && bytes[bytes.len() - 1] == b'.' && bytes[bytes.len() - 2] != b'.'
+}
+
+/// Validate only the filesystem shape of a destination path. On Windows,
+/// reject intermediate Normal components ending in the product's unsupported
+/// single-ASCII-dot shape. Prefix components automatically keep drive anchors
+/// and UNC server/share roots outside this rule; the final Normal component is
+/// the output leaf and remains governed by its own filename and extension
+/// contracts.
+///
+/// This intentionally does not call [`validate_ipc_path`]. CLI relocation may
+/// preserve an already-classified extended-length path for its separate length
+/// contract, while safe-I/O entrypoints call [`validate_output_path`] and retain
+/// the full untrusted-string validation boundary.
+pub fn validate_output_path_shape(path: &Path, label: &str) -> Result<(), String> {
+    #[cfg(windows)]
+    {
+        let raw = path.to_string_lossy();
+        if uses_reserved_path_namespace(raw.as_ref()) {
+            return Ok(());
+        }
+
+        let normalized = raw.replace('\\', "/");
+        if normalized.starts_with("//") {
+            let components: Vec<&str> = normalized.split('/').collect();
+            let mut root_components = 0;
+            let mut first_directory_index = components.len();
+            for (index, component) in components.iter().enumerate().skip(2) {
+                if component.is_empty() {
+                    continue;
+                }
+                root_components += 1;
+                if root_components == 2 {
+                    first_directory_index = index + 1;
+                    break;
+                }
+            }
+            if root_components < 2 {
+                return Ok(());
+            }
+            let end_exclusive = components.len().saturating_sub(1);
+            for component in &components[first_directory_index..end_exclusive] {
+                if component.is_empty() || matches!(*component, "." | "..") {
+                    continue;
+                }
+                if output_directory_component_has_unsupported_trailing_dot(std::ffi::OsStr::new(
+                    component,
+                )) {
+                    return Err(format!(
+                        "{label} path contains a directory component ending in an unsupported ASCII dot: {component}"
+                    ));
+                }
+            }
+            return Ok(());
+        }
+
+        if let Some(std::path::Component::Prefix(prefix)) = path.components().next() {
+            if matches!(
+                prefix.kind(),
+                std::path::Prefix::Verbatim(_)
+                    | std::path::Prefix::VerbatimDisk(_)
+                    | std::path::Prefix::VerbatimUNC(_, _)
+                    | std::path::Prefix::DeviceNS(_)
+            ) {
+                return Ok(());
+            }
+        }
+        let mut normal_components = path
+            .components()
+            .filter_map(|component| match component {
+                std::path::Component::Normal(value) => Some(value),
+                _ => None,
+            })
+            .peekable();
+
+        while let Some(component) = normal_components.next() {
+            if normal_components.peek().is_none() {
+                break;
+            }
+            if output_directory_component_has_unsupported_trailing_dot(component) {
+                return Err(format!(
+                    "{label} path contains a directory component ending in an unsupported ASCII dot: {}",
+                    component.to_string_lossy()
+                ));
+            }
+        }
+    }
+
+    #[cfg(not(windows))]
+    let _ = (path, label);
+
+    Ok(())
+}
+
+/// Validate an untrusted destination path, then apply output-specific shape
+/// checks before any scope, existence, or filesystem operation.
+pub fn validate_output_path(path: &str, label: &str) -> Result<(), String> {
+    validate_ipc_path(path, label)?;
+    validate_output_path_shape(Path::new(path), label)
 }
 
 /// Validate a font family name received from the IPC boundary or
@@ -691,6 +797,58 @@ mod tests {
         // serializations) must also reject.
         let err = validate_ipc_path("//?/C:/Users/u/.ssh/id_rsa", "Test").unwrap_err();
         assert!(err.contains("reserved device namespace"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn output_directory_component_predicate_has_the_exact_ascii_boundary() {
+        for component in ["dir.", ".hidden.", "dir .", "dir. ."] {
+            assert!(output_directory_component_has_unsupported_trailing_dot(
+                std::ffi::OsStr::new(component)
+            ));
+        }
+        for component in ["dir..", "dir...", "dir ", "dir. ", "dir．", ".", ".."] {
+            assert!(!output_directory_component_has_unsupported_trailing_dot(
+                std::ffi::OsStr::new(component)
+            ));
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn validate_output_path_rejects_only_intermediate_normal_components() {
+        let err = validate_output_path(r"C:\base\dir.\episode.ass", "Output").unwrap_err();
+        assert!(err.contains("directory component ending in an unsupported ASCII dot"));
+
+        for path in [
+            r"C:\base\dir..\episode.ass",
+            r"C:\base\dir...\episode.ass",
+            r"C:\base\dir \episode.ass",
+            r"C:\base\dir. \episode.ass",
+            r"\\server.\share.\base\episode.ass",
+            r"//server.//share./base/episode.ass",
+            r"C:\base\episode.ass.",
+        ] {
+            validate_output_path(path, "Output")
+                .unwrap_or_else(|error| panic!("{path} should validate here: {error}"));
+        }
+
+        let err =
+            validate_output_path(r"//server.//share./dir./episode.ass", "Output").unwrap_err();
+        assert!(err.contains("directory component ending in an unsupported ASCII dot"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn validate_output_path_keeps_reserved_namespace_error_priority() {
+        validate_output_path_shape(Path::new(r"\\?\C:\dir.\episode.ass"), "Output")
+            .expect("shape-only validation must preserve verbatim paths");
+        validate_output_path_shape(Path::new(r"//?/C:/dir./episode.ass"), "Output")
+            .expect("shape-only validation must preserve slash-form verbatim paths");
+        let err = validate_output_path(r"\\?\C:\dir.\episode.ass", "Output").unwrap_err();
+        assert!(err.contains("reserved device namespace"), "got: {err}");
+        let err = validate_output_path(r"//?/C:/dir./episode.ass", "Output").unwrap_err();
+        assert!(err.contains("reserved device namespace"), "got: {err}");
     }
 
     // ── strip_visual_line_breaks ──

--- a/src-tauri/tests/test_chain.rs
+++ b/src-tauri/tests/test_chain.rs
@@ -357,6 +357,131 @@ fn chain_self_overwrite_fails_before_the_exists_check() {
 }
 
 #[test]
+fn chain_rejects_trailing_dot_output_template_before_write() {
+    if let Some(reason) = engine_bundle_missing() {
+        panic!("engine bundle missing — run `npm run build:engine` first ({reason})");
+    }
+
+    let dir = temp_dir("windows_trailing_dot_template");
+    let input = write_fixture(&dir, "cat.ass");
+    let before = fs::read(&input).expect("read input before trailing-dot template probe");
+
+    let output = Command::new(cli_path())
+        .args([
+            "--overwrite",
+            "--lang",
+            "en",
+            "chain",
+            "--output-template",
+            "{name}{ext}.",
+            "shift",
+            "--offset",
+            "+2s",
+        ])
+        .arg(&input)
+        .output()
+        .expect("failed to run trailing-dot output-template probe");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "trailing-dot output filename should be a complete failure: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("cannot end with an ASCII space or dot"),
+        "failure should come from early output-filename validation: {stderr}"
+    );
+    assert_eq!(
+        fs::read(&input).expect("read input after trailing-dot template probe"),
+        before,
+        "filename rejection must leave the input byte-identical"
+    );
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[cfg(windows)]
+#[test]
+fn chain_rejects_intermediate_trailing_dot_output_directory_without_mutation() {
+    if let Some(reason) = engine_bundle_missing() {
+        panic!("engine bundle missing — run `npm run build:engine` first ({reason})");
+    }
+
+    let dir = temp_dir("windows_intermediate_trailing_dot_output_dir");
+    let input = write_fixture(&dir, "cat.ass");
+    let input_before = fs::read(&input).expect("read source before output-dir probe");
+    let real_output_dir = dir.join("real-output");
+    fs::create_dir_all(&real_output_dir).unwrap();
+    let destination = real_output_dir.join("cat.shifted.ass");
+    let destination_before = b"known destination bytes";
+    fs::write(&destination, destination_before).unwrap();
+    let alias_output_dir = PathBuf::from(format!("{}.", real_output_dir.to_string_lossy()));
+
+    let output = Command::new(cli_path())
+        .args(["--overwrite", "--dry-run", "--lang", "en", "--output-dir"])
+        .arg(&alias_output_dir)
+        .args(["chain", "shift", "--offset", "+2s"])
+        .arg(&input)
+        .output()
+        .expect("failed to run intermediate trailing-dot output-dir probe");
+
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "unsupported output directory should be a complete failure: stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("directory component ending in an unsupported ASCII dot"),
+        "failure should identify the output-directory component rule: {stderr}"
+    );
+    assert_eq!(fs::read(&input).unwrap(), input_before);
+    assert_eq!(fs::read(&destination).unwrap(), destination_before);
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[cfg(windows)]
+#[test]
+fn chain_rejects_win32_output_directory_alias_before_real_overwrite() {
+    if let Some(reason) = engine_bundle_missing() {
+        panic!("engine bundle missing — run `npm run build:engine` first ({reason})");
+    }
+
+    let dir = temp_dir("windows_real_intermediate_trailing_dot_output_dir");
+    let input = write_fixture(&dir, "cat.ass");
+    let input_before = fs::read(&input).expect("read source before real output-dir probe");
+    let real_output_dir = dir.join("real-output");
+    fs::create_dir_all(&real_output_dir).unwrap();
+    let destination = real_output_dir.join("cat.shifted.ass");
+    let destination_before = b"known destination bytes before real overwrite";
+    fs::write(&destination, destination_before).unwrap();
+    let alias_output_dir = PathBuf::from(format!("{}.", real_output_dir.to_string_lossy()));
+
+    let output = Command::new(cli_path())
+        .args(["--overwrite", "--lang", "en", "--output-dir"])
+        .arg(&alias_output_dir)
+        .args(["chain", "shift", "--offset", "+2s"])
+        .arg(&input)
+        .output()
+        .expect("failed to run real intermediate trailing-dot output-dir probe");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("directory component ending in an unsupported ASCII dot"),
+        "failure should identify Win32 output-directory alias rejection: {stderr}"
+    );
+    assert_eq!(fs::read(&input).unwrap(), input_before);
+    assert_eq!(fs::read(&destination).unwrap(), destination_before);
+
+    let _ = fs::remove_dir_all(dir);
+}
+
+#[test]
 fn chain_multi_file_batch_processes_all_inputs() {
     if let Some(reason) = engine_bundle_missing() {
         // Hard-fail instead of skip-and-return : a

--- a/src/cli-engine-roundtrip.test.ts
+++ b/src/cli-engine-roundtrip.test.ts
@@ -416,6 +416,14 @@ describe("Cheap resolver ↔ heavy converter byte equivalence", () => {
     expect(cheap).toBe(heavy.outputPath);
   });
 
+  it("resolveShiftOutputPath rejects output names ending in an ASCII dot or space", () => {
+    for (const outputTemplate of ["{name}{ext}.", "{name}{ext} "]) {
+      expect(() => resolveShiftOutputPath({ inputPath: inputAss, outputTemplate })).toThrow(
+        /cannot end with an ASCII space or dot/
+      );
+    }
+  });
+
   it("resolveEmbedOutputPath matches planFontEmbed.outputPath for the default template", () => {
     const embedAss = [
       "[Script Info]",

--- a/src/lib/path-validation.test.ts
+++ b/src/lib/path-validation.test.ts
@@ -55,6 +55,43 @@ describe("assertSafeOutputFilename", () => {
     expect(() => assertSafeOutputFilename(".hidden.ass")).not.toThrow();
   });
 
+  it("rejects trailing ASCII spaces and dots in output leaves on every platform", async () => {
+    for (const platform of [
+      { isWindows: true, isCaseInsensitiveFs: true },
+      { isWindows: false, isCaseInsensitiveFs: false },
+      { isWindows: false, isCaseInsensitiveFs: true },
+    ]) {
+      await withInjectedPlatform(platform, ({ assertSafeOutputFilename: assertInjected }) => {
+        for (const filename of [
+          "episode.ass.",
+          "episode.ass ",
+          "episode.ass..",
+          "episode.ass  ",
+          "episode.ass. ",
+          "episode.ass .",
+        ]) {
+          expect(() => assertInjected(filename)).toThrow(/cannot end with an ASCII space or dot/);
+        }
+      });
+    }
+  });
+
+  it("does not classify leading ASCII space or trailing non-ASCII spaces under the leaf rule", async () => {
+    // This pins only the shared product validator. It does not claim every
+    // supported filesystem can create each name unchanged.
+    for (const platform of [
+      { isWindows: true, isCaseInsensitiveFs: true },
+      { isWindows: false, isCaseInsensitiveFs: false },
+      { isWindows: false, isCaseInsensitiveFs: true },
+    ]) {
+      await withInjectedPlatform(platform, ({ assertSafeOutputFilename: assertInjected }) => {
+        for (const filename of [" episode.ass", "episode.ass\u00a0", "episode.ass\u3000"]) {
+          expect(() => assertInjected(filename)).not.toThrow();
+        }
+      });
+    }
+  });
+
   it("rejects path separators in the filename", () => {
     expect(() => assertSafeOutputFilename("dir/file.ass")).toThrow(/illegal/);
     expect(() => assertSafeOutputFilename("dir\\file.ass")).toThrow(/illegal/);
@@ -329,6 +366,35 @@ describe("decomposeOutputDirectoryPath", () => {
     expect(() => decomposeOutputDirectoryPath("C:\\subs.v1\\out")).not.toThrow();
     expect(() => decomposeOutputDirectoryPath("/tmp/.../out")).not.toThrow();
   });
+
+  it("applies the exact Windows trailing-dot directory rule to the terminal component", async () => {
+    await withInjectedPlatform(
+      { isWindows: true, isCaseInsensitiveFs: true },
+      ({ decomposeOutputDirectoryPath: decomposeInjected }) => {
+        expect(() => decomposeInjected("C:\\base\\dir.")).toThrow(
+          /directory component.*ASCII dot/i
+        );
+        expect(() => decomposeInjected("C:/dir.")).toThrow(/directory component.*ASCII dot/i);
+        for (const outputDir of ["C:/", "C:\\base\\dir..", "C:\\base\\dir "]) {
+          expect(() => decomposeInjected(outputDir)).not.toThrow();
+        }
+      }
+    );
+  });
+
+  it("does not apply the Windows trailing-dot directory rule on non-Windows platforms", async () => {
+    for (const platform of [
+      { isWindows: false, isCaseInsensitiveFs: false },
+      { isWindows: false, isCaseInsensitiveFs: true },
+    ]) {
+      await withInjectedPlatform(
+        platform,
+        ({ decomposeOutputDirectoryPath: decomposeInjected }) => {
+          expect(() => decomposeInjected("/base/dir.")).not.toThrow();
+        }
+      );
+    }
+  });
 });
 
 describe("assertSafeOutputPath", () => {
@@ -350,6 +416,65 @@ describe("assertSafeOutputPath", () => {
     // Construct a sibling whose name happens to contain `..` as a
     // non-segment substring. The traversal check is segment-anchored.
     expect(() => assertSafeOutputPath("C:/subs/show..ep01.ass", inputBackslash)).not.toThrow();
+  });
+
+  it("rejects only the exact unsupported Windows intermediate trailing-dot shape", async () => {
+    await withInjectedPlatform(
+      { isWindows: true, isCaseInsensitiveFs: true },
+      ({ assertSafeOutputPath: assertInjected }) => {
+        const driveInput = "C:\\base\\source.ass";
+        for (const outputPath of [
+          "C:/dir./out.ass",
+          "C:\\base\\dir.\\out.ass",
+          "C:/base\\dir.\\nested/out.ass",
+          "C:\\base\\.hidden.\\out.ass",
+          "C:\\base\\dir .\\out.ass",
+          "C:\\base\\dir. .\\out.ass",
+        ]) {
+          expect(() => assertInjected(outputPath, driveInput)).toThrow(
+            /directory component.*ASCII dot/i
+          );
+        }
+
+        for (const outputPath of [
+          "C:\\base\\dir..\\out.ass",
+          "C:\\base\\dir...\\out.ass",
+          "C:\\base\\dir \\out.ass",
+          "C:\\base\\dir. \\out.ass",
+          "C:\\base\\dir．\\out.ass",
+        ]) {
+          expect(() => assertInjected(outputPath, driveInput)).not.toThrow();
+        }
+
+        const uncInput = "\\\\server.\\share.\\base\\source.ass";
+        expect(() =>
+          assertInjected("\\\\server.\\share.\\base\\nested.\\out.ass", uncInput)
+        ).toThrow(/directory component.*ASCII dot/i);
+        expect(() => assertInjected("\\\\server.\\share.\\base\\out.ass", uncInput)).not.toThrow();
+        expect(() =>
+          assertInjected("//server.//share./base/out.ass", "//server.//share./base/source.ass")
+        ).not.toThrow();
+        expect(() =>
+          assertInjected("//server.//share./dir./out.ass", "//server.//share./base/source.ass")
+        ).toThrow(/directory component.*ASCII dot/i);
+        expect(() => assertInjected("C:/out.ass", "C:/source.ass")).not.toThrow();
+
+        expect(() =>
+          assertInjected("//?/C:/base/dir./out.ass", "//?/C:/base/source.ass")
+        ).not.toThrow();
+      }
+    );
+  });
+
+  it("allows intermediate trailing-dot directory names outside Windows", async () => {
+    for (const platform of [
+      { isWindows: false, isCaseInsensitiveFs: false },
+      { isWindows: false, isCaseInsensitiveFs: true },
+    ]) {
+      await withInjectedPlatform(platform, ({ assertSafeOutputPath: assertInjected }) => {
+        expect(() => assertInjected("/base/dir./out.ass", "/base/source.ass")).not.toThrow();
+      });
+    }
   });
 
   it("rejects paths that escape the input directory", () => {

--- a/src/lib/path-validation.ts
+++ b/src/lib/path-validation.ts
@@ -297,7 +297,57 @@ function trimTrailingPathSeparators(path: string): string {
   return path.replace(/\/+$/, "");
 }
 
-function assertOutputPathShape(normalizedOutput: string): void {
+function hasUnsupportedTrailingAsciiDot(component: string): boolean {
+  return component.endsWith(".") && !component.endsWith("..");
+}
+
+function assertNoUnsupportedWindowsOutputDirectoryComponents(
+  normalizedOutput: string,
+  terminalComponentIsDirectory: boolean
+): void {
+  if (!isWindowsRuntime) return;
+
+  const lower = normalizedOutput.toLowerCase();
+  if (lower.startsWith("//?/") || lower.startsWith("//./")) return;
+
+  const components = normalizedOutput.split("/");
+  let firstDirectoryIndex: number;
+  if (/^[A-Za-z]:\/$/.test(normalizedOutput.slice(0, 3))) {
+    firstDirectoryIndex = 1;
+  } else if (normalizedOutput.startsWith("//")) {
+    let rootComponents = 0;
+    firstDirectoryIndex = components.length;
+    for (let index = 2; index < components.length; index += 1) {
+      if (!components[index]) continue;
+      rootComponents += 1;
+      if (rootComponents === 2) {
+        firstDirectoryIndex = index + 1;
+        break;
+      }
+    }
+  } else if (normalizedOutput.startsWith("/")) {
+    firstDirectoryIndex = 1;
+  } else {
+    // Preserve the existing absolute-path error priority for relative shapes.
+    return;
+  }
+
+  const endExclusive = terminalComponentIsDirectory ? components.length : components.length - 1;
+  for (let index = firstDirectoryIndex; index < endExclusive; index += 1) {
+    const component = components[index];
+    if (!component || component === "." || component === "..") continue;
+    if (hasUnsupportedTrailingAsciiDot(component)) {
+      throw new Error(
+        `Output path contains a directory component ending in an unsupported ASCII dot: ${component}`
+      );
+    }
+  }
+}
+
+function assertOutputPathShape(
+  normalizedOutput: string,
+  terminalComponentIsDirectory = false
+): void {
   if (new RegExp(`[${ASCII_CONTROL_CHARS}]`).test(normalizedOutput)) {
     throw new Error(`Output path contains control characters: ${normalizedOutput}`);
   }
@@ -311,6 +361,11 @@ function assertOutputPathShape(normalizedOutput: string): void {
   if (/(^|\/)\.\.($|\/)/.test(normalizedOutput)) {
     throw new Error(`Output path contains directory traversal: ${normalizedOutput}`);
   }
+
+  assertNoUnsupportedWindowsOutputDirectoryComponents(
+    normalizedOutput,
+    terminalComponentIsDirectory
+  );
 }
 
 function assertNoCurrentDirectorySegments(normalizedPath: string, label: string): void {
@@ -370,7 +425,7 @@ export function decomposeOutputDirectoryPath(outputDir: string): OutputDirectory
 
   const usedBackslash = isWindowsRuntime && outputDir.includes("\\");
   const normalized = usedBackslash ? outputDir.replace(/\\/g, "/") : outputDir;
-  assertOutputPathShape(normalized);
+  assertOutputPathShape(normalized, true);
 
   const isAbsolute = normalized.startsWith("/") || /^[A-Za-z]:\//.test(normalized);
   if (!isAbsolute) {
@@ -511,6 +566,7 @@ export function substituteTemplate(template: string, vars: Record<string, string
  *
  * Throws on:
  *   - empty / whitespace-only filename
+ *   - trailing ASCII space or dot under the product output contract
  *   - illegal characters (control / NTFS-reserved / separators)
  *   - Windows reserved name (CON, PRN, etc., case-insensitive,
  *     applied to the stem with trailing whitespace + dots stripped)
@@ -531,6 +587,9 @@ export function assertSafeOutputFilename(
   }
   if (!filename.replace(/\./g, "").trim()) {
     throw new Error("Template resolves to a dots-only filename");
+  }
+  if (filename.endsWith(" ") || filename.endsWith(".")) {
+    throw new Error("Output filename cannot end with an ASCII space or dot");
   }
   const illegalRe = options?.allowBraces
     ? ILLEGAL_FILENAME_CHARS_BRACES_OK


### PR DESCRIPTION
## What changed

- Reject output filenames ending in an ASCII space or dot before conversion or write planning.
- Reject the exact unsafe Win32 intermediate-directory trailing-dot shape across TypeScript validation, CLI relocation, and native destination operations.
- Preserve drive, UNC, long-path, and reserved-namespace boundaries while handling redundant UNC separators consistently.
- Add native overwrite backstops and CLI integration coverage proving rejected aliases cannot mutate existing source or destination bytes.
- Audit the locked Tauri/glob matcher contract: matching is already case-insensitive on Windows, so this change does not rewrite runtime filesystem scope behavior.

## Why

Windows can resolve selected trailing-dot directory spellings to an existing directory. Rejecting those output shapes before existence checks or mutation keeps planning and native write paths consistent and prevents an aliased destination from being cleared or replaced.

The earlier case-bypass premise was disproven by the locked matcher behavior. The retained matcher test documents that dependency contract without claiming an end-to-end Scope rewrite.

## User impact

Invalid output templates and Windows output-directory aliases now fail early with a clear validation error. Ordinary drive paths, UNC roots, long-path planning, double-dot directory names, trailing-space directories, and non-ASCII dot/space lookalikes retain their documented behavior.

## Validation

- TypeScript type checks: TypeScript 7 and TypeScript 6
- Vitest: 37 files, 815 tests passed
- ESLint, Prettier, and Stylelint
- Vite production build and embedded engine build
- Cargo metadata (locked, offline) and rustfmt
- Clippy: all targets with warnings denied
- Rust tests: 496 passed, 8 fixture-dependent ignored
- Rust 1.91 all-target compatibility check
- git diff integrity check

Local npm audit was unavailable under the execution environment's egress policy. Dependency Review remains the pull-request dependency gate.