### PR TITLE
[codex] 准备 v1.7.1 发布

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ssahdrify-tauri",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ssahdrify-tauri",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "GPL-3.0-or-later",
       "dependencies": {
         "@tauri-apps/api": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ssahdrify-tauri",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.7.1",
   "license": "GPL-3.0-or-later",
   "packageManager": "npm@11.19.0",
   "type": "module",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4399,7 +4399,7 @@ dependencies = [
 
 [[package]]
 name = "ssahdrify"
-version = "1.7.0"
+version = "1.7.1"
 dependencies = [
  "base64 0.23.1",
  "chardetng",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ssahdrify"
-version = "1.7.0"
+version = "1.7.1"
 description = "SDR subtitle to HDR color space converter with font embedding and timing tools"
 authors = ["koagaroon"]
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
Synchronizes five version authorities to 1.7.1 across the npm and Cargo manifests and lockfiles.

No dependency, source, documentation, or license changes.

Prepares stable v1.7.1 for the Windows output-path protection merged in PR #14.

Validation:
- Release contract: 2/2
- Typechecks: passed
- Vitest: 815 passed
- Lints: passed
- npm audit: 0 vulnerabilities
- Web and engine builds: passed
- Cargo metadata, fmt, and Clippy: passed
- Rust tests: 496 passed, 8 ignored
- Rust 1.91 check: passed
- Diff integrity: passed