### PR TITLE
Protect batch sources and correct subtitle, resource, and dependency handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,10 @@ Format support is not identical across workflows. The table below describes curr
 >
 > Here `.sub` means MicroDVD text subtitles. Blu-ray PGS `.sup` and VobSub `.sub/.idx` are image subtitle formats, so HDR text color conversion, Timing Shift, ASS font embedding, and `diagnose-fonts` do not apply. `.sup` is only paired, copied, or renamed as an opaque sidecar in Batch Rename. To turn image subtitles into text subtitles, use a dedicated subtitle conversion/OCR tool first.
 
+ASS/SSA 的时间轴处理遵循 `[Events]` 中的 `Format:` 字段声明，支持字段重排及带正负号的 Layer。当前支持范围要求 `Text` 位于最后，且 Start/End 字段完整、无歧义；超出此范围的声明会明确报错。为获得跨播放器兼容性，建议使用标准 ASS 字段顺序。
+
+ASS/SSA timing operations follow the `Format:` declaration in `[Events]`, including reordered fields and signed Layer values. The supported format requires `Text` last and unambiguous Start/End fields; unsupported declarations produce an explicit error. Standard ASS field order is recommended for compatibility across players.
+
 ---
 
 ## 使用方法 | Usage
@@ -243,6 +247,14 @@ ssahdrify-cli rename "<series-folder>" --langs all --dry-run
 `rename --mode` 控制文件操作。默认的 `copy-to-video` 会把字幕复制到匹配视频所在的目录；`rename` 会在字幕原目录中直接重命名源文件；`copy-to-chosen` 会把字幕复制到 `--output-dir` 指定的目录。`copy-to-chosen` 必须同时传入 `--output-dir`，另外两种模式则不接受该参数。
 
 `rename --mode` controls the file operation. The default `copy-to-video` copies each subtitle beside its matched video; `rename` renames the source subtitle in its existing directory; and `copy-to-chosen` copies it to the directory supplied through `--output-dir`. `--output-dir` is required with `copy-to-chosen` and is rejected with the other two modes.
+
+仅包含时间轴偏移的 `chain` 默认保留输入扩展名；包含 HDR 或字体嵌入步骤时默认输出 `.ass`。自定义输出模板仍按指定内容使用。
+
+A shift-only `chain` preserves the input extension by default. A chain containing HDR conversion or font embedding defaults to `.ass`. Explicit output templates retain the requested filename.
+
+GUI 会保护已加载的字幕源文件，CLI 会保护本批次所选的输入文件；普通的覆盖确认或 `--overwrite` 不允许用另一个输出替换这些源文件。在 GUI 中，覆盖确认仅涵盖预检查中列出的目标（包括无法确认是否存在的目标）；其他路径仍使用独占创建或重命名检查。
+
+The GUI protects loaded subtitle sources, and the CLI protects inputs selected for the current batch. Ordinary overwrite consent or `--overwrite` does not allow another output to replace these sources. In the GUI, overwrite consent covers destinations included in the preflight confirmation, including destinations whose existence could not be checked. Other paths retain exclusive creation or rename checks.
 
 `rename --langs auto` 保持和 GUI 一致的默认行为：每个视频只选一个字幕，输出文件名与视频主名（stem）完全一致（如 `Video.ass`）。`rename --langs all` 或显式列表（如 `--langs sc,jp`）可以为同一个视频规划多个字幕，并写成带语言后缀的文件名（如 `Video.sc.ass`、`Video.jp.srt`）；没有语言标记的字幕仍使用与视频同名的文件名（如 `Video.ass`）。如果多行会写入同一个目标路径，CLI 会在写入前拦截这些存在冲突的条目。
 
@@ -641,6 +653,7 @@ The tables below list the main direct dependencies and bundled assets. For the f
 | [fontcull](https://github.com/bearcove/fontcull)                             | MIT / MIT OR Apache-2.0                        | 字体子集化（含 fontcull-klippa、fontcull-skrifa）/ Font subsetting (includes fontcull-klippa, fontcull-skrifa) |
 | [chardetng](https://github.com/hsivonen/chardetng)                           | MIT OR Apache-2.0                              | 编码检测 (Firefox 引擎) / Encoding detection (Firefox's engine)                                                |
 | [encoding_rs](https://github.com/hsivonen/encoding_rs)                       | (Apache-2.0 OR MIT) AND BSD-3-Clause           | 编码转换 / Encoding conversion                                                                                 |
+| [rustix](https://github.com/bytecodealliance/rustix)                         | Apache-2.0 OR MIT                              | Linux、Android 和 Apple 平台上的独占重命名 / Exclusive rename on Linux, Android, and Apple platforms           |
 | [rusqlite](https://github.com/rusqlite/rusqlite)                             | MIT                                            | 字体缓存和本地字体索引 / Font cache and local font index                                                       |
 | [serde](https://serde.rs/) / serde_json                                      | MIT OR Apache-2.0                              | Rust 序列化 / Rust serialization                                                                               |
 | [deno_core](https://github.com/denoland/deno)                                | MIT                                            | 嵌入式 V8 JS 运行时（CLI）/ Embedded V8 JS runtime (CLI)                                                       |
@@ -665,9 +678,9 @@ The tables below list the main direct dependencies and bundled assets. For the f
 >
 > OFL-1.1 allows these fonts to be bundled, embedded, and redistributed alongside any software, including GPL-3.0 projects. The fonts and their derivatives must remain licensed under OFL, must not be sold on their own, and modified versions must not use Reserved Font Names declared by their respective licenses. The bundled Smiley Sans license declares `Smiley` and `得意黑`; the bundled Inter license declares none.
 
-在桌面版中，点击页脚的「许可证」即可离线阅读项目 GPL 正文、两款捆绑字体的完整 OFL 文本，以及 Feather Icons 的 MIT 声明。
+在桌面版中，点击页脚的「许可证」即可离线阅读项目 GPL 正文、锁定版本的 JavaScript 运行时依赖及 Vite 注入辅助代码的许可声明、两款捆绑字体的完整 OFL 文本，以及 Feather Icons 的 MIT 声明。前端构建同时生成 `third-party-notices.txt`；这些前端声明不代表完整的 Rust 原生依赖许可清单。
 
-In the desktop app, choose **Licenses** in the footer to read offline copies of the project GPL, both bundled fonts' complete OFL texts, and the Feather Icons MIT notice.
+In the desktop app, choose **Licenses** in the footer to read offline copies of the project GPL, notices for locked JavaScript runtime dependencies and Vite-injected helper code, both bundled fonts' complete OFL texts, and the Feather Icons MIT notice. The frontend build also emits `third-party-notices.txt`; this frontend inventory does not represent a complete Rust native dependency license inventory.
 
 #### 构建时依赖（不随应用分发）| Build-time only (not shipped)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "stylelint-config-standard": "^40.0.0",
         "tailwindcss": "^4.3.3",
         "typescript": "npm:@typescript/typescript6@6.0.2",
-        "typescript-eslint": "^8.69.0",
+        "typescript-eslint": "^8.70.0",
         "vite": "^8.2.2",
         "vitest": "^5.0.0"
       },
@@ -2193,17 +2193,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.69.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.69.0.tgz",
-      "integrity": "sha512-t5jQTKPIgVW1PE6dR6H6Qz5gm8zjMlX5/2gRaOGd9eO6V7J+tQc6iWKukEe7dY8u9HyYasQ0yfF0/FSSTEO2gA==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.70.0.tgz",
+      "integrity": "sha512-/v8HZt6RlyIZxB3ntehELOcUcfxKPVGWXnQdJuHRmzrqgF8nQypcC/oxGW+Ot4VGKDq81XugPKxx0n5PBtf9PA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.69.0",
-        "@typescript-eslint/type-utils": "8.69.0",
-        "@typescript-eslint/utils": "8.69.0",
-        "@typescript-eslint/visitor-keys": "8.69.0",
+        "@typescript-eslint/scope-manager": "8.70.0",
+        "@typescript-eslint/type-utils": "8.70.0",
+        "@typescript-eslint/utils": "8.70.0",
+        "@typescript-eslint/visitor-keys": "8.70.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2216,7 +2216,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.69.0",
+        "@typescript-eslint/parser": "^8.70.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2232,16 +2232,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.69.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.69.0.tgz",
-      "integrity": "sha512-l4b0DhWioGg6Gt2ebGlvfkFMOjRsauxtsnDRwUSRX1qHq3HdTfQHV8wW9zEXeciai6HfeaKOedQn2Zoofx3WBw==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.70.0.tgz",
+      "integrity": "sha512-zYvrmj9Yxd63UGaXw+kdt6A0F0s0qveJyuatIM77bYC2DE4pgmg7a50u8LR7PRtXd0x+h+Tl3eXabGm06SWd3Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.69.0",
-        "@typescript-eslint/types": "8.69.0",
-        "@typescript-eslint/typescript-estree": "8.69.0",
-        "@typescript-eslint/visitor-keys": "8.69.0",
+        "@typescript-eslint/scope-manager": "8.70.0",
+        "@typescript-eslint/types": "8.70.0",
+        "@typescript-eslint/typescript-estree": "8.70.0",
+        "@typescript-eslint/visitor-keys": "8.70.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2257,14 +2257,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.69.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.69.0.tgz",
-      "integrity": "sha512-yi4obFrHMmnsesWehHbkg9zMA7Jt8cXT+mKM08G999pH1yT6nqgsHx7MYm0uY1wAj8CqiBXYRJ7WAT0QdQHQXg==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.70.0.tgz",
+      "integrity": "sha512-hFHbTNqhU9G+2eKFXCBVb1tjFT/LceiJ4+HfLO4pTpDI0KHi6iajpcFFkaSQ9gXmCh7n82A0PthaayEdN6mspQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.69.0",
-        "@typescript-eslint/types": "^8.69.0",
+        "@typescript-eslint/tsconfig-utils": "^8.70.0",
+        "@typescript-eslint/types": "^8.70.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2279,14 +2279,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.69.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.69.0.tgz",
-      "integrity": "sha512-ewfspqWvSxKSOaplqAUNbaSFO0eB6w1EtQ+esfYFRm3614Ty4uNtExkcbgd6nWsXphbqKyf9ZYdbZdv2xEoWEQ==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.70.0.tgz",
+      "integrity": "sha512-8nP3Kwh5hlgZ4FicGvmznAmJe8UL4sdU8tLukrPaMuQmDuk4Y8xYfzu/aYZW4xT2JCgc7H/TpDI5cGlxcWJSqQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.69.0",
-        "@typescript-eslint/visitor-keys": "8.69.0"
+        "@typescript-eslint/types": "8.70.0",
+        "@typescript-eslint/visitor-keys": "8.70.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2297,9 +2297,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.69.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.69.0.tgz",
-      "integrity": "sha512-xNqK7YTDZsLniQMV/4rpFR8Z5JlqeRvVjuG1YgF/mdPVH84HSD19L8CczMA0qg2RfwEV231GHH3VnToJDo4MfQ==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.70.0.tgz",
+      "integrity": "sha512-adnkeeNq9Sq1sUf4+FRVc0KdgYghzsgFpZSQVZVvY0LCuUuN0FnQgyGzCJeC4fW1cdXseBAjU2EOqUIjbNcZUw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2314,15 +2314,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.69.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.69.0.tgz",
-      "integrity": "sha512-ZfoJAVg3JZndQEpEl9petVlxau3lRuElc4HRMuAlLCf8to04/iHz692RUSNmXKDjEuJmIL+KZ2/BsOcBc16dsA==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.70.0.tgz",
+      "integrity": "sha512-NUMKIhYVaVIVLnRL9CRt+VVcuLgSHUCpXn4/+K8wql+vdInUzvx8BjUO1oJ7cG9shjFJKtF8F8Hh2kCh3/KBVw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.69.0",
-        "@typescript-eslint/typescript-estree": "8.69.0",
-        "@typescript-eslint/utils": "8.69.0",
+        "@typescript-eslint/types": "8.70.0",
+        "@typescript-eslint/typescript-estree": "8.70.0",
+        "@typescript-eslint/utils": "8.70.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -2339,9 +2339,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.69.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.69.0.tgz",
-      "integrity": "sha512-K3VrubUPhlo9VDBS6QdI8YB5j7ClpqLRdefcz6PFrhnwicehBweqQ9Evhl4l+FYz0HdDmMqIiSX0aldGRYtDCA==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.70.0.tgz",
+      "integrity": "sha512-asTOIYhDg4zdzOScCyaytrsV3cR6B4ecPQlXw/dJIm7J/MZTtCtfVII9JD8Geh4jTCrK/Xe6cg5UevoleMcoJQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2353,16 +2353,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.69.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.69.0.tgz",
-      "integrity": "sha512-AdFkgqck3Vudb/kWnxlyafU/4aBhHrbQ9locP2N4psXTy5mOBg0SHJumnLvx7r6g1gV4DKvUFwV2nJZBoqOD8w==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.70.0.tgz",
+      "integrity": "sha512-d9NmHMPEKQ7QCLLm1jI3zmoQBwT5KwFYjXBJ9ymZfKCUU+5rmTRykKAFvH5Qn/ZCds3CEAFS9OC9M/jkl0X2bA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.69.0",
-        "@typescript-eslint/tsconfig-utils": "8.69.0",
-        "@typescript-eslint/types": "8.69.0",
-        "@typescript-eslint/visitor-keys": "8.69.0",
+        "@typescript-eslint/project-service": "8.70.0",
+        "@typescript-eslint/tsconfig-utils": "8.70.0",
+        "@typescript-eslint/types": "8.70.0",
+        "@typescript-eslint/visitor-keys": "8.70.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -2394,16 +2394,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.69.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.69.0.tgz",
-      "integrity": "sha512-tUbx60BBqQa31kXF5MCsOOLL5E/WzUuxIn7YpAvq+eaUlqvk8/NXnXMBNAdLCr0icjkzem7iUA5QqWHe/hJ1aw==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.70.0.tgz",
+      "integrity": "sha512-oZmtKJz/4fufZ2p3+Cn3ijEojcdfR+1zYDH2xKYrEly0dR/Q/1xUPRCOlKGxod78nWlU2UnDe09GZ3TaknBFGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.69.0",
-        "@typescript-eslint/types": "8.69.0",
-        "@typescript-eslint/typescript-estree": "8.69.0"
+        "@typescript-eslint/scope-manager": "8.70.0",
+        "@typescript-eslint/types": "8.70.0",
+        "@typescript-eslint/typescript-estree": "8.70.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2418,13 +2418,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.69.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.69.0.tgz",
-      "integrity": "sha512-+rmdgPA+EXkNgKYvHvFfhrs35utXbwaC5PGpDquSXcoXQDKUA5UjV0LmTucG/4JXkM31BTu4TilHtrN8IVBe8w==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.70.0.tgz",
+      "integrity": "sha512-BoC8PiO4Hkdo0TVJh9Ntxr5MxPDI7/oFsrygN5ADelFSeXG/qgNuucIGA+L5Z6JpPTE/uRfcTWtscjbUaufepQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.69.0",
+        "@typescript-eslint/types": "8.70.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -5629,16 +5629,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.69.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.69.0.tgz",
-      "integrity": "sha512-B3MltX0VqjUBNEe3b3sSuiRbfa6XrfHFtBiPamjT5AsW/dfq+y+bc0wyuS9DxAS1LyzCxRp2+rxzpLUvqM2BvA==",
+      "version": "8.70.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.70.0.tgz",
+      "integrity": "sha512-P/W5cz70/cQAuKfY3xwQMWWTV7BvJ0mAQmi+9mBcsVPaBUpd6Ohpa+fECv9rBFrQcig86jAiNBFNWUqnTjr4pw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.69.0",
-        "@typescript-eslint/parser": "8.69.0",
-        "@typescript-eslint/typescript-estree": "8.69.0",
-        "@typescript-eslint/utils": "8.69.0"
+        "@typescript-eslint/eslint-plugin": "8.70.0",
+        "@typescript-eslint/parser": "8.70.0",
+        "@typescript-eslint/typescript-estree": "8.70.0",
+        "@typescript-eslint/utils": "8.70.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "stylelint-config-standard": "^40.0.0",
     "tailwindcss": "^4.3.3",
     "typescript": "npm:@typescript/typescript6@6.0.2",
-    "typescript-eslint": "^8.69.0",
+    "typescript-eslint": "^8.70.0",
     "vite": "^8.2.2",
     "vitest": "^5.0.0"
   }

--- a/scripts/lib/dependency-currency.mjs
+++ b/scripts/lib/dependency-currency.mjs
@@ -796,6 +796,84 @@ export function collectCargoTargets(metadata) {
   };
 }
 
+/** @param {string} key */
+function isYamlUsesKey(key) {
+  if (key === "uses" || key === "'uses'") return true;
+  if (!key.startsWith('"') || !key.endsWith('"')) return false;
+  let position = 1;
+  for (const expected of "uses") {
+    if (key[position] === expected) {
+      position += 1;
+      continue;
+    }
+    // YAML hex escapes can spell a mapping key. Recognize only the four
+    // characters we need to refuse unsupported uses syntax, not all YAML.
+    const escape = /^\\(?:x([0-9a-fA-F]{2})|u([0-9a-fA-F]{4})|U([0-9a-fA-F]{8}))/u.exec(
+      key.slice(position)
+    );
+    if (
+      escape === null ||
+      parseInt(escape[1] ?? escape[2] ?? escape[3], 16) !== expected.charCodeAt(0)
+    )
+      return false;
+    position += escape[0].length;
+  }
+  return position === key.length - 1;
+}
+
+/** @param {string} line @param {number} position */
+function isYamlMappingKeyPosition(line, position) {
+  let previous = position - 1;
+  while (previous >= 0 && /\s/u.test(line[previous])) previous -= 1;
+  if (line[previous] === "?") {
+    previous -= 1;
+    while (previous >= 0 && /\s/u.test(line[previous])) previous -= 1;
+  }
+  if (previous < 0 || line[previous] === "{" || line[previous] === ",") return true;
+  return line[previous] === "-" && line.slice(0, previous).trim() === "";
+}
+
+/** @param {string} line @param {string | null} initialQuote */
+function scanYamlLine(line, initialQuote = null) {
+  let quote = initialQuote;
+  let hasUsesKey = false;
+  for (let position = 0; position < line.length; position += 1) {
+    const character = line[position];
+    if (quote === '"' && character === "\\") {
+      position += 1;
+      continue;
+    }
+    if (quote !== null) {
+      if (character === quote) {
+        if (quote === "'" && line[position + 1] === "'") position += 1;
+        else quote = null;
+      }
+      continue;
+    }
+    if (character === "#" && (position === 0 || /\s/u.test(line[position - 1]))) break;
+    if (
+      (character === "u" || character === '"' || character === "'") &&
+      isYamlMappingKeyPosition(line, position)
+    ) {
+      const mappingKey = /^(uses|"(?:[^"\\]|\\.)*"|'(?:[^']|'')*')\s*:/u.exec(line.slice(position));
+      if (mappingKey !== null && isYamlUsesKey(mappingKey[1])) hasUsesKey = true;
+    }
+    if (character === '"' || character === "'") {
+      let previous = position - 1;
+      while (previous >= 0 && /\s/u.test(line[previous])) previous -= 1;
+      // Quotes embedded in plain text (for example John's) are ordinary data.
+      if (
+        isYamlMappingKeyPosition(line, position) ||
+        line[previous] === ":" ||
+        line[previous] === "["
+      ) {
+        quote = character;
+      }
+    }
+  }
+  return { quote, hasUsesKey };
+}
+
 /**
  * @param {{path: string, content: string}[]} files
  */
@@ -810,63 +888,65 @@ export function parseActionReferences(files) {
       throw new MonitorDataError("Workflow source has an invalid shape");
     }
     const lines = file.content.split(/\r?\n/u);
-    /** @type {number | null} */
     let blockScalarParentIndent = null;
-    for (let index = 0; index < lines.length; index += 1) {
-      const line = lines[index];
+    /** @type {string | null} */
+    let quote = null;
+    /** @param {number} index */
+    const unsupportedUses = (index) => {
+      errors.push({
+        dependency: "unsupported uses syntax",
+        reason: `${file.path}:${index + 1} contains a uses key that the monitor cannot parse safely.`,
+      });
+    };
+    for (const [index, line] of lines.entries()) {
       const lineIndent = /^\s*/u.exec(line)?.[0].length ?? 0;
       if (blockScalarParentIndent !== null) {
         if (line.trim() === "" || lineIndent > blockScalarParentIndent) continue;
         blockScalarParentIndent = null;
       }
-      if (/^\s*(?:-\s*)?[A-Za-z0-9_-]+:\s*[|>][+-]?\s*(?:#.*)?$/u.test(line)) {
-        blockScalarParentIndent = lineIndent;
+      const explicitKey =
+        quote === null
+          ? /^\s*(?:-\s*)?\?\s+(uses|"(?:[^"\\]|\\.)*"|'(?:[^']|'')*')\s*(?::|#|$)/u.exec(line)
+          : null;
+      if (explicitKey !== null && isYamlUsesKey(explicitKey[1])) {
+        unsupportedUses(index);
+        continue;
+      }
+      /** @type {RegExpExecArray | null} */
+      const scalarEntry =
+        quote === null
+          ? /^(\s*(?:-\s*)?)([A-Za-z0-9_-]+|"[^"]+"|'[^']+')\s*:\s*(.*)$/u.exec(line)
+          : null;
+      const isUsesEntry = scalarEntry !== null && isYamlUsesKey(scalarEntry[2]);
+      /** @type {string | undefined} */
+      const scalarValue = scalarEntry?.[3].replace(/^(?:[!&]\S+\s+)*/u, "");
+      if (
+        scalarEntry !== null &&
+        scalarValue !== undefined &&
+        /^[|>](?:[1-9][+-]?|[+-][1-9]?)?\s*(?:#.*)?$/u.test(scalarValue)
+      ) {
+        // The sequence marker is outside the key's indentation; a sibling key
+        // on the next line is not part of a preceding `- run: |` value.
+        blockScalarParentIndent = scalarEntry[1].length;
+        if (isUsesEntry) unsupportedUses(index);
+        continue;
+      }
+      // A plain/quoted scalar such as `run: echo ...` is not a flow mapping.
+      // Braces and uses-like text inside that scalar must remain ordinary data.
+      if (scalarEntry !== null && !isUsesEntry && !/^(?:\{|\[)/u.test(scalarValue ?? "")) {
+        if (/^["']/u.test(scalarValue ?? "")) quote = scanYamlLine(scalarValue ?? "").quote;
         continue;
       }
       const match =
-        /^\s*(?:-\s*)?uses:\s*(?:"([^"]+)"|'([^']+)'|([^\s#]+))\s*(?:#\s*(.+?))?\s*$/u.exec(line);
+        quote === null
+          ? /^\s*(?:-\s*)?uses:\s*(?:"([^"]+)"|'([^']+)'|([^\s#"']+))\s*(?:#\s*(.+?))?\s*$/u.exec(
+              line
+            )
+          : null;
       if (match === null) {
-        const unquotedKey = (() => {
-          let singleQuoted = false;
-          let doubleQuoted = false;
-          for (let position = 0; position < line.length; position += 1) {
-            const character = line[position];
-            if (doubleQuoted && character === "\\") {
-              position += 1;
-              continue;
-            }
-            if (!doubleQuoted && character === "'") {
-              if (singleQuoted && line[position + 1] === "'") {
-                position += 1;
-                continue;
-              }
-              singleQuoted = !singleQuoted;
-              continue;
-            }
-            if (!singleQuoted && character === '"') {
-              doubleQuoted = !doubleQuoted;
-              continue;
-            }
-            if (singleQuoted || doubleQuoted) continue;
-            if (character === "#") break;
-            if (line.slice(position, position + 4) !== "uses") continue;
-            const before = line.slice(0, position).trim();
-            const after = line.slice(position + 4);
-            if (!/^\s*:/u.test(after)) continue;
-            if (before === "" || before === "-" || before.endsWith("{") || before.endsWith(",")) {
-              return true;
-            }
-          }
-          return false;
-        })();
-        const quotedKey = /^\s*(?:-\s*)?(?:"uses"|'uses')\s*:/u.test(line);
-        if (unquotedKey || quotedKey) {
-          const location = `${file.path}:${index + 1}`;
-          errors.push({
-            dependency: "unsupported uses syntax",
-            reason: `${location} contains a uses key that the monitor cannot parse safely.`,
-          });
-        }
+        const scanned = scanYamlLine(line, quote);
+        quote = scanned.quote;
+        if (scanned.hasUsesKey) unsupportedUses(index);
         continue;
       }
       const reference = match[1] ?? match[2] ?? match[3];
@@ -931,6 +1011,12 @@ export function parseActionReferences(files) {
         pin: pin.toLowerCase(),
         declaredTag: annotation,
         locations: [...(existing?.locations ?? []), location],
+      });
+    }
+    if (quote !== null) {
+      errors.push({
+        dependency: "unsupported workflow syntax",
+        reason: `${file.path} contains an unterminated quoted scalar that prevents safe action inspection.`,
       });
     }
   }

--- a/scripts/lib/dependency-currency.test.mjs
+++ b/scripts/lib/dependency-currency.test.mjs
@@ -1,3 +1,4 @@
+import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 import { describe, expect, test, vi } from "vitest";
@@ -312,6 +313,136 @@ describe("GitHub Actions pins", () => {
     expect(parsed).toEqual({ actions: [], errors: [] });
   });
 
+  test("reports quoted uses keys in flow mappings instead of silently omitting actions", () => {
+    const lines = [
+      `steps: [{ "uses": actions/checkout@${SHA_ONE} }]`,
+      `- { 'uses': actions/checkout@${SHA_ONE} }`,
+      `- { name: checkout, "uses": actions/checkout@${SHA_ONE} }`,
+      `jobs: { test: { steps: [{ 'uses': actions/checkout@${SHA_ONE} }] } }`,
+      `steps: &reused [{ "uses": actions/checkout@${SHA_ONE} }]`,
+    ];
+    const parsed = parseActionReferences([{ path: "flow.yml", content: lines.join("\n") }]);
+    assert.deepEqual(parsed.actions, []);
+    assert.deepEqual(
+      parsed.errors.map(({ reason, dependency }) => ({
+        location: reason.split(" ")[0],
+        dependency,
+      })),
+      lines.map((_, index) => ({
+        location: `flow.yml:${index + 1}`,
+        dependency: "unsupported uses syntax",
+      }))
+    );
+  });
+
+  test("ignores quoted uses text in commands, scalar values, and comments", () => {
+    const parsed = parseActionReferences([
+      {
+        path: "literals.yml",
+        content: [
+          `- run: echo '{ "uses": actions/checkout@${SHA_ONE} }'`,
+          `- run: 'echo { "uses": actions/checkout@${SHA_ONE} }'`,
+          `- { run: 'echo { "uses": actions/checkout@${SHA_ONE} }' }`,
+          `- { name: "a uses: label", run: 'echo ''uses'': text' }`,
+          `# steps: [{ "uses": actions/checkout@${SHA_ONE} }]`,
+          `- "run": |`,
+          `    echo '{ "uses": actions/checkout@${SHA_ONE} }'`,
+          `    uses: text in a script`,
+          `- uses: actions/checkout@${SHA_ONE} # v7.0.1`,
+        ].join("\n"),
+      },
+    ]);
+    assert.deepEqual(parsed.errors, []);
+    assert.equal(parsed.actions.length, 1);
+    assert.deepEqual(parsed.actions[0].locations, ["literals.yml:9"]);
+  });
+
+  test.each(["|", ">", "|2", "|2-", "|-2", ">2+", ">+2", "&script |2-", "!!str >-2"])(
+    "keeps uses text inside run: %s scalar content",
+    (header) => {
+      const parsed = parseActionReferences([
+        {
+          path: "block.yml",
+          content: [
+            `  - run: ${header}`,
+            `      uses: actions/setup-node@${SHA_TWO} # v7.0.1`,
+            `    shell: bash`,
+            `  - uses: actions/checkout@${SHA_ONE} # v7.0.1`,
+          ].join("\n"),
+        },
+      ]);
+      assert.deepEqual(parsed.errors, []);
+      assert.equal(parsed.actions.length, 1);
+      assert.deepEqual(parsed.actions[0].locations, ["block.yml:4"]);
+    }
+  );
+
+  test.each(["|", ">2-", "&action |-2"])(
+    "reports uses: %s itself as unsupported rather than skipping the declaration",
+    (header) => {
+      const parsed = parseActionReferences([
+        {
+          path: "action-block.yml",
+          content: [
+            `  - uses: ${header}`,
+            `      actions/checkout@${SHA_ONE}`,
+            `  - uses: actions/setup-node@${SHA_TWO} # v7.0.1`,
+          ].join("\n"),
+        },
+      ]);
+      assert.equal(parsed.errors.length, 1);
+      assert.equal(parsed.errors[0].dependency, "unsupported uses syntax");
+      assert.equal(parsed.errors[0].reason.split(" ")[0], "action-block.yml:1");
+      assert.equal(parsed.actions.length, 1);
+      assert.deepEqual(parsed.actions[0].locations, ["action-block.yml:3"]);
+    }
+  );
+
+  test.each(["'", '"'])(
+    "keeps multiline %s scalar contents out of the action inventory",
+    (quote) => {
+      const parsed = parseActionReferences([
+        {
+          path: "quoted.yml",
+          content: [
+            `- run: ${quote}echo first line`,
+            `    uses: actions/setup-node@${SHA_TWO} # v7.0.1`,
+            `    last line${quote}`,
+            `- uses: actions/checkout@${SHA_ONE} # v7.0.1`,
+          ].join("\n"),
+        },
+      ]);
+      assert.deepEqual(parsed.errors, []);
+      assert.equal(parsed.actions.length, 1);
+      assert.deepEqual(parsed.actions[0].locations, ["quoted.yml:4"]);
+    }
+  );
+
+  test("resumes flow-key inspection after multiline quoted content and ignores plain apostrophes", () => {
+    const parsed = parseActionReferences([
+      {
+        path: "flow-quoted.yml",
+        content: [
+          `steps: [{ run: "echo first line`,
+          `    uses: actions/setup-node@${SHA_TWO} # v7.0.1`,
+          `    last line", 'uses': actions/checkout@${SHA_ONE} }]`,
+          `- { name: John's job, uses: actions/checkout@${SHA_ONE} }`,
+        ].join("\n"),
+      },
+    ]);
+    assert.deepEqual(parsed.actions, []);
+    assert.deepEqual(
+      parsed.errors.map(({ reason }) => reason.split(" ")[0]),
+      ["flow-quoted.yml:3", "flow-quoted.yml:4"]
+    );
+  });
+
+  test("reports an unterminated quoted scalar instead of claiming a complete inventory", () => {
+    const parsed = parseActionReferences([{ path: "broken.yml", content: '- run: "unterminated' }]);
+    assert.equal(parsed.errors.length, 1);
+    assert.match(parsed.errors[0].reason, /unterminated quoted scalar/u);
+  });
+
   test("selects the greatest stable semantic release rather than a later backport", () => {
     const release = inspectGitHubReleases([
       { tag_name: "v6.9.1", draft: false, prerelease: false },
@@ -474,5 +605,62 @@ describe("repository no-branch contract", () => {
     expect(workflowText).not.toMatch(/permissions:\s*write-all/u);
     expect(dependabotText.match(/open-pull-requests-limit:\s*0/gu)).toHaveLength(3);
     expect(dependabotText).not.toMatch(/open-pull-requests-limit:\s*[1-9]/u);
+  });
+});
+
+describe("unsupported YAML key notation", () => {
+  test.each([
+    String.raw`"us\u0065s"`,
+    String.raw`"\x75ses"`,
+    String.raw`"\U00000075ses"`,
+    String.raw`"\u0075\u0073\u0065\u0073"`,
+  ])("refuses a credible escaped uses key %s but ignores the same command text", (key) => {
+    for (const content of [
+      `- ${key}: actions/checkout@v7`,
+      `steps: [{ ${key}: actions/checkout@v7 }]`,
+    ]) {
+      const parsed = parseActionReferences([{ path: "escaped.yml", content }]);
+      assert.equal(parsed.errors.length, 1);
+      assert.equal(parsed.errors[0].dependency, "unsupported uses syntax");
+    }
+    for (const content of [
+      `- run: echo '${key}: actions/checkout@v7'`,
+      `- { run: 'echo ${key}: actions/checkout@v7' }`,
+      `# - ${key}: actions/checkout@v7`,
+      `- run: |\n    ${key}: actions/checkout@v7`,
+    ]) {
+      assert.deepEqual(parseActionReferences([{ path: "literal.yml", content }]).errors, []);
+    }
+  });
+
+  test.each(["uses", "'uses'", '"uses"', String.raw`"us\u0065s"`])(
+    "refuses an explicit uses key %s without treating quoted shell text as a key",
+    (key) => {
+      for (const content of [
+        `- ? ${key}\n  : actions/checkout@v7`,
+        `steps: [{ ? ${key}: actions/checkout@v7 }]`,
+      ]) {
+        const parsed = parseActionReferences([{ path: "explicit.yml", content }]);
+        assert.equal(parsed.errors.length, 1);
+        assert.equal(parsed.errors[0].dependency, "unsupported uses syntax");
+      }
+      const literal = `- run: |\n    ? ${key}\n    : actions/checkout@v7\n- uses: actions/checkout@${SHA_ONE} # v7.0.1`;
+      const parsed = parseActionReferences([{ path: "script.yml", content: literal }]);
+      assert.deepEqual(parsed.errors, []);
+      assert.equal(parsed.actions.length, 1);
+    }
+  );
+
+  test("does not decode single-quoted or escaped-backslash literals as uses keys", () => {
+    const lines = [
+      String.raw`- 'us\u0065s': ordinary value`,
+      String.raw`- "us\\u0065s": ordinary value`,
+      `- ? name\n  : ordinary value`,
+      `- uses: actions/checkout@${SHA_ONE} # v7.0.1`,
+    ];
+    const parsed = parseActionReferences([{ path: "ordinary.yml", content: lines.join("\n") }]);
+    assert.deepEqual(parsed.errors, []);
+    assert.equal(parsed.actions.length, 1);
+    assert.deepEqual(parsed.actions[0].locations, ["ordinary.yml:5"]);
   });
 });

--- a/scripts/lib/frontend-notices.mjs
+++ b/scripts/lib/frontend-notices.mjs
@@ -1,0 +1,109 @@
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * @typedef {{name?: string, version?: string, license?: string, dev?: boolean, dependencies?: Record<string, string>}} PackageMetadata
+ * @typedef {{lockfileVersion: number, packages: Record<string, PackageMetadata>}} NoticeLockfile
+ * @typedef {{name: string, text: string}} NoticeFile
+ * @typedef {{metadata: PackageMetadata, files: NoticeFile[]}} InstalledPackage
+ */
+
+/** @param {string} text */
+const normalizeNewlines = (text) => text.replace(/\r\n/gu, "\n");
+const licenseName = /^(?:licen[cs]e|copying)(?:$|[._-])/iu;
+const noticeName = /^(?:licen[cs]e|copying|notice)(?:$|[._-])/iu;
+
+/**
+ * @param {NoticeLockfile} lockfile
+ * @param {(location: string) => InstalledPackage} readPackage
+ */
+export function collectNpmNotices(lockfile, readPackage) {
+  if (lockfile.lockfileVersion !== 3 || !lockfile.packages?.[""]?.dependencies) {
+    throw new Error("Runtime notices require an npm v3 lockfile with root dependencies.");
+  }
+  for (const name of Object.keys(lockfile.packages[""].dependencies)) {
+    const entry = lockfile.packages[`node_modules/${name}`];
+    if (!entry || entry.dev)
+      throw new Error(`Runtime dependency is missing from the lock: ${name}`);
+  }
+  const locations = Object.keys(lockfile.packages)
+    .filter(
+      (location) =>
+        location !== "" &&
+        // Vite's modulepreload helper is emitted into index.html builds.
+        (!lockfile.packages[location].dev || location === "node_modules/vite")
+    )
+    .sort();
+  if (!locations.includes("node_modules/vite")) {
+    throw new Error("Vite runtime helper notices are missing from the lock.");
+  }
+  return locations.map((location) => {
+    if (!/^node_modules\/(?:[A-Za-z0-9@_.-]+\/)*[A-Za-z0-9_.-]+$/u.test(location)) {
+      throw new Error(`Unsupported runtime package location: ${location}`);
+    }
+    const { metadata, files } = readPackage(location);
+    const locked = lockfile.packages[location];
+    const name = location.slice(location.lastIndexOf("node_modules/") + "node_modules/".length);
+    if (metadata.name !== name || metadata.version !== locked.version) {
+      throw new Error(`Installed runtime package differs from the lock: ${location}`);
+    }
+    if (typeof metadata.license !== "string" || metadata.license !== locked.license) {
+      throw new Error(`Runtime license metadata is missing or inconsistent: ${name}`);
+    }
+    if (!files.some(({ name: file }) => licenseName.test(file))) {
+      throw new Error(`No full runtime license text found for ${name}; review its license files.`);
+    }
+    for (const file of files) {
+      if (!file.text.trim()) throw new Error(`Empty runtime notice: ${name}/${file.name}`);
+    }
+    return { name, version: metadata.version, license: metadata.license, location, files };
+  });
+}
+
+/** @param {string} root */
+export function buildFrontendNotices(root) {
+  /** @param {string} relative */
+  const readText = (relative) => normalizeNewlines(readFileSync(join(root, relative), "utf8"));
+  const lockfile = JSON.parse(readText("package-lock.json"));
+  const packages = collectNpmNotices(lockfile, (location) => ({
+    metadata: JSON.parse(readText(`${location}/package.json`)),
+    files: readdirSync(join(root, location), { withFileTypes: true })
+      .filter((entry) => entry.isFile() && noticeName.test(entry.name))
+      .map((entry) => entry.name)
+      .sort()
+      .map((name) => ({ name, text: readText(`${location}/${name}`) })),
+  }));
+  const sections = [
+    "SSA HDRify — Third-party notices\n\n" +
+      "This inventory covers the locked JavaScript runtime packages, Vite's generated " +
+      "runtime helpers, and the bundled fonts and icon attribution. Some included package " +
+      "notices also describe code used only during development.\n" +
+      "Native Rust dependency attribution is listed separately in the project README; " +
+      "this is not a complete native dependency license inventory.\n",
+    `Application license\n\n${readText("LICENSE")}`,
+  ];
+  for (const entry of packages) {
+    sections.push(
+      `${entry.name} ${entry.version}\nLicense: ${entry.license}\n` +
+        `Source: https://www.npmjs.com/package/${entry.name}/v/${entry.version}\n` +
+        "\n" +
+        entry.files.map((file) => `${file.name}\n\n${file.text}`).join("\n\n")
+    );
+  }
+  for (const [name, source, file] of [
+    ["Inter", "https://github.com/rsms/inter", "src/assets/fonts/inter/LICENSE.txt"],
+    [
+      "Smiley Sans",
+      "https://github.com/atelier-anchor/smiley-sans",
+      "src/assets/fonts/smiley-sans/LICENSE.txt",
+    ],
+    [
+      "Feather icon attribution",
+      "https://github.com/feathericons/feather/tree/v4.29.2",
+      "src/assets/licenses/feather-LICENSE.txt",
+    ],
+  ]) {
+    sections.push(`${name}\nSource: ${source}\n\n${readText(file)}`);
+  }
+  return sections.join("\n\n" + "=".repeat(72) + "\n\n") + "\n";
+}

--- a/scripts/lib/frontend-notices.test.mjs
+++ b/scripts/lib/frontend-notices.test.mjs
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, it } from "vitest";
+import { buildFrontendNotices, collectNpmNotices } from "./frontend-notices.mjs";
+
+/** @type {import("./frontend-notices.mjs").NoticeLockfile} */
+const lockfile = {
+  lockfileVersion: 3,
+  packages: {
+    "": { dependencies: { react: "^19.2.8" } },
+    "node_modules/react": { version: "19.2.8", license: "MIT" },
+    "node_modules/scheduler": { version: "0.27.0", license: "MIT" },
+    "node_modules/vite": { version: "8.2.2", license: "MIT", dev: true },
+    "node_modules/vitest": { version: "5.0.0", license: "MIT", dev: true },
+  },
+};
+/** @param {string} location */
+function readPackage(location) {
+  const entry = lockfile.packages[location];
+  return {
+    metadata: { name: location.replace("node_modules/", ""), ...entry },
+    files: [{ name: "LICENSE", text: "Copyright: fixture\nPermission: fixture\n" }],
+  };
+}
+
+describe("frontend runtime notice inventory", () => {
+  it("includes transitive runtime packages and Vite's emitted helper but excludes test tools", () => {
+    const entries = collectNpmNotices(lockfile, readPackage);
+    assert.deepEqual(
+      entries.map(({ name }) => name),
+      ["react", "scheduler", "vite"]
+    );
+  });
+
+  it("refuses a missing production lock entry instead of shipping a partial inventory", () => {
+    const broken = structuredClone(lockfile);
+    delete broken.packages["node_modules/react"];
+    assert.throws(() => collectNpmNotices(broken, readPackage), /missing from the lock/u);
+  });
+
+  it("refuses stale installed versions and mismatched license metadata", () => {
+    for (const replacement of [{ version: "19.2.7" }, { license: "unknown" }]) {
+      assert.throws(
+        () =>
+          collectNpmNotices(lockfile, (location) => {
+            const entry = readPackage(location);
+            Object.assign(entry.metadata, replacement);
+            return entry;
+          }),
+        /differs from the lock|license metadata/u
+      );
+    }
+  });
+
+  it("requires a license file and refuses empty notice files", () => {
+    for (const files of [[], [{ name: "NOTICE", text: "MIT" }], [{ name: "LICENSE", text: "" }]]) {
+      assert.throws(
+        () => collectNpmNotices(lockfile, (location) => ({ ...readPackage(location), files })),
+        /No full runtime license text|Empty runtime notice/u
+      );
+    }
+  });
+
+  it("preserves additional NOTICE files along with the license", () => {
+    const files = [
+      { name: "LICENSE", text: "full original license" },
+      { name: "NOTICE", text: "additional copyright attribution" },
+    ];
+    assert.deepEqual(
+      collectNpmNotices(lockfile, (location) => ({ ...readPackage(location), files }))[0].files,
+      files
+    );
+  });
+
+  it("deterministically retains the current full runtime and asset license texts", () => {
+    const root = fileURLToPath(new URL("../../", import.meta.url));
+    const output = buildFrontendNotices(root);
+    assert.equal(output, buildFrontendNotices(root));
+    for (const file of [
+      "LICENSE",
+      "node_modules/react/LICENSE",
+      "node_modules/react-dom/LICENSE",
+      "node_modules/scheduler/LICENSE",
+      "node_modules/@tauri-apps/api/LICENSE_MIT",
+      "node_modules/@tauri-apps/api/LICENSE_APACHE-2.0",
+      "node_modules/vite/LICENSE.md",
+      "src/assets/fonts/inter/LICENSE.txt",
+      "src/assets/fonts/smiley-sans/LICENSE.txt",
+      "src/assets/licenses/feather-LICENSE.txt",
+    ]) {
+      const source = readFileSync(new URL(`../../${file}`, import.meta.url), "utf8").replace(
+        /\r\n/gu,
+        "\n"
+      );
+      assert.ok(output.includes(source), `Missing full text: ${file}`);
+    }
+    for (const name of ["react", "react-dom", "scheduler", "@tauri-apps/api", "vite"]) {
+      assert.ok(output.includes(`Source: https://www.npmjs.com/package/${name}/v/`));
+    }
+    assert.ok(!output.includes(root));
+  });
+});

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4464,6 +4464,7 @@ dependencies = [
  "once_cell",
  "rfd",
  "rusqlite",
+ "rustix 1.1.4",
  "serde",
  "serde_json",
  "sha2 0.11.0",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -98,6 +98,9 @@ rfd = { version = "0.16", default-features = false }
 [target.'cfg(any(target_os = "windows", target_os = "macos", target_os = "linux"))'.dependencies]
 tauri-plugin-single-instance = "2.4.4"
 
+[target.'cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple"))'.dependencies]
+rustix = { version = "1.1.4", features = ["fs"] }
+
 [dev-dependencies]
 glob = "0.3.3"
 

--- a/src-tauri/src/bin/cli/chain.rs
+++ b/src-tauri/src/bin/cli/chain.rs
@@ -560,14 +560,18 @@ fn collect_suspicious_orderings(steps: &[ParsedStep]) -> Vec<String> {
 /// Build the chain's default output template by stacking each
 /// step's natural suffix: `{name}.<suffix1>.<suffix2>...<suffixN>.ass`.
 ///
-/// All chain default outputs use `.ass` extension regardless of input
-/// — chains in practice include HDR or embed (both ASS-producing),
-/// so an `.ass`-stripped default is wrong for the typical case more
-/// often than the input-extension-preserving alternative. Single-step
-/// chains on non-ASS input should pass `--output-template` explicitly.
+/// Shift-only chains preserve their input format; HDR and embed use ASS outputs.
 fn derive_stacked_default(steps: &[ParsedStep]) -> String {
     let suffixes: Vec<&str> = steps.iter().map(ParsedStep::stack_suffix).collect();
-    format!("{{name}}.{}.ass", suffixes.join("."))
+    let extension = if steps
+        .iter()
+        .all(|step| matches!(step, ParsedStep::Shift(_)))
+    {
+        "{ext}"
+    } else {
+        ".ass"
+    };
+    format!("{{name}}.{}{extension}", suffixes.join("."))
 }
 
 #[cfg(test)]
@@ -939,6 +943,13 @@ mod tests {
         let step = parse_one_step(&segment, true).unwrap();
         let template = derive_stacked_default(&[step]);
         assert_eq!(template, "{name}.hdr.ass");
+    }
+
+    #[test]
+    fn stacked_default_shift_only_preserves_the_input_extension() {
+        let step =
+            parse_one_step(&argv_of(&["shift", "--offset", "+1s", "cat.srt"]), true).unwrap();
+        assert_eq!(derive_stacked_default(&[step]), "{name}.shifted{ext}");
     }
 
     #[test]

--- a/src-tauri/src/bin/cli/main.rs
+++ b/src-tauri/src/bin/cli/main.rs
@@ -1063,6 +1063,7 @@ struct ShiftProcessContext<'a> {
     threshold_ms: Option<i64>,
     timing_map_rules: Option<Vec<engine::TimingMapRule>>,
     output_dir: Option<&'a Path>,
+    selected_input_keys: &'a HashSet<String>,
 }
 
 struct TempFontDbDir(PathBuf);
@@ -1996,6 +1997,7 @@ fn run_chain(globals: &GlobalOptions, args: ChainArgs) -> Result<ExitCode, Strin
     // transitive bound that run_hdr / run_shift / run_embed rely on,
     // so no chain-local cap is added.
     let mut seen_outputs: HashSet<String> = HashSet::new();
+    let selected_inputs = selected_input_keys(&plan.input_files);
     // Named `chain_aborted` instead of the CommandReport field name
     // `aborted_by_fail_fast` so the chain-local flag and the per-
     // CommandReport struct field don't collide on grep.
@@ -2012,6 +2014,7 @@ fn run_chain(globals: &GlobalOptions, args: ChainArgs) -> Result<ExitCode, Strin
             input,
             globals,
             &mut seen_outputs,
+            &selected_inputs,
         ) {
             ChainFileOutcome::Written(out, warnings) => {
                 if !warnings.is_empty() {
@@ -2515,6 +2518,7 @@ fn process_one_chain_input(
     input: &Path,
     globals: &GlobalOptions,
     seen_outputs: &mut HashSet<String>,
+    selected_inputs: &HashSet<String>,
 ) -> ChainFileOutcome {
     // Outcome funnel owns the warnings vec; each early-return consumes
     // the builder via `.into_failed(…)` /
@@ -2564,6 +2568,11 @@ fn process_one_chain_input(
                 "refusing self-overwrite: predicted output path {} is the input file; choose a different --output-template or --output-dir",
                 predicted.display()
             ));
+        }
+        if output_matches_selected_input(&predicted, selected_inputs) {
+            return builder.into_failed(
+                "output path matches a selected input file; choose a different --output-template or --output-dir".to_string(),
+            );
         }
         if !seen_outputs.insert(key.clone()) {
             // `predicted.display()` is interpolated
@@ -2765,6 +2774,12 @@ fn process_one_chain_input(
     // predictor abstained (template too dynamic), so this is the
     // first insertion of the actual key.
     let output_key = normalize_output_key(&output_path);
+    if output_matches_selected_input(&output_path, selected_inputs) {
+        evict_predicted(seen_outputs);
+        return builder.into_failed(
+            "output path matches a selected input file; choose a different --output-template or --output-dir".to_string(),
+        );
+    }
     if predicted_key.as_deref() != Some(output_key.as_str()) {
         if let Some(stale) = predicted_key.as_deref() {
             seen_outputs.remove(stale);
@@ -2847,6 +2862,7 @@ fn process_one_chain_input(
 }
 
 fn emit_chain_dry_run(plan: &chain::ChainPlan, globals: &GlobalOptions) -> Result<(), String> {
+    let selected_inputs = selected_input_keys(&plan.input_files);
     // Dry-run normally treats predictor abstention as non-fatal, but a concrete
     // predicted filename plus an invalid relocation is not abstention. Validate
     // that final relocated path before printing a plan so output-directory
@@ -2856,7 +2872,13 @@ fn emit_chain_dry_run(plan: &chain::ChainPlan, globals: &GlobalOptions) -> Resul
             if let Some(predicted) =
                 predict_chain_output_path(&absolute, &plan.output_template, None)
             {
-                relocate_output_path(&predicted.to_string_lossy(), globals.output_dir.as_deref())?;
+                let output = relocate_output_path(
+                    &predicted.to_string_lossy(),
+                    globals.output_dir.as_deref(),
+                )?;
+                if output_matches_selected_input(&output, &selected_inputs) {
+                    return Err("output path matches a selected input file; choose a different --output-template or --output-dir".to_string());
+                }
             }
         }
     }
@@ -2954,6 +2976,7 @@ fn run_hdr(
         .map(absolute_path)
         .transpose()?;
     let mut report = CommandReport::new("hdr");
+    let selected_inputs = selected_input_keys(&args.files);
     // First-input-wins dedup is intentional for non-destructive
     // transformations (HDR/Shift/Embed): the second input's work is
     // wasted but no source data is lost. Rename takes the opposite
@@ -2969,6 +2992,7 @@ fn run_hdr(
             &mut engine,
             file,
             &mut seen_outputs,
+            &selected_inputs,
         );
         let failed = result.status == FileStatus::Failed;
         emit_file_report(globals, &result);
@@ -2992,6 +3016,7 @@ fn process_hdr_file(
     engine: &mut engine::CliEngine,
     file: &Path,
     seen_outputs: &mut HashSet<String>,
+    selected_inputs: &HashSet<String>,
 ) -> FileReport {
     let input_path = match absolute_path(file) {
         Ok(path) => path,
@@ -3031,6 +3056,7 @@ fn process_hdr_file(
         &output,
         None,
         seen_outputs,
+        selected_inputs,
     ) {
         Ok(reservation) => reservation,
         Err(early) => return *early,
@@ -3256,6 +3282,7 @@ fn run_shift(
         .map(absolute_path)
         .transpose()?;
     let mut report = CommandReport::new("shift");
+    let selected_inputs = selected_input_keys(&args.files);
     // Same first-wins dedup policy as run_hdr. Shift now does
     // cheap-first dedup for the common case (default template, no
     // `{format}` token). Templates that reference `{format}` need
@@ -3272,6 +3299,7 @@ fn run_shift(
                 threshold_ms,
                 timing_map_rules: timing_map_rules.clone(),
                 output_dir: output_dir.as_deref(),
+                selected_input_keys: &selected_inputs,
             },
             &mut engine,
             file,
@@ -3344,8 +3372,17 @@ fn reserve_output<'a>(
     output: &str,
     encoding: Option<&str>,
     seen_outputs: &'a mut HashSet<String>,
+    selected_inputs: &HashSet<String>,
 ) -> Result<OutputReservation<'a>, Box<FileReport>> {
     let cloned_encoding = || encoding.map(|s| s.to_string());
+    if output_matches_selected_input(output_path, selected_inputs) {
+        return Err(Box::new(failed_report(
+            input_path,
+            Some(output.to_string()),
+            cloned_encoding(),
+            "output path matches a selected input file; choose a different --output-template or --output-dir".to_string(),
+        )));
+    }
     let key = normalize_output_key(output_path);
     if !seen_outputs.insert(key.clone()) {
         return Err(Box::new(failed_report(
@@ -3424,6 +3461,7 @@ fn process_shift_file_cheap_first(
         &output,
         None,
         seen_outputs,
+        context.selected_input_keys,
     ) {
         Ok(reservation) => reservation,
         Err(early) => return *early,
@@ -3603,6 +3641,7 @@ fn process_shift_file_heavy_first(
         &output,
         Some(&read_result.encoding),
         seen_outputs,
+        context.selected_input_keys,
     ) {
         Ok(reservation) => reservation,
         Err(mut early) => {
@@ -3700,6 +3739,7 @@ fn run_embed(
         .map(absolute_path)
         .transpose()?;
     let mut report = CommandReport::new("embed");
+    let selected_inputs = selected_input_keys(&args.files);
     let collect_font_diagnostics = diagnose.is_some();
     let mut font_diagnostics = Vec::new();
     // Same first-wins dedup policy as run_hdr. Embed already orders
@@ -3718,6 +3758,7 @@ fn run_embed(
             &mut engine,
             file,
             &mut seen_outputs,
+            &selected_inputs,
         );
         if collect_font_diagnostics {
             for diagnostic in &mut diagnostics {
@@ -4892,6 +4933,7 @@ fn process_embed_file(
     engine: &mut engine::CliEngine,
     file: &Path,
     seen_outputs: &mut HashSet<String>,
+    selected_inputs: &HashSet<String>,
 ) -> EmbedFileOutcome {
     let input_path = match absolute_path(file) {
         Ok(path) => path,
@@ -4941,6 +4983,7 @@ fn process_embed_file(
         &output,
         None,
         seen_outputs,
+        selected_inputs,
     ) {
         Ok(reservation) => reservation,
         Err(early) => return (*early, Vec::new()),
@@ -5512,6 +5555,15 @@ fn group_resolved_fonts_by_face(
 /// instead of shipping silently.
 const MAX_SUBSET_CODEPOINTS_FOR_DEDUP: usize = 200_000;
 
+fn checked_subset_total(current: usize, additional: usize) -> Result<usize, String> {
+    current
+        .checked_add(additional)
+        .filter(|total| *total <= MAX_V8_SUBSET_TOTAL_BYTES)
+        .ok_or_else(|| format!(
+            "font subsets exceed the {MAX_V8_SUBSET_TOTAL_BYTES}-byte total cap; reduce per-input font count or split the input"
+        ))
+}
+
 fn subset_resolved_fonts(
     globals: &GlobalOptions,
     args: &EmbedArgs,
@@ -5521,6 +5573,7 @@ fn subset_resolved_fonts(
 
     let mut payloads = Vec::new();
     let mut skipped = Vec::new();
+    let mut total_bytes = 0;
 
     for group in face_groups.values() {
         let merged = match group.merged_codepoints_with_cap(MAX_SUBSET_CODEPOINTS_FOR_DEDUP) {
@@ -5544,10 +5597,13 @@ fn subset_resolved_fonts(
                         alias.index,
                         alias.codepoints.clone(),
                     ) {
-                        Ok(data) => payloads.push(engine::FontSubsetPayload {
-                            font_name: alias.font_name.clone(),
-                            data,
-                        }),
+                        Ok(data) => {
+                            total_bytes = checked_subset_total(total_bytes, data.len())?;
+                            payloads.push(engine::FontSubsetPayload {
+                                font_name: alias.font_name.clone(),
+                                data,
+                            });
+                        }
                         Err(error) => {
                             skipped.push(format!("{} ({error})", alias.label));
                         }
@@ -5560,10 +5616,13 @@ fn subset_resolved_fonts(
         let codepoints: Vec<u32> = merged.into_iter().collect();
         let template = group.template();
         match app_lib::fonts::subset_font(template.path.clone(), template.index, codepoints) {
-            Ok(data) => payloads.push(engine::FontSubsetPayload {
-                font_name: template.font_name.clone(),
-                data,
-            }),
+            Ok(data) => {
+                total_bytes = checked_subset_total(total_bytes, data.len())?;
+                payloads.push(engine::FontSubsetPayload {
+                    font_name: template.font_name.clone(),
+                    data,
+                });
+            }
             Err(error) => {
                 // Surface every alias that hit this face — the user
                 // needs to know all the Styles that lost their font,
@@ -7199,6 +7258,26 @@ fn sanitize_for_display(s: &str) -> String {
         .collect()
 }
 
+fn selected_input_keys(inputs: &[PathBuf]) -> HashSet<String> {
+    let mut keys = HashSet::new();
+    for input in inputs {
+        if let Ok(absolute) = absolute_path(input) {
+            keys.insert(normalize_output_key(&absolute));
+            if let Ok(canonical) = absolute.canonicalize() {
+                keys.insert(normalize_output_key(&canonical));
+            }
+        }
+    }
+    keys
+}
+
+fn output_matches_selected_input(output: &Path, selected_inputs: &HashSet<String>) -> bool {
+    selected_inputs.contains(&normalize_output_key(output))
+        || output
+            .canonicalize()
+            .is_ok_and(|canonical| selected_inputs.contains(&normalize_output_key(&canonical)))
+}
+
 fn normalize_output_key(path: &Path) -> String {
     let raw = path.to_string_lossy();
     // Strip the Win32 extended-length prefix BEFORE slash folding so a
@@ -7457,6 +7536,16 @@ fn parse_timestamp_part(part: &str, label: &str) -> Result<i64, String> {
 
 #[cfg(test)]
 mod tests {
+    #[test]
+    fn subset_retention_budget_accepts_boundary_and_rejects_excess_or_overflow() {
+        assert_eq!(
+            super::checked_subset_total(super::MAX_V8_SUBSET_TOTAL_BYTES - 1, 1).unwrap(),
+            super::MAX_V8_SUBSET_TOTAL_BYTES
+        );
+        assert!(super::checked_subset_total(super::MAX_V8_SUBSET_TOTAL_BYTES, 1).is_err());
+        assert!(super::checked_subset_total(usize::MAX, 1).is_err());
+    }
+
     #[cfg(unix)]
     use super::run_refresh_fonts;
     use super::{

--- a/src-tauri/src/font_cache.rs
+++ b/src-tauri/src/font_cache.rs
@@ -688,6 +688,39 @@ pub fn cache_source_key(
     Ok(CacheSourceKey { source_root, scope })
 }
 
+fn collect_snapshot_children(
+    entries: impl IntoIterator<Item = std::io::Result<PathBuf>>,
+    directory: &Path,
+    visited_entries: &mut usize,
+    retained_path_bytes: usize,
+) -> Result<Vec<PathBuf>, String> {
+    let mut children = Vec::new();
+    let mut temporary_path_bytes = 0usize;
+    for entry in entries {
+        if *visited_entries >= crate::fonts::MAX_PREFLIGHT_ENTRIES {
+            return Err(format!(
+                "Font source exceeds the {}-entry traversal limit",
+                crate::fonts::MAX_PREFLIGHT_ENTRIES
+            ));
+        }
+        *visited_entries += 1;
+        let path =
+            entry.map_err(|e| format!("read directory entry in {}: {e}", directory.display()))?;
+        temporary_path_bytes = temporary_path_bytes.saturating_add(path.as_os_str().len());
+        if retained_path_bytes.saturating_add(temporary_path_bytes)
+            > crate::fonts::MAX_SCAN_PATH_BYTES
+        {
+            return Err(format!(
+                "Font source exceeds the {}-byte retained-path limit",
+                crate::fonts::MAX_SCAN_PATH_BYTES
+            ));
+        }
+        children.push(path);
+    }
+    children.sort();
+    Ok(children)
+}
+
 /// Build the metadata-only freshness snapshot used by drift detection and by
 /// the publication stability check. Recursive traversal is deterministic and
 /// never follows symlinks, junctions, or other reparse points.
@@ -721,24 +754,16 @@ pub fn snapshot_source_directories(
     while let Some((directory, depth)) = pending.pop() {
         let read_dir = std::fs::read_dir(&directory)
             .map_err(|e| format!("read directory {}: {e}", directory.display()))?;
-        let mut children = Vec::new();
-        for entry in read_dir {
-            let entry = entry
-                .map_err(|e| format!("read directory entry in {}: {e}", directory.display()))?;
-            children.push(entry.path());
-        }
-        children.sort();
+        let children = collect_snapshot_children(
+            read_dir.map(|entry| entry.map(|entry| entry.path())),
+            &directory,
+            &mut visited_entries,
+            retained_path_bytes,
+        )?;
 
         // Reverse push preserves ascending traversal with a LIFO stack. Final
         // output is sorted too, so database contents never depend on OS order.
         for child in children {
-            visited_entries = visited_entries.saturating_add(1);
-            if visited_entries > crate::fonts::MAX_PREFLIGHT_ENTRIES {
-                return Err(format!(
-                    "Font source exceeds the {}-entry traversal limit",
-                    crate::fonts::MAX_PREFLIGHT_ENTRIES
-                ));
-            }
             match crate::util::try_is_reparse_point(&child) {
                 Ok(false) => {}
                 Ok(true) => continue,
@@ -4085,6 +4110,61 @@ mod tests {
             .query_row("SELECT COUNT(*) FROM cached_fonts", [], |row| row.get(0))
             .unwrap();
         assert_eq!(face_count, 20_130);
+    }
+
+    #[test]
+    fn snapshot_children_preserve_sorting_at_the_entry_limit() {
+        let mut visited = crate::fonts::MAX_PREFLIGHT_ENTRIES - 2;
+        let children = collect_snapshot_children(
+            [Ok(PathBuf::from("z.ttf")), Ok(PathBuf::from("a.ttf"))],
+            Path::new("library"),
+            &mut visited,
+            0,
+        )
+        .unwrap();
+        assert_eq!(children, [PathBuf::from("a.ttf"), PathBuf::from("z.ttf")]);
+        assert_eq!(visited, crate::fonts::MAX_PREFLIGHT_ENTRIES);
+    }
+
+    #[test]
+    fn snapshot_children_stop_consuming_an_over_limit_iterator() {
+        let read = std::cell::Cell::new(0);
+        let entries = std::iter::repeat_with(|| {
+            read.set(read.get() + 1);
+            assert!(
+                read.get() <= 3,
+                "must stop before consuming the rest of a wide directory"
+            );
+            Ok(PathBuf::from("candidate.ttf"))
+        });
+        let mut visited = crate::fonts::MAX_PREFLIGHT_ENTRIES - 2;
+        let error =
+            collect_snapshot_children(entries, Path::new("library"), &mut visited, 0).unwrap_err();
+        assert!(error.contains("traversal limit"));
+        assert_eq!(read.get(), 3);
+        assert_eq!(visited, crate::fonts::MAX_PREFLIGHT_ENTRIES);
+    }
+
+    #[test]
+    fn snapshot_children_include_temporary_paths_in_the_byte_budget() {
+        let path = PathBuf::from("candidate.ttf");
+        let remaining = path.as_os_str().len();
+        let mut visited = 0;
+        assert!(collect_snapshot_children(
+            [Ok(path.clone())],
+            Path::new("library"),
+            &mut visited,
+            crate::fonts::MAX_SCAN_PATH_BYTES - remaining
+        )
+        .is_ok());
+        let error = collect_snapshot_children(
+            [Ok(path)],
+            Path::new("library"),
+            &mut visited,
+            crate::fonts::MAX_SCAN_PATH_BYTES - remaining + 1,
+        )
+        .unwrap_err();
+        assert!(error.contains("retained-path limit"));
     }
 
     #[test]

--- a/src-tauri/src/ipc_commands.rs
+++ b/src-tauri/src/ipc_commands.rs
@@ -168,6 +168,18 @@ pub async fn safe_output_path_exists(app: tauri::AppHandle, path: String) -> Res
 }
 
 #[tauri::command]
+pub async fn safe_find_selected_input_conflicts(
+    app: tauri::AppHandle,
+    input_paths: Vec<String>,
+    output_paths: Vec<String>,
+) -> Result<Vec<String>, String> {
+    run_blocking_command("safe_find_selected_input_conflicts", move || {
+        crate::safe_io::safe_find_selected_input_conflicts(app, input_paths, output_paths)
+    })
+    .await
+}
+
+#[tauri::command]
 pub async fn safe_write_text_file(
     app: tauri::AppHandle,
     path: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -151,6 +151,7 @@ pub fn run() {
             ipc_commands::clear_font_cache,
             ipc_commands::lookup_font_family,
             ipc_commands::safe_output_path_exists,
+            ipc_commands::safe_find_selected_input_conflicts,
             ipc_commands::safe_write_text_file,
             ipc_commands::safe_write_style_edit_output,
             ipc_commands::safe_copy_file,

--- a/src-tauri/src/safe_io.rs
+++ b/src-tauri/src/safe_io.rs
@@ -56,6 +56,7 @@
 
 use crate::encoding::{read_text_detect_encoding_inner, ALLOWED_TEXT_EXTENSIONS, MAX_TEXT_SIZE};
 use crate::util::{is_reparse_point, validate_ipc_path, validate_output_path};
+use std::collections::HashSet;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -624,6 +625,79 @@ pub fn safe_output_path_exists_inner(
         Err(e) => Err(format!("Failed to check output path existence: {e}")),
     }
 }
+/// Resolve a bounded batch before overwrite consent, including existing parent
+/// aliases. This is a read-only snapshot, not a guard against later path swaps.
+pub fn safe_find_selected_input_conflicts_inner(
+    input_paths: &[String],
+    output_paths: &[String],
+    is_allowed: impl Fn(&Path) -> bool,
+) -> Result<Vec<String>, String> {
+    let limit = crate::dropzone::MAX_RESULT_FILES;
+    if input_paths.len() > limit || output_paths.len() > limit {
+        return Err(format!(
+            "Selected-input conflict check accepts at most {limit} inputs and {limit} outputs"
+        ));
+    }
+    if output_paths.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut selected = HashSet::with_capacity(input_paths.len());
+    let mut visited_inputs = HashSet::new();
+    for input in input_paths {
+        if !visited_inputs.insert(input) {
+            continue;
+        }
+        validate_ipc_path(input, "Selected input")?;
+        let path = Path::new(input);
+        check_output_probe_extension(path, "Selected input")?;
+        check_scope_allows(&is_allowed, path, "Selected input")?;
+        // A missing or inaccessible source cannot supply a reliable identity;
+        // abort preparation instead of silently dropping it from protection.
+        let canonical = path.canonicalize().map_err(|error| {
+            format!(
+                "Failed to resolve selected input {}: {error}",
+                path.display()
+            )
+        })?;
+        check_scope_allows(&is_allowed, &canonical, "Selected input")?;
+        let metadata = fs::metadata(&canonical)
+            .map_err(|error| format!("Failed to inspect selected input: {error}"))?;
+        if !metadata.is_file() {
+            return Err(format!(
+                "Selected input is not a regular file: {}",
+                path.display()
+            ));
+        }
+        selected.insert(canonical);
+    }
+
+    let mut conflicts = Vec::new();
+    let mut visited_outputs = HashSet::new();
+    for output in output_paths {
+        if !visited_outputs.insert(output) {
+            continue;
+        }
+        validate_output_path(output, "Output")?;
+        let path = Path::new(output);
+        check_output_probe_extension(path, "Output")?;
+        check_scope_allows(&is_allowed, path, "Output")?;
+        match path.canonicalize() {
+            Ok(canonical) => {
+                check_scope_allows(&is_allowed, &canonical, "Output")?;
+                if selected.contains(&canonical) {
+                    conflicts.push(output.clone());
+                }
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                check_scope_allows_resolved(&is_allowed, path, "Output")?;
+            }
+            Err(error) => return Err(format!("Failed to resolve output path: {error}")),
+        }
+    }
+    Ok(conflicts)
+}
+
 pub fn safe_write_text_file_inner(
     path: &str,
     content: &str,
@@ -811,8 +885,84 @@ pub fn safe_rename_file_inner(
     is_allowed: impl Fn(&Path) -> bool,
 ) -> Result<(), String> {
     safe_rename_file_inner_with_rename(src, dst, overwrite, is_allowed, |source, destination| {
-        fs::rename(source, destination)
+        if overwrite {
+            fs::rename(source, destination)
+        } else {
+            rename_without_overwrite(source, destination)
+        }
     })
+}
+
+#[cfg(windows)]
+fn windows_rename_path(path: &Path) -> std::io::Result<Vec<u16>> {
+    use std::os::windows::ffi::OsStrExt;
+
+    // Normalize without resolving links. Long paths require the extended
+    // namespace when calling Win32 directly, independent of process opt-in.
+    let absolute = std::path::absolute(path)?;
+    let wide: Vec<u16> = absolute.as_os_str().encode_wide().collect();
+    if wide.contains(&0) {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Path contains NUL",
+        ));
+    }
+    let mut wide = if wide.len() >= 260 && !wide.starts_with(&[92, 92, 63, 92]) {
+        if wide.starts_with(&[92, 92]) {
+            r"\\?\UNC\"
+                .encode_utf16()
+                .chain(wide[2..].iter().copied())
+                .collect()
+        } else {
+            r"\\?\".encode_utf16().chain(wide).collect()
+        }
+    } else {
+        wide
+    };
+    wide.push(0);
+    Ok(wide)
+}
+
+#[cfg(windows)]
+fn rename_without_overwrite(source: &Path, destination: &Path) -> std::io::Result<()> {
+    #[link(name = "kernel32")]
+    unsafe extern "system" {
+        fn MoveFileExW(existing: *const u16, new: *const u16, flags: u32) -> i32;
+    }
+    let source = windows_rename_path(source)?;
+    let destination = windows_rename_path(destination)?;
+    // Both buffers are NUL-terminated and live through the call. Flags zero
+    // forbids replacement and cross-volume copy/delete fallback atomically.
+    if unsafe { MoveFileExW(source.as_ptr(), destination.as_ptr(), 0) } == 0 {
+        Err(std::io::Error::last_os_error())
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(any(target_os = "linux", target_os = "android", target_vendor = "apple"))]
+fn rename_without_overwrite(source: &Path, destination: &Path) -> std::io::Result<()> {
+    rustix::fs::renameat_with(
+        rustix::fs::CWD,
+        source,
+        rustix::fs::CWD,
+        destination,
+        rustix::fs::RenameFlags::NOREPLACE,
+    )
+    .map_err(Into::into)
+}
+
+#[cfg(not(any(
+    windows,
+    target_os = "linux",
+    target_os = "android",
+    target_vendor = "apple"
+)))]
+fn rename_without_overwrite(_source: &Path, _destination: &Path) -> std::io::Result<()> {
+    Err(std::io::Error::new(
+        std::io::ErrorKind::Unsupported,
+        "Atomic no-overwrite rename is unavailable on this platform",
+    ))
 }
 
 fn safe_rename_file_inner_with_rename(
@@ -832,6 +982,11 @@ fn safe_rename_file_inner_with_rename(
     check_scope_allows_resolved(&is_allowed, src_ref, "Source")?;
     check_scope_allows_resolved(&is_allowed, dst_ref, "Destination")?;
     reject_reparse_source(src_ref, "rename")?;
+    let source_metadata = fs::symlink_metadata(src_ref)
+        .map_err(|error| format!("Failed to inspect rename source: {error}"))?;
+    if !source_metadata.is_file() {
+        return Err("Source is not a regular file; refusing to rename it".to_string());
+    }
     reject_same_canonical_path(src_ref, dst_ref)?;
     ensure_parent_dir(dst_ref)?;
     // Keep an ordinary existing destination in place until the OS performs the
@@ -852,13 +1007,8 @@ fn safe_rename_file_inner_with_rename(
         );
         return Err("Refusing to rename symlink / junction (race-time detection)".to_string());
     }
-    // Rename destination TOCTOU symmetry: copy's destination
-    // is implicitly protected by `OpenOptions::create_new(true)` at
-    // open time; rename has no equivalent atomic guard. Between
-    // destination inspection and the `fs::rename` below, an attacker can
-    // replace dst with a symlink — same window copy already closes.
-    // One syscall (`is_reparse_point` = lstat on POSIX, file_attributes
-    // on Windows); race window is narrow but the cost is trivial.
+    // Keep explicit reparse rejection for overwrite=true too; no-overwrite
+    // additionally rejects every late-created destination in the OS operation.
     if is_reparse_point(dst_ref) {
         log::warn!(
             "Refusing to rename to possible symlink / junction at rename-time: {}",
@@ -884,6 +1034,17 @@ pub fn safe_output_path_exists(app: tauri::AppHandle, path: String) -> Result<bo
     let scope = crate::fs_policy::app_fs_scope(&app)?;
     safe_output_path_exists_inner(&path, move |p| scope.is_allowed(p))
 }
+pub fn safe_find_selected_input_conflicts(
+    app: tauri::AppHandle,
+    input_paths: Vec<String>,
+    output_paths: Vec<String>,
+) -> Result<Vec<String>, String> {
+    let scope = crate::fs_policy::app_fs_scope(&app)?;
+    safe_find_selected_input_conflicts_inner(&input_paths, &output_paths, move |p| {
+        scope.is_allowed(p)
+    })
+}
+
 /// Write a text file safely. Layered defenses: scope deny enforcement,
 /// subtitle-extension whitelist, symlink rejection on destination,
 /// atomic `create_new(true)` open.
@@ -1000,6 +1161,219 @@ mod tests {
         );
 
         (real_dir, raw, resolved)
+    }
+
+    #[test]
+    fn selected_input_conflicts_keep_ordinary_and_missing_outputs_eligible() {
+        let dir = temp_dir("selected_conflicts_ordinary");
+        let input = dir.join("source.ass");
+        let existing = dir.join("previous.ass");
+        let missing = dir.join("new").join("output.ass");
+        fs::write(&input, "source").unwrap();
+        fs::write(&existing, "previous output").unwrap();
+        let conflicts = safe_find_selected_input_conflicts_inner(
+            &[input.to_string_lossy().into_owned()],
+            &[
+                input.to_string_lossy().into_owned(),
+                existing.to_string_lossy().into_owned(),
+                missing.to_string_lossy().into_owned(),
+            ],
+            allow_all,
+        )
+        .unwrap();
+        assert_eq!(conflicts, [input.to_string_lossy()]);
+        assert_eq!(fs::read_to_string(input).unwrap(), "source");
+        assert_eq!(fs::read_to_string(existing).unwrap(), "previous output");
+        assert!(!missing.parent().unwrap().exists());
+    }
+
+    #[test]
+    fn selected_input_conflicts_resolve_existing_aliases_in_both_directions() {
+        let (dir, raw, _) = scope_alias_paths("selected_conflicts_alias", "source.ass");
+        let original = dir.join("source.ass");
+        fs::write(&original, "source").unwrap();
+        #[cfg(windows)]
+        let raw = PathBuf::from(raw.to_string_lossy().to_uppercase());
+        let original = original.to_string_lossy().into_owned();
+        let alias = raw.to_string_lossy().into_owned();
+        assert_ne!(original, alias);
+        for (input, output) in [(&original, &alias), (&alias, &original)] {
+            assert_eq!(
+                safe_find_selected_input_conflicts_inner(
+                    std::slice::from_ref(input),
+                    std::slice::from_ref(output),
+                    allow_all,
+                )
+                .unwrap(),
+                std::slice::from_ref(output)
+            );
+        }
+    }
+
+    #[test]
+    fn selected_input_conflicts_fail_closed_for_missing_selected_source() {
+        let dir = temp_dir("selected_conflicts_missing_input");
+        let existing = dir.join("source.ass");
+        fs::write(&existing, "source").unwrap();
+        let error = safe_find_selected_input_conflicts_inner(
+            &[dir.join("missing.ass").to_string_lossy().into_owned()],
+            &[existing.to_string_lossy().into_owned()],
+            allow_all,
+        )
+        .unwrap_err();
+        assert!(error.contains("Failed to resolve selected input"));
+        assert_eq!(fs::read_to_string(existing).unwrap(), "source");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn selected_input_conflicts_resolve_a_selected_directory_junction() {
+        use std::os::windows::process::CommandExt;
+
+        struct JunctionGuard(PathBuf);
+        impl Drop for JunctionGuard {
+            fn drop(&mut self) {
+                // RemoveDirectory removes the junction itself without following it.
+                let _ = fs::remove_dir(&self.0);
+            }
+        }
+
+        let dir = temp_dir("selected_conflicts_junction");
+        let real = dir.join("real");
+        fs::create_dir(&real).unwrap();
+        let junction = dir.join("picked_alias");
+        let result = std::process::Command::new("powershell.exe")
+            .args([
+                "-NoLogo",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                "$ErrorActionPreference = 'Stop'; New-Item -ItemType Junction -Path $env:SSAHDRIFY_TEST_JUNCTION_PATH -Target $env:SSAHDRIFY_TEST_JUNCTION_TARGET | Out-Null",
+            ])
+            .env("SSAHDRIFY_TEST_JUNCTION_PATH", &junction)
+            .env("SSAHDRIFY_TEST_JUNCTION_TARGET", &real)
+            .creation_flags(0x08000000)
+            .output()
+            .expect("run Windows junction fixture setup");
+        let _cleanup = JunctionGuard(junction.clone());
+        assert!(
+            result.status.success(),
+            "junction creation failed: {}",
+            String::from_utf8_lossy(&result.stderr)
+        );
+
+        let source = real.join("episode.srt");
+        let output = real.join("episode.hdr.ass");
+        let selected_alias = junction.join("episode.hdr.ass");
+        fs::write(&source, "original subtitle").unwrap();
+        fs::write(&output, "selected original output").unwrap();
+        assert_ne!(output, selected_alias);
+        let output = output.to_string_lossy().into_owned();
+        let conflicts = safe_find_selected_input_conflicts_inner(
+            &[
+                source.to_string_lossy().into_owned(),
+                selected_alias.to_string_lossy().into_owned(),
+            ],
+            std::slice::from_ref(&output),
+            allow_all,
+        )
+        .unwrap();
+        assert_eq!(conflicts, [output]);
+        assert_eq!(
+            fs::read_to_string(selected_alias).unwrap(),
+            "selected original output"
+        );
+        assert_eq!(fs::read_to_string(source).unwrap(), "original subtitle");
+    }
+
+    #[test]
+    fn selected_input_conflicts_validate_extensions_and_regular_sources() {
+        let dir = temp_dir("selected_conflicts_kinds");
+        let source = dir.join("source.sup");
+        fs::write(&source, [0u8, 1, 2]).unwrap();
+        let input = source.to_string_lossy().into_owned();
+        let output = dir.join("out.sup").to_string_lossy().into_owned();
+        assert!(safe_find_selected_input_conflicts_inner(
+            std::slice::from_ref(&input),
+            std::slice::from_ref(&output),
+            allow_all,
+        )
+        .unwrap()
+        .is_empty());
+        for (inputs, outputs) in [
+            (
+                vec![dir.join("private.txt").to_string_lossy().into_owned()],
+                vec![output.clone()],
+            ),
+            (
+                vec![input.clone()],
+                vec![dir.join("out.exe").to_string_lossy().into_owned()],
+            ),
+        ] {
+            assert!(
+                safe_find_selected_input_conflicts_inner(&inputs, &outputs, allow_all)
+                    .unwrap_err()
+                    .contains("subtitle extension")
+            );
+        }
+        let directory = dir.join("folder.ass");
+        fs::create_dir(&directory).unwrap();
+        assert!(safe_find_selected_input_conflicts_inner(
+            &[directory.to_string_lossy().into_owned()],
+            &[output],
+            allow_all,
+        )
+        .unwrap_err()
+        .contains("not a regular file"));
+    }
+
+    #[test]
+    fn selected_input_conflicts_enforce_raw_and_resolved_scopes() {
+        let (dir, input, resolved_input) =
+            scope_alias_paths("selected_conflicts_scope", "source.ass");
+        fs::write(&input, "source").unwrap();
+        let output = dir.join("out.ass");
+        fs::write(&output, "output").unwrap();
+        let resolved_output = output.canonicalize().unwrap();
+        let inputs = vec![input.to_string_lossy().into_owned()];
+        let outputs = vec![output.to_string_lossy().into_owned()];
+        for denied in [&input, &resolved_input, &output, &resolved_output] {
+            assert!(
+                safe_find_selected_input_conflicts_inner(&inputs, &outputs, |path| path != denied)
+                    .unwrap_err()
+                    .contains("scope")
+            );
+        }
+        let missing = dir.join("missing.ass");
+        let resolved_missing = dir.canonicalize().unwrap().join("missing.ass");
+        assert!(safe_find_selected_input_conflicts_inner(
+            &inputs,
+            &[missing.to_string_lossy().into_owned()],
+            |path| path != resolved_missing,
+        )
+        .unwrap_err()
+        .contains("scope"));
+    }
+
+    #[test]
+    fn selected_input_conflicts_accept_the_batch_limit_and_reject_one_more() {
+        let dir = temp_dir("selected_conflicts_limit");
+        let path = dir.join("source.ass");
+        fs::write(&path, "source").unwrap();
+        let value = path.to_string_lossy().into_owned();
+        let at_limit = vec![value.clone(); crate::dropzone::MAX_RESULT_FILES];
+        assert_eq!(
+            safe_find_selected_input_conflicts_inner(&at_limit, &at_limit, allow_all).unwrap(),
+            std::slice::from_ref(&value)
+        );
+        let over_limit = vec![value; crate::dropzone::MAX_RESULT_FILES + 1];
+        for (inputs, outputs) in [(&over_limit, &at_limit), (&at_limit, &over_limit)] {
+            assert!(
+                safe_find_selected_input_conflicts_inner(inputs, outputs, allow_all)
+                    .unwrap_err()
+                    .contains("at most 5000")
+            );
+        }
     }
 
     #[test]
@@ -1636,6 +2010,103 @@ mod tests {
         .unwrap();
         assert!(!src.exists());
         assert_eq!(fs::read(&dst).unwrap(), b"payload");
+    }
+
+    #[test]
+    fn rename_no_overwrite_preserves_a_destination_created_after_inspection() {
+        let dir = temp_dir("rename_late_destination");
+        let src = dir.join("src.ass");
+        let dst = dir.join("dst.ass");
+        fs::write(&src, b"source payload").unwrap();
+        let error = safe_rename_file_inner_with_rename(
+            &src.to_string_lossy(),
+            &dst.to_string_lossy(),
+            false,
+            allow_all,
+            |source, destination| {
+                fs::write(destination, b"late destination").unwrap();
+                rename_without_overwrite(source, destination)
+            },
+        )
+        .unwrap_err();
+        assert!(error.contains("Failed to rename file"), "got: {error}");
+        assert_eq!(fs::read(&src).unwrap(), b"source payload");
+        assert_eq!(fs::read(&dst).unwrap(), b"late destination");
+    }
+
+    #[test]
+    fn rename_rejects_directory_sources_before_creating_or_overwriting_outputs() {
+        let dir = temp_dir("rename_directory_source");
+        let src = dir.join("folder.ass");
+        fs::create_dir(&src).unwrap();
+        fs::write(src.join("child.txt"), b"keep child").unwrap();
+        for overwrite in [false, true] {
+            let dst = if overwrite {
+                dir.join("existing.ass")
+            } else {
+                dir.join("new_parent/output.ass")
+            };
+            if overwrite {
+                fs::write(&dst, b"existing output").unwrap();
+            }
+            let error = safe_rename_file_inner_with_rename(
+                &src.to_string_lossy(),
+                &dst.to_string_lossy(),
+                overwrite,
+                allow_all,
+                |_, _| panic!("directory source reached the rename operation"),
+            )
+            .unwrap_err();
+            assert!(error.contains("not a regular file"), "got: {error}");
+            assert_eq!(fs::read(src.join("child.txt")).unwrap(), b"keep child");
+            if overwrite {
+                assert_eq!(fs::read(&dst).unwrap(), b"existing output");
+            } else {
+                assert!(!dst.parent().unwrap().exists());
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rename_no_overwrite_supports_windows_paths_beyond_max_path() {
+        let mut dir = temp_dir("rename_long_path");
+        while dir.to_string_lossy().encode_utf16().count() < 280 {
+            dir = dir.join("nested_directory_component");
+        }
+        fs::create_dir_all(&dir).unwrap();
+        let src = dir.join("source.ass");
+        let dst = dir.join("destination.ass");
+        fs::write(&src, b"long path payload").unwrap();
+        safe_rename_file_inner(
+            &src.to_string_lossy(),
+            &dst.to_string_lossy(),
+            false,
+            allow_all,
+        )
+        .unwrap();
+        assert!(!src.exists());
+        assert_eq!(fs::read(&dst).unwrap(), b"long path payload");
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rename_wide_paths_keep_short_paths_and_extend_drive_and_unc_paths() {
+        use std::ffi::OsString;
+        use std::os::windows::ffi::OsStringExt;
+        let decode = |path: &Path| {
+            let wide = windows_rename_path(path).unwrap();
+            assert_eq!(wide.last(), Some(&0));
+            OsString::from_wide(&wide[..wide.len() - 1])
+                .to_string_lossy()
+                .into_owned()
+        };
+        assert_eq!(decode(Path::new(r"C:\base\file.ass")), r"C:\base\file.ass");
+        let drive = format!("C:\\{}\\file.ass", "directory\\".repeat(30));
+        assert!(decode(Path::new(&drive)).starts_with(r"\\?\C:\"));
+        let unc = format!("\\\\server\\share\\{}file.ass", "directory\\".repeat(30));
+        assert!(decode(Path::new(&unc)).starts_with(r"\\?\UNC\server\share\"));
+        assert!(windows_rename_path(Path::new("C:\\bad\0.ass")).is_err());
     }
 
     #[test]

--- a/src-tauri/src/util.rs
+++ b/src-tauri/src/util.rs
@@ -301,7 +301,11 @@ pub fn validate_output_path_shape(path: &Path, label: &str) -> Result<(), String
                 return Ok(());
             }
             let end_exclusive = components.len().saturating_sub(1);
-            for component in &components[first_directory_index..end_exclusive] {
+            for component in components
+                .iter()
+                .take(end_exclusive)
+                .skip(first_directory_index)
+            {
                 if component.is_empty() || matches!(*component, "." | "..") {
                     continue;
                 }
@@ -836,6 +840,26 @@ mod tests {
         let err =
             validate_output_path(r"//server.//share./dir./episode.ass", "Output").unwrap_err();
         assert!(err.contains("directory component ending in an unsupported ASCII dot"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn output_path_shape_handles_bare_unc_roots_without_panicking() {
+        for path in [
+            r"\\server\share",
+            r"\\server\share\",
+            "//server/share",
+            "//server//share",
+            "//server/share/",
+        ] {
+            validate_output_path_shape(Path::new(path), "Output").unwrap();
+        }
+        validate_output_path_shape(Path::new(r"\\server\share\episode.ass"), "Output").unwrap();
+        assert!(validate_output_path_shape(
+            Path::new(r"\\server\share\dir.\episode.ass"),
+            "Output"
+        )
+        .is_err());
     }
 
     #[cfg(windows)]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -22,8 +22,8 @@
       }
     ],
     "security": {
-      "devCsp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' ws://127.0.0.1:5173; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; frame-src 'none'; worker-src 'none'; media-src 'none'; manifest-src 'none'",
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'none'; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; frame-src 'none'; worker-src 'none'; media-src 'none'; manifest-src 'none'"
+      "devCsp": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self' ws://127.0.0.1:5173 ipc: http://ipc.localhost https://ipc.localhost; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; frame-src 'none'; worker-src 'none'; media-src 'none'; manifest-src 'none'",
+      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src ipc: http://ipc.localhost https://ipc.localhost; object-src 'none'; base-uri 'self'; form-action 'none'; frame-ancestors 'none'; frame-src 'none'; worker-src 'none'; media-src 'none'; manifest-src 'none'"
     }
   },
   "bundle": {

--- a/src-tauri/tests/test_cli_shift.rs
+++ b/src-tauri/tests/test_cli_shift.rs
@@ -427,7 +427,7 @@ fn chain_normalizes_relative_input_and_output_directory() {
         .expect("failed to run chain");
 
     assert!(output.status.success(), "{}", combined_output(&output));
-    let shifted = fs::read_to_string(root.join("out").join("episode.shifted.ass")).unwrap();
+    let shifted = fs::read_to_string(root.join("out").join("episode.shifted.srt")).unwrap();
     assert!(shifted.contains("00:00:02,000 --> 00:00:03,000"));
     let _ = fs::remove_dir_all(root);
 }

--- a/src-tauri/tests/test_input_protection.rs
+++ b/src-tauri/tests/test_input_protection.rs
@@ -1,0 +1,149 @@
+use std::fs;
+use std::path::PathBuf;
+use std::process::Command;
+
+const ASS: &str = include_str!("fixtures/utf8.ass");
+
+fn temp_dir(label: &str) -> PathBuf {
+    let stamp = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let path = std::env::temp_dir().join(format!(
+        "ssahdrify-input-protection-{label}-{}-{stamp}",
+        std::process::id()
+    ));
+    fs::create_dir_all(&path).unwrap();
+    path
+}
+
+#[test]
+fn transforms_never_replace_another_selected_input_even_with_overwrite() {
+    let commands: &[(&str, &[&str])] = &[
+        (
+            "hdr",
+            &["hdr", "--eotf", "pq", "--output-template", "protected.ass"],
+        ),
+        (
+            "shift",
+            &[
+                "shift",
+                "--offset",
+                "+1s",
+                "--output-template",
+                "protected.ass",
+            ],
+        ),
+        ("embed", &["embed", "--output-template", "protected.ass"]),
+        (
+            "chain",
+            &[
+                "chain",
+                "--output-template",
+                "protected.ass",
+                "shift",
+                "--offset",
+                "+1s",
+            ],
+        ),
+    ];
+    for (name, args) in commands {
+        for dry_run in [false, true] {
+            let root = temp_dir(name);
+            let source = root.join("source.ass");
+            let protected = root.join("protected.ass");
+            fs::write(&source, ASS).unwrap();
+            let protected_content = format!("{ASS}\n; preserve this selected source\n");
+            fs::write(&protected, &protected_content).unwrap();
+            let mut command = Command::new(env!("CARGO_BIN_EXE_ssahdrify-cli"));
+            command.args(["--lang", "en", "--no-cache", "--overwrite"]);
+            if dry_run {
+                command.arg("--dry-run");
+            }
+            let output = command
+                .args(*args)
+                .arg(&source)
+                .arg(&protected)
+                .output()
+                .unwrap();
+            let text = format!(
+                "{}\n{}",
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+            assert!(!output.status.success(), "{name} dry_run={dry_run}: {text}");
+            assert!(
+                text.contains("selected input file"),
+                "{name} dry_run={dry_run}: {text}"
+            );
+            assert_eq!(
+                fs::read_to_string(&source).unwrap(),
+                ASS,
+                "{name}: source changed"
+            );
+            assert_eq!(
+                fs::read_to_string(&protected).unwrap(),
+                protected_content,
+                "{name}: selected output changed"
+            );
+            fs::remove_dir_all(root).unwrap();
+        }
+    }
+}
+
+#[test]
+fn format_dependent_shift_checks_selected_inputs_after_resolving_the_output() {
+    let root = temp_dir("detected-format");
+    let source = root.join("episode.srt");
+    let protected = root.join("episode.shifted.srt");
+    let subtitle = "1\n00:00:01,000 --> 00:00:02,000\nsource\n";
+    fs::write(&source, subtitle).unwrap();
+    fs::write(&protected, subtitle).unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_ssahdrify-cli"))
+        .args([
+            "--lang",
+            "en",
+            "--overwrite",
+            "shift",
+            "--offset",
+            "+1s",
+            "--output-template",
+            "{name}.shifted.{format}",
+        ])
+        .arg(&source)
+        .arg(&protected)
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr).contains("selected input file"));
+    assert_eq!(fs::read_to_string(&source).unwrap(), subtitle);
+    assert_eq!(fs::read_to_string(&protected).unwrap(), subtitle);
+    assert!(String::from_utf8_lossy(&output.stderr).contains("same as input"));
+    assert_eq!(fs::read_dir(&root).unwrap().count(), 2);
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn explicit_overwrite_still_replaces_an_unselected_previous_output() {
+    let root = temp_dir("ordinary-overwrite");
+    let source = root.join("episode.srt");
+    let destination = root.join("episode.shifted.srt");
+    let subtitle = "1\n00:00:01,000 --> 00:00:02,000\nsource\n";
+    fs::write(&source, subtitle).unwrap();
+    fs::write(&destination, "previous output").unwrap();
+    let output = Command::new(env!("CARGO_BIN_EXE_ssahdrify-cli"))
+        .args(["--lang", "en", "--overwrite", "shift", "--offset", "+1s"])
+        .arg(&source)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(fs::read_to_string(&source).unwrap(), subtitle);
+    assert!(fs::read_to_string(&destination)
+        .unwrap()
+        .contains("00:00:02,000 --> 00:00:03,000"));
+    fs::remove_dir_all(root).unwrap();
+}

--- a/src/AboutLicensesModal.tsx
+++ b/src/AboutLicensesModal.tsx
@@ -8,6 +8,7 @@ interface Props {
 }
 
 const SUMMARY_KEYS: Record<LicenseNoticeId, string> = {
+  frontend: "licenses_frontend_summary",
   ssahdrify: "licenses_ssahdrify_summary",
   inter: "licenses_inter_summary",
   "smiley-sans": "licenses_smiley_sans_summary",

--- a/src/cli-engine-entry.ts
+++ b/src/cli-engine-entry.ts
@@ -19,7 +19,7 @@ import {
   type PairingSource,
   type ParsedFile,
 } from "./features/batch-rename/pairing-engine";
-import { buildFontEntry } from "./features/font-embed/ass-uuencode";
+import { FontSectionBuilder } from "./features/font-embed/ass-uuencode";
 import { assertAssShape, insertFontsSection } from "./features/font-embed/ass-font-section";
 import { buildFontFileName } from "./features/font-embed/font-embedder";
 import { collectFontsWithParser, fontKeyLabel } from "./features/font-embed/font-collector";
@@ -399,21 +399,21 @@ export function applyFontEmbed(request: FontEmbedApplyRequest): FontEmbedApplyRe
   // short-circuit) without shape validation.
   assertAssShape(request.content);
 
-  const fontEntries = request.fonts.map((font) =>
-    buildFontEntry(font.fontName, decodeSubsetBase64(font.dataB64, font.fontName))
-  );
+  const fontSection = new FontSectionBuilder();
+  for (const font of request.fonts) {
+    fontSection.add(font.fontName, decodeSubsetBase64(font.dataB64, font.fontName));
+  }
 
-  if (fontEntries.length === 0) {
+  if (fontSection.count === 0) {
     return {
       content: request.content,
       embeddedCount: 0,
     };
   }
 
-  const fontsSection = `[Fonts]\n${fontEntries.join("\n\n")}\n`;
   return {
-    content: insertFontsSection(request.content, fontsSection),
-    embeddedCount: fontEntries.length,
+    content: insertFontsSection(request.content, fontSection.build()),
+    embeddedCount: fontSection.count,
   };
 }
 

--- a/src/features/batch-rename/BatchRename.tsx
+++ b/src/features/batch-rename/BatchRename.tsx
@@ -5,7 +5,7 @@
  * categorization, count chips, cross-tab dedup). Pairing engine +
  * preview grid. Output-mode radios (rename / copy-to-video /
  * copy-to-chosen) + per-row checkbox toggle + run flow with
- * rename-confirm + countExistingFiles overwrite-confirm + cancel
+ * rename-confirm + existing-output overwrite-confirm + cancel
  * mid-batch. Manual edit: video-centric grid — exactly one row per
  * video. The subtitle column is a dropdown listing every subtitle
  * in the batch; the first regex-paired sub is pre-selected. The
@@ -19,6 +19,7 @@
  * engine's seed.
  */
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { SubtitlePicker } from "./SubtitlePicker";
 import {
   pickRenameInputs,
   pickOutputDirectory,
@@ -33,7 +34,7 @@ import type { Status } from "../../lib/StatusContext";
 import { useTabStatus } from "../../lib/useTabStatus";
 import { useFolderDrop } from "../../lib/useFolderDrop";
 import { PreviewTable, type PreviewTableColumn } from "../../lib/PreviewTable";
-import { countExistingFiles } from "../../lib/output-collisions";
+import { findExistingOutputKeys } from "../../lib/output-collisions";
 import { useLogPanel } from "../../lib/useLogPanel";
 import { LogPanel } from "../../lib/LogPanel";
 import { DropErrorBanner } from "../../lib/DropErrorBanner";
@@ -148,7 +149,8 @@ function renderSourceBadge(
 
 export default function BatchRename() {
   const { t } = useI18n();
-  const { renameFiles, setRenameFiles, clearFile, isFileInUse } = useFileContext();
+  const { renameFiles, setRenameFiles, clearFile, isFileInUse, findLoadedInputConflictKeys } =
+    useFileContext();
 
   const [busy, setBusy] = useState(false);
   const [progress, setProgress] = useState<{ processed: number; total: number } | null>(null);
@@ -176,6 +178,7 @@ export default function BatchRename() {
   // marking edited rows as `source: 'manual'`. ↺ Reset restores the
   // engine's seed.
   const [editedRows, setEditedRows] = useState<PairingRow[]>([]);
+  const [activePickerRow, setActivePickerRow] = useState<string | null>(null);
 
   const pickGenRef = useRef(0);
   // Output-directory picks have their own generation because the chosen
@@ -354,27 +357,21 @@ export default function BatchRename() {
           // when there are no subs at all in the batch — otherwise
           // it would be useless and the muted "(none)" placeholder
           // would mislead.
-          const currentValue = row.subtitle?.path ?? "";
           return (
-            <select
-              name={`subtitle-picker-${row.id}`}
-              value={currentValue}
-              disabled={busy || availableSubtitles.length === 0}
-              onChange={(e) => {
-                const path = e.target.value;
-                assignSubtitleLocal(row.id, path === "" ? null : path);
-              }}
-              className={`rename-row-picker${row.subtitle ? " is-paired" : ""}`}
-              aria-label={t("rename_pick_subtitle")}
-              title={row.subtitle ? sanitizeForDialog(row.subtitle.name) : undefined}
-            >
-              <option value="">{t("rename_pick_subtitle_none")}</option>
-              {availableSubtitles.map((s) => (
-                <option key={s.path} value={s.path}>
-                  {sanitizeForDialog(s.name)}
-                </option>
-              ))}
-            </select>
+            <SubtitlePicker
+              rowId={row.id}
+              subtitle={row.subtitle}
+              choices={availableSubtitles}
+              active={activePickerRow === row.id}
+              disabled={busy}
+              label={t("rename_pick_subtitle")}
+              emptyLabel={t("rename_pick_subtitle_none")}
+              onActivate={() => setActivePickerRow(row.id)}
+              onDeactivate={() =>
+                setActivePickerRow((current) => (current === row.id ? null : current))
+              }
+              onAssign={(path) => assignSubtitleLocal(row.id, path)}
+            />
           );
         },
       },
@@ -385,7 +382,7 @@ export default function BatchRename() {
         render: (row) => renderSourceBadge(row.source, t),
       },
     ],
-    [t, busy, toggleRow, assignSubtitleLocal, availableSubtitles]
+    [t, busy, toggleRow, assignSubtitleLocal, availableSubtitles, activePickerRow]
   );
 
   const actionableRows = useMemo(
@@ -520,6 +517,10 @@ export default function BatchRename() {
     // Synchronous double-click gate — see HdrConvert::handleConvert.
     if (busyRef.current) return;
     busyRef.current = true;
+    pickGenRef.current++;
+    chosenDirPickGenRef.current++;
+    abortRef.current = new AbortController();
+    setBusy(true);
     try {
       if (outputMode === "copy_to_chosen" && !chosenDir) {
         addLog(t("msg_rename_no_chosen_dir"), "error");
@@ -651,6 +652,32 @@ export default function BatchRename() {
           (tgt) => !duplicateOutputKeys.has(normalizeOutputKey(tgt.outputPath))
         );
       }
+      let canonicalInputConflicts: ReadonlySet<string> = new Set();
+      if (targets.length > 0) {
+        try {
+          canonicalInputConflicts = await findLoadedInputConflictKeys(
+            targets.map((target) => target.outputPath),
+            abortRef.current?.signal
+          );
+          if (abortRef.current?.signal.aborted) {
+            setLastActionResult("cancelled");
+            return;
+          }
+          targets = targets.filter((target) => {
+            if (!canonicalInputConflicts.has(normalizeOutputKey(target.outputPath))) return true;
+            addLog(
+              t("msg_rename_input_conflict", sanitizeForDialog(target.row.subtitle!.name)),
+              "error"
+            );
+            preflightFailedCount++;
+            return false;
+          });
+        } catch (error) {
+          addLog(t("error_prefix", sanitizeError(error)), "error");
+          setLastActionResult("error");
+          return;
+        }
+      }
       if (targets.length === 0) {
         if (preflightFailedCount > 0 || duplicateTargets.length > 0) {
           addLog(
@@ -721,7 +748,7 @@ export default function BatchRename() {
             skippedSuffix,
           { title: t("dialog_rename_inplace_title"), kind: "warning" }
         );
-        if (!confirmed) {
+        if (!confirmed || abortRef.current?.signal.aborted) {
           addLog(t("msg_rename_cancelled"), "info");
           setLastActionResult("cancelled");
           return;
@@ -750,8 +777,14 @@ export default function BatchRename() {
           seenProjected.add(key);
           return true;
         });
+      let existingOutputs: ReadonlySet<string> = new Set();
       try {
-        const existingCount = await countExistingFiles(projectedOutputs);
+        existingOutputs = await findExistingOutputKeys(projectedOutputs);
+        if (abortRef.current?.signal.aborted) {
+          setLastActionResult("cancelled");
+          return;
+        }
+        const existingCount = existingOutputs.size;
         if (existingCount > 0) {
           // Show the skipped-count once per run: the rename-mode confirm
           // above already includes `skippedSuffix`, so suppress it here
@@ -765,7 +798,7 @@ export default function BatchRename() {
               kind: "warning",
             }
           );
-          if (!confirmed) {
+          if (!confirmed || abortRef.current?.signal.aborted) {
             addLog(t("msg_rename_cancelled"), "info");
             setLastActionResult("cancelled");
             return;
@@ -777,10 +810,6 @@ export default function BatchRename() {
         return;
       }
 
-      // Construct AbortController at the boundary into busy state —
-      // see HdrConvert::handleConvert for rationale.
-      abortRef.current = new AbortController();
-      setBusy(true);
       setProgress({ processed: 0, total: targets.length });
 
       try {
@@ -838,6 +867,9 @@ export default function BatchRename() {
             // write; keep this loop check so future refactors cannot
             // accidentally reintroduce first-wins overwrite behavior.
             const normalizedOut = normalizeOutputKey(outputPath);
+            if (canonicalInputConflicts.has(normalizedOut)) {
+              throw new Error(t("msg_rename_input_conflict", subName));
+            }
             if (seenOutputs.has(normalizedOut)) {
               addLog(t("msg_skipped_duplicate", subName), "error");
               continue;
@@ -847,9 +879,17 @@ export default function BatchRename() {
             if (abortRef.current?.signal.aborted) break;
 
             if (outputMode === "rename") {
-              await renamePath(row.subtitle!.path, outputPath);
+              await renamePath(
+                row.subtitle!.path,
+                outputPath,
+                existingOutputs.has(normalizeOutputKey(outputPath))
+              );
             } else {
-              await copyPath(row.subtitle!.path, outputPath);
+              await copyPath(
+                row.subtitle!.path,
+                outputPath,
+                existingOutputs.has(normalizeOutputKey(outputPath))
+              );
             }
             addLog(t("msg_rename_done", subName, outName), "success");
             successCount++;
@@ -925,6 +965,9 @@ export default function BatchRename() {
       }
     } finally {
       busyRef.current = false;
+      setBusy(false);
+      setProgress(null);
+      abortRef.current = null;
     }
   }, [
     busy,
@@ -937,6 +980,7 @@ export default function BatchRename() {
     renameFiles,
     setRenameFiles,
     isFileInUse,
+    findLoadedInputConflictKeys,
     addLog,
     t,
   ]);
@@ -1046,7 +1090,7 @@ export default function BatchRename() {
           className="flex-none px-5 rounded-lg font-medium text-sm transition-colors"
           style={{
             background: busy ? "var(--bg-input)" : "var(--accent)",
-            color: busy ? "var(--text-muted)" : "white",
+            color: busy ? "var(--text-muted)" : "var(--accent-text)",
             height: "38px",
           }}
         >
@@ -1091,7 +1135,7 @@ export default function BatchRename() {
                     }
                   : {
                       background: "var(--accent)",
-                      color: "#fff",
+                      color: "var(--accent-text)",
                       height: "38px",
                       minWidth: "140px",
                     }
@@ -1187,7 +1231,7 @@ export default function BatchRename() {
                   className="px-3 py-1 rounded text-xs font-medium"
                   style={{
                     background: busy ? "var(--bg-input)" : "var(--accent)",
-                    color: busy ? "var(--text-muted)" : "white",
+                    color: busy ? "var(--text-muted)" : "var(--accent-text)",
                   }}
                 >
                   {t("btn_pick_chosen_dir")}

--- a/src/features/batch-rename/SubtitlePicker.test.tsx
+++ b/src/features/batch-rename/SubtitlePicker.test.tsx
@@ -1,0 +1,83 @@
+import { createElement, type ChangeEvent } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, it, vi } from "vitest";
+import { SubtitlePicker } from "./SubtitlePicker";
+
+function props() {
+  const choices = [
+    { path: "/subs/first.ass", name: "First" },
+    { path: "/subs/unpaired.ass", name: "Unpaired" },
+  ];
+  return {
+    rowId: "row",
+    subtitle: choices[0]!,
+    choices,
+    active: false,
+    disabled: false,
+    label: "Subtitle",
+    emptyLabel: "None",
+    onActivate: vi.fn(),
+    onDeactivate: vi.fn(),
+    onAssign: vi.fn(),
+  };
+}
+
+describe("SubtitlePicker", () => {
+  it("keeps labels in closed rows and mounts the full pool only for the active row", () => {
+    const choices = Array.from({ length: 500 }, (_, i) => ({
+      path: `/subs/${i}.ass`,
+      name: `Subtitle ${i}`,
+    }));
+    const html = renderToStaticMarkup(
+      createElement(
+        "div",
+        null,
+        choices.map((subtitle, i) =>
+          createElement(SubtitlePicker, {
+            ...props(),
+            key: i,
+            rowId: String(i),
+            choices,
+            subtitle,
+            active: i === 10,
+          })
+        )
+      )
+    );
+    expect(html.match(/<select/g)).toHaveLength(500);
+    expect(html.match(/<option/g)).toHaveLength(499 * 2 + 501);
+    expect(html).toContain("Subtitle 499");
+  });
+
+  it("activates before keyboard or pointer interaction and retains assignment and unpairing", () => {
+    const input = props();
+    const element = SubtitlePicker(input);
+    element.props.onFocus();
+    element.props.onPointerDown();
+    expect(input.onActivate).toHaveBeenCalledTimes(2);
+    element.props.onChange({
+      target: { value: input.choices[1]!.path },
+    } as ChangeEvent<HTMLSelectElement>);
+    element.props.onChange({ target: { value: "" } } as ChangeEvent<HTMLSelectElement>);
+    expect(input.onAssign.mock.calls).toEqual([[input.choices[1]!.path], [null]]);
+    element.props.onBlur();
+    expect(input.onDeactivate).toHaveBeenCalledOnce();
+    const active = renderToStaticMarkup(createElement(SubtitlePicker, { ...input, active: true }));
+    expect(active).toContain(input.choices[1]!.path);
+  });
+
+  it("never expands a disabled picker and sanitizes visible source labels", () => {
+    const input = {
+      ...props(),
+      active: true,
+      disabled: true,
+      subtitle: { path: "/subs/first.ass", name: "Safe\u202eName" },
+    };
+    SubtitlePicker(input).props.onFocus();
+    expect(input.onActivate).not.toHaveBeenCalled();
+    const html = renderToStaticMarkup(createElement(SubtitlePicker, input));
+    expect(html.match(/<option/g)).toHaveLength(2);
+    expect(html).toContain("SafeName");
+    expect(html).not.toContain("\u202e");
+  });
+});

--- a/src/features/batch-rename/SubtitlePicker.tsx
+++ b/src/features/batch-rename/SubtitlePicker.tsx
@@ -1,0 +1,53 @@
+import { flushSync } from "react-dom";
+import { sanitizeForDialog } from "../../lib/dedup-helpers";
+
+interface SubtitleChoice {
+  path: string;
+  name: string;
+}
+
+interface SubtitlePickerProps {
+  rowId: string;
+  subtitle: SubtitleChoice | null;
+  choices: readonly SubtitleChoice[];
+  active: boolean;
+  disabled: boolean;
+  label: string;
+  emptyLabel: string;
+  onActivate: () => void;
+  onDeactivate: () => void;
+  onAssign: (path: string | null) => void;
+}
+
+/** Only the focused picker mounts the complete pool; closed rows retain their label. */
+export function SubtitlePicker(props: SubtitlePickerProps) {
+  const activate = () => {
+    if (!props.active && !props.disabled) {
+      // Populate options before the browser opens its native popup or handles a key.
+      flushSync(props.onActivate);
+    }
+  };
+  const choices =
+    props.active && !props.disabled ? props.choices : props.subtitle ? [props.subtitle] : [];
+  return (
+    <select
+      name={`subtitle-picker-${props.rowId}`}
+      value={props.subtitle?.path ?? ""}
+      disabled={props.disabled || props.choices.length === 0}
+      onPointerDown={activate}
+      onFocus={activate}
+      onBlur={props.onDeactivate}
+      onChange={(event) => props.onAssign(event.target.value || null)}
+      className={`rename-row-picker${props.subtitle ? " is-paired" : ""}`}
+      aria-label={props.label}
+      title={props.subtitle ? sanitizeForDialog(props.subtitle.name) : undefined}
+    >
+      <option value="">{props.emptyLabel}</option>
+      {choices.map((subtitle) => (
+        <option key={subtitle.path} value={subtitle.path}>
+          {sanitizeForDialog(subtitle.name)}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/src/features/chain/chain-runtime.ts
+++ b/src/features/chain/chain-runtime.ts
@@ -12,7 +12,7 @@
 
 import { processAssContent } from "../hdr-convert/ass-processor";
 import { assertFiniteShiftMs, shiftSubtitlesCompact } from "../timing-shift/timing-engine";
-import { buildFontEntry } from "../font-embed/ass-uuencode";
+import { FontSectionBuilder } from "../font-embed/ass-uuencode";
 import { assertAssShape, insertFontsSection } from "../font-embed/ass-font-section";
 import {
   assertSafeOutputFilename,
@@ -154,8 +154,8 @@ function embedTransform(ctx: TransformContext, params: EmbedStepParams): Transfo
   //
   // Resource budgets are layered. Before V8, the Rust shell caps the
   // aggregate raw subset payload at 100 MiB and subset_font rejects
-  // source font files above 64 MiB. After decoding, buildFontEntry's
-  // encoder applies its own stricter 50 MiB per-subset cap. decodeBase64
+  // source font files above 64 MiB. Before encoding each entry, FontSectionBuilder
+  // enforces a 50 MiB aggregate encoded-section cap. decodeBase64
   // itself has no local cap, so the Rust preflight remains load-bearing.
   // Today the chain V8 entry is ONLY reached via the Rust shell;
   // any future caller that constructs a ChainPlan from another
@@ -185,12 +185,12 @@ function embedTransform(ctx: TransformContext, params: EmbedStepParams): Transfo
     };
   }
 
-  const fontEntries = params.subsets.map((s) =>
-    buildFontEntry(s.fontName, decodeBase64(s.dataB64, s.fontName))
-  );
-  const fontsSection = `[Fonts]\n${fontEntries.join("\n\n")}\n`;
-  const content = insertFontsSection(ctx.content, fontsSection);
-  const note = `embed: ${fontEntries.length} font(s) embedded`;
+  const fontSection = new FontSectionBuilder();
+  for (const subset of params.subsets) {
+    fontSection.add(subset.fontName, decodeBase64(subset.dataB64, subset.fontName));
+  }
+  const content = insertFontsSection(ctx.content, fontSection.build());
+  const note = `embed: ${fontSection.count} font(s) embedded`;
   return { content, note };
 }
 

--- a/src/features/font-embed/FontCacheDriftModal.tsx
+++ b/src/features/font-embed/FontCacheDriftModal.tsx
@@ -428,8 +428,8 @@ export default function FontCacheDriftModal({
               disabled={working !== null || totalChanged === 0}
               className="px-3 py-1.5 rounded text-sm"
               style={{
-                background: "var(--accent-bg, #6e56cf)",
-                color: "var(--accent-text, white)",
+                background: "var(--accent)",
+                color: "var(--accent-text)",
                 border: "1px solid var(--accent-border, #6e56cf)",
                 cursor: working !== null ? "not-allowed" : "pointer",
                 filter: working !== null ? "grayscale(1)" : "none",

--- a/src/features/font-embed/FontEmbed.tsx
+++ b/src/features/font-embed/FontEmbed.tsx
@@ -13,6 +13,7 @@ import {
 import { ask } from "@tauri-apps/plugin-dialog";
 import {
   aggregateFonts,
+  FontAnalysisBudget,
   analyzeFonts,
   embedFonts,
   planEmbeddedOutputs,
@@ -29,12 +30,17 @@ import type { Status } from "../../lib/StatusContext";
 import { useTabStatus } from "../../lib/useTabStatus";
 import FontSourceModal, { type FontSource } from "./FontSourceModal";
 import { useFolderDrop } from "../../lib/useFolderDrop";
-import { countExistingFiles } from "../../lib/output-collisions";
+import { findExistingOutputKeys } from "../../lib/output-collisions";
 import { useClickOutside } from "../../lib/useClickOutside";
 import { useLogPanel } from "../../lib/useLogPanel";
 import { LogPanel } from "../../lib/LogPanel";
 import { DropErrorBanner } from "../../lib/DropErrorBanner";
-import { buildConflictMessage, sanitizeError, sanitizeForDialog } from "../../lib/dedup-helpers";
+import {
+  buildConflictMessage,
+  normalizeOutputKey,
+  sanitizeError,
+  sanitizeForDialog,
+} from "../../lib/dedup-helpers";
 import { isFontCacheUnavailable } from "../../lib/font-cache-ui-state";
 
 type FontEmbedOutputMode = "beside_input" | "chosen_dir";
@@ -78,34 +84,8 @@ function fileNameHasAssExt(name: string): boolean {
   return ASS_EXTS.has(name.slice(dot + 1).toLowerCase());
 }
 
-// Batch ingest caps — OOM-by-input defense.
-//
-// Font Embed is the only tab that retains EVERY batch file's decoded content
-// in `perFileAnalysisRef` for the unified detection grid + embed loop —
-// HDR / Time Shift / Batch Rename process per-file and discard. Without
-// these caps, a 5000-file folder drop (the drag-drop expansion ceiling on
-// the Rust side) × the 50 MB per-file encoding-layer cap = up to 250 GB
-// theoretical retention. Realistic batches are season-scoped: ≤ 24 ASS
-// files per pick; 500 leaves ample slack for full-series or multi-language
-// batches without straying into adversarial territory.
-//
-// The aggregate-bytes cap is the load-bearing one — file count alone
-// doesn't bound memory when individual files approach 50 MB. 500 MB
-// covers any legitimate workflow (a typical fan-sub ASS is 30-200 KB,
-// even rich-typography ones rarely exceed 5 MB).
+// Decoded text and retained glyph sets have separate batch budgets.
 const MAX_BATCH_FILES = 500;
-// lowered from 500 MB to 200 MB headroom. The
-// cap counts decoded UTF-16 string bytes (`content.length * 2`)
-// only — per-file `usages` Maps with up to MAX_CODEPOINTS_PER_VARIANT
-// entries × MAX_FONT_VARIANTS variants per file add another ~25-100
-// MB of JS Set memory PER FILE under adversarial inputs (a fan-sub
-// pack crafted to maximize codepoint diversity). At 500 MB
-// content-bytes + N×100 MB Set retention, a 5-file batch could
-// reach ~1 GB JS heap before the cap fires. 200 MB content-bytes
-// keeps total batch retention under ~700 MB even under the worst-
-// case Set inflation, comfortably inside V8's default heap. Real-
-// world batches (24 ASS at 30-200 KB each) consume single-digit MB,
-// so the lower cap is invisible to legitimate workflows.
 const MAX_BATCH_AGGREGATE_BYTES = 200 * 1024 * 1024;
 
 interface FontEmbedProps {
@@ -119,7 +99,8 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
     () => ({ bold: t("font_style_bold"), italic: t("font_style_italic") }),
     [t]
   );
-  const { fontsFiles, setFontsFiles, clearFile, isFileInUse } = useFileContext();
+  const { fontsFiles, setFontsFiles, clearFile, isFileInUse, findLoadedInputConflictKeys } =
+    useFileContext();
 
   // Aggregated font state for the unified detection grid and checkbox
   // selection. Every selected file is analyzed during ingest; single-file
@@ -166,6 +147,7 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
   // outdated work without writing state. Standard "discard stale
   // async results" idiom — see the same shape in BatchRename.
   const pickGenRef = useRef(0);
+  const outputDirPickGenRef = useRef(0);
   // Per-file analysis cache: <path → {content, infos, usages}>. Holds
   // all batch contents in memory so the unified detection grid + the
   // embed loop don't have to re-read or re-parse on every interaction.
@@ -285,14 +267,7 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
         // Symmetric cache for the persistent font cache lookup tier
         // (#5). Same N×M IPC concern as sysCache.
         const cacheLookupCache = new Map<string, { path: string; index: number } | null>();
-        // Tracks total decoded-content bytes already retained in
-        // `cache` so we abort before the next read pushes the batch
-        // past MAX_BATCH_AGGREGATE_BYTES. UTF-16 string length × 2
-        // approximates the JS-engine retention; the actual memory
-        // footprint with `infos`/`usages` is somewhat higher, but the
-        // dominant term is the decoded content (subtitles average
-        // hundreds of bytes per Dialogue line; analysis structures
-        // average a couple of bytes per font reference).
+        const analysisBudget = new FontAnalysisBudget();
         let aggregateBytes = 0;
         for (const path of paths) {
           if (gen !== pickGenRef.current) return;
@@ -335,6 +310,7 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
             cacheLookupCache
           );
           if (gen !== pickGenRef.current) return;
+          analysisBudget.add(analyzed.usages);
           cache.set(path, {
             content,
             infos: analyzed.infos,
@@ -461,7 +437,10 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
     // user manually unchecked gets auto-re-checked the next time
     // any source mutation triggers reanalyze — explicit user intent
     // silently overridden.
-    const prevResolved = keysOfResolvedFonts(aggregateFonts(cache).infos);
+    const prevResolved = new Set<string>();
+    for (const analysis of cache.values()) {
+      for (const key of keysOfResolvedFonts(analysis.infos)) prevResolved.add(key);
+    }
     const gen = (pickGenRef.current = pickGenRef.current + 1);
     // set analyzing=true during the sequential
     // per-file IPC sequence. Without this, the Embed button remains
@@ -472,6 +451,7 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
     setAnalyzing(true);
     try {
       const newCache = new Map<string, FileAnalysis>();
+      const analysisBudget = new FontAnalysisBudget();
       // Same batch-shared caches as ingestPaths — one round of
       // system / cache lookups per source change, not per (file × font).
       const sysCache = new Map<string, SystemFontResolution>();
@@ -480,6 +460,7 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
         if (gen !== pickGenRef.current) return;
         const analyzed = await analyzeFonts(prev.content, null, sysCache, true, cacheLookupCache);
         if (gen !== pickGenRef.current) return;
+        analysisBudget.add(analyzed.usages);
         newCache.set(path, {
           ...prev,
           infos: analyzed.infos,
@@ -593,10 +574,13 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
 
   const handlePickOutputDir = useCallback(async () => {
     if (analyzing || embedding) return;
+    const gen = ++outputDirPickGenRef.current;
     try {
       const dir = await pickOutputDirectory(t);
+      if (gen !== outputDirPickGenRef.current) return;
       if (dir) setChosenOutputDir(dir);
     } catch (e) {
+      if (gen !== outputDirPickGenRef.current) return;
       addLog(t("error_prefix", sanitizeError(e)), "error");
     }
   }, [analyzing, embedding, addLog, t]);
@@ -633,6 +617,10 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
     // Synchronous double-click gate — see HdrConvert::handleConvert.
     if (busyRef.current) return;
     busyRef.current = true;
+    pickGenRef.current++;
+    outputDirPickGenRef.current++;
+    abortRef.current = new AbortController();
+    setEmbedding(true);
     try {
       if (outputMode === "chosen_dir" && !chosenOutputDir) {
         addLog(t("msg_rename_no_chosen_dir"), "error");
@@ -662,23 +650,46 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
         setLastActionResult("error");
         return;
       }
+      let existingOutputs: ReadonlySet<string> = new Set();
+      let inputConflicts: ReadonlySet<string> = new Set();
+      let targets = planned.targets;
+      let skippedCount = planned.skipped.length;
       try {
-        const existingCount = await countExistingFiles(
-          planned.targets.map((target) => target.outputPath)
+        inputConflicts = await findLoadedInputConflictKeys(
+          targets.map((target) => target.outputPath),
+          abortRef.current?.signal
         );
+        if (abortRef.current?.signal.aborted) {
+          setLastActionResult("cancelled");
+          return;
+        }
+        targets = targets.filter((target) => {
+          if (!inputConflicts.has(normalizeOutputKey(target.outputPath))) return true;
+          addLog(t("msg_fonts_input_conflict", safeDisplayFileName(target.inputPath)), "error");
+          skippedCount++;
+          return false;
+        });
+        if (targets.length === 0) {
+          setLastActionResult("error");
+          return;
+        }
+        existingOutputs = await findExistingOutputKeys(targets.map((target) => target.outputPath));
+        if (abortRef.current?.signal.aborted) {
+          setLastActionResult("cancelled");
+          return;
+        }
+        const existingCount = existingOutputs.size;
         if (existingCount > 0) {
           const skippedSuffix =
-            planned.skipped.length > 0
-              ? `\n\n${t("msg_fonts_skipped_count", planned.skipped.length)}`
-              : "";
+            skippedCount > 0 ? `\n\n${t("msg_fonts_skipped_count", skippedCount)}` : "";
           const confirmed = await ask(
-            t("msg_overwrite_confirm", existingCount, planned.targets.length) + skippedSuffix,
+            t("msg_overwrite_confirm", existingCount, targets.length) + skippedSuffix,
             {
               title: t("dialog_overwrite_title"),
               kind: "warning",
             }
           );
-          if (!confirmed) {
+          if (!confirmed || abortRef.current?.signal.aborted) {
             addLog(t("msg_fonts_cancelled"), "info");
             setLastActionResult("cancelled");
             return;
@@ -690,20 +701,16 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
         return;
       }
 
-      // Construct AbortController at the boundary into busy state — see
-      // HdrConvert::handleConvert for rationale.
-      abortRef.current = new AbortController();
-      setEmbedding(true);
-      setBatchProgress({ processed: planned.skipped.length, total: filePaths.length });
+      setBatchProgress({ processed: skippedCount, total: filePaths.length });
 
       try {
         addLog(t("msg_fonts_start", filePaths.length));
 
         let successCount = 0;
-        let issueCount = planned.skipped.length;
-        let processedCount = planned.skipped.length;
+        let issueCount = skippedCount;
+        let processedCount = skippedCount;
 
-        for (const target of planned.targets) {
+        for (const target of targets) {
           const filePath = target.inputPath;
           const outputPath = target.outputPath;
 
@@ -823,7 +830,14 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
             if (cached.inferredEncodingId) {
               addLog(t("msg_inferred_utf16", safeFileName, cached.inferredEncodingId), "warn");
             }
-            await writeText(outputPath, result.content);
+            if (inputConflicts.has(normalizeOutputKey(outputPath))) {
+              throw new Error(t("msg_fonts_input_conflict", safeFileName));
+            }
+            await writeText(
+              outputPath,
+              result.content,
+              existingOutputs.has(normalizeOutputKey(outputPath))
+            );
             const fileWarnings = [...missingWarnings, ...result.warnings];
             if (fileWarnings.length > 0) {
               issueCount += fileWarnings.length;
@@ -883,8 +897,23 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
       }
     } finally {
       busyRef.current = false;
+      setEmbedding(false);
+      setBatchProgress(null);
+      setProgress(null);
+      setEmbedCancelRequested(false);
+      abortRef.current = null;
     }
-  }, [fileCount, filePaths, isSingleFile, selected, outputMode, chosenOutputDir, addLog, t]);
+  }, [
+    fileCount,
+    filePaths,
+    isSingleFile,
+    selected,
+    outputMode,
+    chosenOutputDir,
+    addLog,
+    t,
+    findLoadedInputConflictKeys,
+  ]);
 
   const outputControlsDisabled = analyzing || embedding;
   const missingChosenOutputDir = outputMode === "chosen_dir" && !chosenOutputDir;
@@ -939,6 +968,7 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
 
   const handleClearFiles = useCallback(() => {
     pickGenRef.current = pickGenRef.current + 1;
+    outputDirPickGenRef.current++;
     clearFile("fonts");
     setFonts([]);
     setFontUsages([]);
@@ -1091,7 +1121,8 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
           style={{
             background:
               analyzing || embedding || sourceLocked ? "var(--bg-input)" : "var(--accent)",
-            color: analyzing || embedding || sourceLocked ? "var(--text-muted)" : "white",
+            color:
+              analyzing || embedding || sourceLocked ? "var(--text-muted)" : "var(--accent-text)",
             height: "38px",
           }}
         >
@@ -1155,7 +1186,7 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
               className="px-3 py-1 rounded text-xs font-medium"
               style={{
                 background: outputControlsDisabled ? "var(--bg-input)" : "var(--accent)",
-                color: outputControlsDisabled ? "var(--text-muted)" : "white",
+                color: outputControlsDisabled ? "var(--text-muted)" : "var(--accent-text)",
               }}
             >
               {t("btn_pick_chosen_dir")}
@@ -1196,7 +1227,7 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
                   color: "var(--accent-disabled-text)",
                   height: "38px",
                 }
-              : { background: "var(--accent)", color: "#fff", height: "38px" }
+              : { background: "var(--accent)", color: "var(--accent-text)", height: "38px" }
           }
         >
           {fontSources.length > 0
@@ -1273,7 +1304,12 @@ export default function FontEmbed({ cacheStatus, cacheProbeFailed }: FontEmbedPr
                   height: "38px",
                   minWidth: "140px",
                 }
-              : { background: "var(--accent)", color: "#fff", height: "38px", minWidth: "140px" }
+              : {
+                  background: "var(--accent)",
+                  color: "var(--accent-text)",
+                  height: "38px",
+                  minWidth: "140px",
+                }
           }
         >
           {embedButtonLabel()}

--- a/src/features/font-embed/ass-uuencode.test.ts
+++ b/src/features/font-embed/ass-uuencode.test.ts
@@ -15,9 +15,15 @@
  * group of N chars yields N-1 bytes. A wrong tail therefore fails BOTH the
  * decoder-independent char-count assertion AND the decode round-trip.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
-import { assUuencode, buildFontEntry, MAX_FONT_DATA_SIZE } from "./ass-uuencode";
+import {
+  assUuencode,
+  buildFontEntry,
+  MAX_FONT_DATA_SIZE,
+  FontSectionBuilder,
+  fontEntryByteLength,
+} from "./ass-uuencode";
 
 // ── Faithful libass decoder (libass/ass.c::decode_font) ───────────────────
 // Independent of the encoder under test: reconstructs bytes from the
@@ -176,5 +182,69 @@ describe("buildFontEntry", () => {
 
   it("throws on empty font data (no bare fontname: header)", () => {
     expect(() => buildFontEntry("x.ttf", new Uint8Array(0))).toThrow(/empty font data/);
+  });
+});
+
+describe("cumulative encoded font output budget", () => {
+  it("counts ASCII, CJK, astral and lone surrogate names without browser or Node byte APIs", () => {
+    const names = ["ascii.ttf", "字体.ttf", "emoji😀.ttf", "high\ud800.ttf", "low\udc00.ttf"];
+    const expected = names.map(
+      (name) => new TextEncoder().encode(buildFontEntry(name, makeData(3))).length
+    );
+    vi.stubGlobal("TextEncoder", undefined);
+    vi.stubGlobal("Buffer", undefined);
+    try {
+      for (const [index, name] of names.entries()) {
+        expect(fontEntryByteLength(name, 3)).toBe(expected[index]);
+        const builder = new FontSectionBuilder(9 + expected[index]!);
+        builder.add(name, makeData(3));
+        expect(builder.count).toBe(1);
+      }
+    } finally {
+      vi.unstubAllGlobals();
+    }
+  });
+
+  it("accepts the font-name bound and rejects the next character", () => {
+    expect(() => fontEntryByteLength("a".repeat(1024), 3)).not.toThrow();
+    expect(() => fontEntryByteLength("a".repeat(1025), 3)).toThrow("Font entry name");
+  });
+
+  it.each([1, 2, 3, 59, 60, 61, 120, 121])(
+    "predicts exact UTF-8 entry size for %i bytes",
+    (size) => {
+      const name = "字体:/name.ttf";
+      expect(fontEntryByteLength(name, size)).toBe(
+        new TextEncoder().encode(buildFontEntry(name, makeData(size))).length
+      );
+    }
+  );
+
+  it("accepts the exact complete-section budget and refuses the next font without changing output", () => {
+    const first = buildFontEntry("first.ttf", makeData(61));
+    const second = buildFontEntry("second.ttf", makeData(2));
+    const expected = `[Fonts]\n${first}\n\n${second}\n`;
+    const builder = new FontSectionBuilder(new TextEncoder().encode(expected).length);
+    builder.add("first.ttf", makeData(61));
+    builder.add("second.ttf", makeData(2));
+    expect(builder.build()).toBe(expected);
+    expect(() => builder.add("third.ttf", makeData(1))).toThrow(/encoded output limit/);
+    expect(builder.count).toBe(2);
+    expect(builder.build()).toBe(expected);
+    const oneByteShort = new FontSectionBuilder(new TextEncoder().encode(expected).length - 1);
+    oneByteShort.add("first.ttf", makeData(61));
+    expect(() => oneByteShort.add("second.ttf", makeData(2))).toThrow(/encoded output limit/);
+  });
+
+  it("rejects excessive encoded growth before reading raw byte contents", () => {
+    const unreadable = {
+      length: MAX_FONT_DATA_SIZE,
+      get 0() {
+        throw new Error("must not encode");
+      },
+    } as unknown as Uint8Array;
+    expect(() => new FontSectionBuilder().add("large.ttf", unreadable)).toThrow(
+      /encoded output limit/
+    );
   });
 });

--- a/src/features/font-embed/ass-uuencode.ts
+++ b/src/features/font-embed/ass-uuencode.ts
@@ -36,6 +36,73 @@ import { ASCII_CONTROL_CHARS, BIDI_AND_ZERO_WIDTH_CHARS } from "../../lib/unicod
  * plus the `fontname:` header overhead — well past any realistic subset.
  */
 export const MAX_FONT_DATA_SIZE = 50 * 1024 * 1024;
+export const MAX_ENCODED_FONT_SECTION_BYTES = 50 * 1024 * 1024;
+
+function safeFontEntryName(fontName: string): string {
+  if (fontName.length > 1024) throw new Error("Font entry name exceeds 1024 characters");
+  return fontName.replace(
+    new RegExp(`[${ASCII_CONTROL_CHARS}${BIDI_AND_ZERO_WIDTH_CHARS}:/\\\\]`, "gu"),
+    "_"
+  );
+}
+
+function utf8ByteLength(text: string): number {
+  let bytes = 0;
+  for (const character of text) {
+    const point = character.codePointAt(0)!;
+    bytes += point < 0x80 ? 1 : point < 0x800 ? 2 : point < 0x10000 ? 3 : 4;
+  }
+  return bytes;
+}
+
+/** Exact UTF-8 size, including the header and 80-column line separators. */
+export function fontEntryByteLength(fontName: string, dataLength: number): number {
+  if (!Number.isSafeInteger(dataLength) || dataLength <= 0 || dataLength > MAX_FONT_DATA_SIZE) {
+    throw new Error(`Invalid font data size: ${dataLength} (max ${MAX_FONT_DATA_SIZE})`);
+  }
+  const remainder = dataLength % 3;
+  const encodedChars = Math.floor(dataLength / 3) * 4 + (remainder ? remainder + 1 : 0);
+  return (
+    11 +
+    // The CLI's bare V8 runtime has no TextEncoder or Buffer. Lone UTF-16
+    // surrogates occupy three bytes after UTF-8 replacement, like U+FFFD.
+    utf8ByteLength(safeFontEntryName(fontName)) +
+    encodedChars +
+    Math.floor((encodedChars - 1) / 80)
+  );
+}
+
+/** Reject cumulative growth before allocating the next encoded entry. */
+export class FontSectionBuilder {
+  private entries: string[] = [];
+  private bytes = 9; // [Fonts] header and final newline.
+  private readonly maxBytes: number;
+
+  constructor(maxBytes = MAX_ENCODED_FONT_SECTION_BYTES) {
+    this.maxBytes = maxBytes;
+  }
+
+  get count(): number {
+    return this.entries.length;
+  }
+
+  add(fontName: string, data: Uint8Array): void {
+    const projected =
+      this.bytes + (this.count ? 2 : 0) + fontEntryByteLength(fontName, data.length);
+    if (projected > this.maxBytes) {
+      throw new Error(
+        `Embedded fonts exceed the ${this.maxBytes}-byte encoded output limit; select fewer fonts`
+      );
+    }
+    const entry = buildFontEntry(fontName, data);
+    this.entries.push(entry);
+    this.bytes = projected;
+  }
+
+  build(): string {
+    return this.count ? `[Fonts]\n${this.entries.join("\n\n")}\n` : "";
+  }
+}
 
 /**
  * Encode a binary buffer into ASS [Fonts] section format.
@@ -141,10 +208,7 @@ export function buildFontEntry(fontName: string, data: Uint8Array): string {
   // control set; the extra boundary-specific chars are
   // intentional and MUST NOT be unified into a single helper without
   // re-checking the per-boundary character implications.
-  const safeName = fontName.replace(
-    new RegExp(`[${ASCII_CONTROL_CHARS}${BIDI_AND_ZERO_WIDTH_CHARS}:/\\\\]`, "gu"),
-    "_"
-  );
+  const safeName = safeFontEntryName(fontName);
   const encodedLines = assUuencode(data);
   return `fontname: ${safeName}\n${encodedLines.join("\n")}`;
 }

--- a/src/features/font-embed/font-collector.test.ts
+++ b/src/features/font-embed/font-collector.test.ts
@@ -11,6 +11,7 @@
 import { describe, it, expect } from "vitest";
 
 import { collectFonts, ensureLoaded, fontKeyLabel } from "./font-collector";
+import { convertTextCueSubtitleToAss } from "../hdr-convert/srt-converter";
 
 function makeASS(dialogue: string): string {
   return `[Script Info]
@@ -917,5 +918,44 @@ describe("font-collector font-variant + total-codepoint cap boundaries", () => {
     const run = makeUniqueGlyphRun(65536);
     const ass = makeMultiDialogueAss(Array.from({ length: 16 }, (_, i) => `{\\fnFam${i}}${run}`));
     expect(() => collectFonts(ass)).toThrow(/Too many codepoints across fonts/);
+  });
+});
+
+describe("font collection of literal brace escapes", () => {
+  it("collects escaped braces and their CJK text under the active font", async () => {
+    await ensureLoaded();
+    const usage = collectFonts(makeASS(String.raw`\{漢\}`));
+    expect(usage).toHaveLength(1);
+    expect(usage[0]!.key.family).toBe("Arial");
+    expect([...usage[0]!.codepoints]).toEqual([123, 0x6f22, 125]);
+  });
+
+  it("does not interpret escaped font or drawing tags, but still applies real overrides", async () => {
+    await ensureLoaded();
+    const usage = collectFonts(makeASS(String.raw`\{\fnOther\}漢\{\p1\}字{\fnActual}語`));
+    expect(usage.map((font) => font.key.family)).toEqual(["Arial", "Actual"]);
+    expect(usage[0]!.codepoints.has(0x6f22)).toBe(true);
+    expect(usage[0]!.codepoints.has(0x5b57)).toBe(true);
+    expect([...usage[1]!.codepoints]).toEqual([0x8a9e]);
+  });
+
+  it("treats a brace preceded by two backslashes as escaped, matching libass", async () => {
+    await ensureLoaded();
+    const usage = collectFonts(makeASS(String.raw`\\{漢\}`));
+    expect([...usage[0]!.codepoints]).toEqual([92, 123, 0x6f22, 125]);
+  });
+
+  it("does not leave drawing mode for escaped override-shaped text", async () => {
+    await ensureLoaded();
+    const usage = collectFonts(makeASS(String.raw`{\p1}\{\p0\}漢{\p0}字`));
+    expect([...usage[0]!.codepoints]).toEqual([0x5b57]);
+  });
+
+  it("retains glyphs from the application's SRT-to-ASS brace escaping", async () => {
+    await ensureLoaded();
+    const converted = convertTextCueSubtitleToAss("1\n00:00:01,000 --> 00:00:02,000\n{漢}\n");
+    const usage = collectFonts(converted.content);
+    expect(usage).toHaveLength(1);
+    expect([...usage[0]!.codepoints]).toEqual([123, 0x6f22, 125]);
   });
 });

--- a/src/features/font-embed/font-collector.ts
+++ b/src/features/font-embed/font-collector.ts
@@ -325,6 +325,12 @@ export function collectFontsWithParser(assContent: string, parser: AssParseFunct
 // karaoke songs rarely cross a few KB).
 const MAX_DIALOGUE_TEXT_LEN = 1_000_000;
 
+function decodePlainText(text: string): string {
+  return text.replace(/\\([Nnh{}])/g, (_, escaped: string) =>
+    escaped === "{" || escaped === "}" ? escaped : ""
+  );
+}
+
 function processDialogueText(
   text: string,
   eventStyle: FontKey,
@@ -351,7 +357,7 @@ function processDialogueText(
   let i = 0;
 
   while (i < text.length) {
-    if (text[i] === "{") {
+    if (text[i] === "{" && (i === 0 || text[i - 1] !== "\\")) {
       // Override block — parse tags until closing }
       const closeIdx = text.indexOf("}", i);
       if (closeIdx === -1) {
@@ -374,7 +380,7 @@ function processDialogueText(
           // intermediate string; for a 1 MB malformed-brace tail packed
           // with `\N` / `\n` / `\h`, three passes allocated ~3 MB of
           // intermediate strings. Single alternation is semantic-identical.
-          const cleanTail = tail.replace(/\\[Nnh]/g, "");
+          const cleanTail = decodePlainText(tail);
           if (cleanTail.length > 0) recordChars(current, cleanTail);
         }
         return;
@@ -395,7 +401,12 @@ function processDialogueText(
       i = closeIdx + 1;
     } else {
       // Plain text — find the next override block or end
-      const nextBrace = text.indexOf("{", i);
+      let nextBrace = text.indexOf("{", i);
+      // The converter emits libass's literal-brace escapes. Those braces
+      // cannot begin an override, even when another backslash precedes them.
+      while (nextBrace > 0 && text[nextBrace - 1] === "\\") {
+        nextBrace = text.indexOf("{", nextBrace + 1);
+      }
       const plainEnd = nextBrace >= 0 ? nextBrace : text.length;
       const plain = text.slice(i, plainEnd);
 
@@ -403,7 +414,7 @@ function processDialogueText(
       // combined alternation (one allocator pass, was
       // three sequential .replace calls) — see the malformed-brace
       // tail path above for the rationale.
-      const cleanText = plain.replace(/\\[Nnh]/g, "");
+      const cleanText = decodePlainText(plain);
 
       if (cleanText.length > 0 && !isDrawing) {
         recordChars(current, cleanText);

--- a/src/features/font-embed/font-embedder.test.ts
+++ b/src/features/font-embed/font-embedder.test.ts
@@ -27,6 +27,9 @@ vi.mock("../../lib/tauri-api", () => ({
 import {
   analyzeFonts,
   aggregateFonts,
+  FontAnalysisBudget,
+  MAX_BATCH_ANALYSIS_CODEPOINTS,
+  MAX_BATCH_ANALYSIS_VARIANTS,
   buildUserFontMap,
   embedFonts,
   userFontKey,
@@ -38,6 +41,7 @@ import {
   type FileAnalysis,
 } from "./font-embedder";
 import type { FontUsage, FontKey } from "./font-collector";
+import { MAX_FONT_DATA_SIZE } from "./ass-uuencode";
 
 const MINIMAL_ASS = `[Script Info]
 ScriptType: v4.00+
@@ -52,6 +56,53 @@ Format: Layer, Start, End, Style, Text
 Dialogue: 0,0:00:00.00,0:00:05.00,Default,Hello
 Dialogue: 0,0:00:05.00,0:00:10.00,Emphasis,Bold text
 `;
+
+describe("retained font analysis budget", () => {
+  const usage = (codepoints: Set<number>): FontUsage => ({
+    key: { family: "Arial", bold: false, italic: false },
+    codepoints,
+  });
+
+  it("counts repeated glyph sets across files and accepts exactly the batch boundary", () => {
+    const block = new Set(Array.from({ length: 65_536 }, (_, i) => i));
+    const budget = new FontAnalysisBudget();
+    for (let i = 0; i < 30; i++) budget.add([usage(block)]);
+    const remainder = MAX_BATCH_ANALYSIS_CODEPOINTS - 30 * block.size;
+    budget.add([usage(new Set(Array.from({ length: remainder }, (_, i) => i)))]);
+    expect(() => budget.add([usage(new Set([65]))])).toThrow(/retained codepoints/);
+    expect(() => budget.add([])).not.toThrow();
+  });
+
+  it("bounds variants independently of glyph diversity", () => {
+    const budget = new FontAnalysisBudget();
+    const empty = usage(new Set());
+    budget.add(Array.from({ length: MAX_BATCH_ANALYSIS_VARIANTS }, () => empty));
+    expect(() => budget.add([empty])).toThrow(/retained font variants/);
+    expect(() => budget.add([])).not.toThrow();
+  });
+
+  it("rejects an oversized aggregate before iterating or cloning any input set", () => {
+    class OversizedSet extends Set<number> {
+      override get size() {
+        return MAX_BATCH_ANALYSIS_CODEPOINTS + 1;
+      }
+      override [Symbol.iterator](): SetIterator<number> {
+        throw new Error("must not iterate");
+      }
+    }
+    const perFile = new Map<string, FileAnalysis>([
+      [
+        "input.ass",
+        {
+          content: "",
+          infos: [],
+          usages: [usage(new OversizedSet())],
+        },
+      ],
+    ]);
+    expect(() => aggregateFonts(perFile)).toThrow(/retained codepoints/);
+  });
+});
 
 describe("deriveEmbeddedPath / planEmbeddedOutputs", () => {
   it("keeps sibling output behavior unchanged for ASS and SSA inputs", () => {
@@ -991,6 +1042,27 @@ Dialogue: 0,0:00:05.00,0:00:10.00,Alt,你好
     expect(subsetFontMock).toHaveBeenCalledTimes(2);
   });
 
+  it("fails the file at the encoded budget before reading bytes or requesting another font", async () => {
+    const oversizedSubset = {
+      length: MAX_FONT_DATA_SIZE,
+      get 0() {
+        throw new Error("The rejected subset must not be encoded");
+      },
+    } as unknown as Uint8Array;
+    subsetFontMock.mockResolvedValue(oversizedSubset);
+    const first = makeInfo("First", "/fonts/first.ttf", 0);
+    const second = makeInfo("Second", "/fonts/second.ttf", 0);
+
+    await expect(
+      embedFonts(
+        SHELL_ASS,
+        [first, second],
+        [makeUsage("First", [0x41]), makeUsage("Second", [0x42])]
+      )
+    ).rejects.toThrow("encoded output limit");
+    expect(subsetFontMock).toHaveBeenCalledTimes(1);
+  });
+
   it("returns no-usage warnings instead of leaving them as transient progress only", async () => {
     subsetFontMock.mockResolvedValue(new Uint8Array([1, 2, 3, 4]));
 
@@ -1182,6 +1254,7 @@ describe("aggregateFonts — cross-file union + cap", () => {
     // the one aggregateFonts necessarily builds for its result.
     const key: FontKey = { family: "Arial", bold: false, italic: false };
     const lazyCodepoints = {
+      size: MAX_AGGREGATE_CODEPOINTS_PER_KEY + 1,
       *[Symbol.iterator](): Generator<number> {
         for (let i = 0; i <= MAX_AGGREGATE_CODEPOINTS_PER_KEY; i++) yield i;
       },

--- a/src/features/font-embed/font-embedder.ts
+++ b/src/features/font-embed/font-embedder.ts
@@ -13,7 +13,7 @@ import {
   type FontUsage,
   type FontKey,
 } from "./font-collector";
-import { buildFontEntry } from "./ass-uuencode";
+import { FontSectionBuilder } from "./ass-uuencode";
 import {
   findSystemFont,
   lookupFontFamily,
@@ -443,10 +443,44 @@ export interface FileAnalysis {
 // coverage count. Exported so `font-embedder.test.ts` can pin the cap.
 export const MAX_AGGREGATE_CODEPOINTS_PER_KEY = 1_000_000;
 
+export const MAX_BATCH_ANALYSIS_CODEPOINTS = 2_000_000;
+export const MAX_BATCH_ANALYSIS_VARIANTS = 5_000;
+
+/** Counts retained per-file sets, including repeated glyphs in different files. */
+export class FontAnalysisBudget {
+  private codepoints = 0;
+  private variants = 0;
+
+  add(usages: readonly FontUsage[]): void {
+    const nextVariants = this.variants + usages.length;
+    if (nextVariants > MAX_BATCH_ANALYSIS_VARIANTS) {
+      throw new Error(
+        `Font analysis exceeds ${MAX_BATCH_ANALYSIS_VARIANTS} retained font variants; select fewer subtitle files`
+      );
+    }
+    let nextCodepoints = this.codepoints;
+    for (const usage of usages) {
+      const count = usage.codepoints.size;
+      if (!Number.isSafeInteger(count) || count < 0)
+        throw new Error("Invalid font codepoint count");
+      nextCodepoints += count;
+      if (nextCodepoints > MAX_BATCH_ANALYSIS_CODEPOINTS) {
+        throw new Error(
+          `Font analysis exceeds ${MAX_BATCH_ANALYSIS_CODEPOINTS} retained codepoints; select fewer subtitle files`
+        );
+      }
+    }
+    this.variants = nextVariants;
+    this.codepoints = nextCodepoints;
+  }
+}
+
 export function aggregateFonts(perFile: Map<string, FileAnalysis>): {
   infos: FontInfo[];
   usages: FontUsage[];
 } {
+  const budget = new FontAnalysisBudget();
+  for (const analysis of perFile.values()) budget.add(analysis.usages);
   // Union codepoints per font key across all files, capped per key. The
   // per-file caps in font-collector (MAX_CODEPOINTS_PER_VARIANT,
   // MAX_TOTAL_CODEPOINTS) bound each file's contribution but NOT their union
@@ -547,7 +581,7 @@ function embeddedOutputName(inputPath: string): {
  *
  * Why a derived path instead of a per-file native save dialog: those
  * dialogs are blocking and don't scale to N files. Derived paths give
- * the user a single overwrite-confirm gate via `countExistingFiles`
+ * the user a single overwrite-confirm gate for existing outputs
  * before the batch begins.
  */
 export function deriveEmbeddedPath(
@@ -663,7 +697,7 @@ export async function embedFonts(
   isCancelled?: () => boolean,
   t?: (key: string, ...args: (string | number)[]) => string
 ): Promise<EmbedFontsResult | null> {
-  const fontEntries: string[] = [];
+  const fontSection = new FontSectionBuilder();
   const warnings: string[] = [];
   const fontStyleLabels = t
     ? { bold: t("font_style_bold"), italic: t("font_style_italic") }
@@ -894,7 +928,7 @@ export async function embedFonts(
           });
           continue;
         }
-        fontEntries.push(buildFontEntry(aliasFontName, aliasSubsetData));
+        fontSection.add(aliasFontName, aliasSubsetData);
       }
       continue; // Group handled; advance to next face.
     }
@@ -958,7 +992,7 @@ export async function embedFonts(
     }
 
     // Build the [Fonts] entry
-    fontEntries.push(buildFontEntry(fontName, subsetData));
+    fontSection.add(fontName, subsetData);
   }
 
   if (isCancelled?.()) {
@@ -974,7 +1008,7 @@ export async function embedFonts(
   // assertAssShape so the contract is "valid ASS in, valid ASS out
   // (or throw)" regardless of font count.
   assertAssShape(assContent);
-  if (fontEntries.length === 0) {
+  if (fontSection.count === 0) {
     // zero-font early-return returns
     // `assContent` verbatim — no [Fonts] insertion means no
     // separator normalization either. The non-zero path below
@@ -991,12 +1025,12 @@ export async function embedFonts(
   }
 
   // Build [Fonts] section (no leading \n — insertFontsSection handles the separator)
-  const fontsSection = `[Fonts]\n${fontEntries.join("\n\n")}\n`;
+  const fontsSection = fontSection.build();
 
   // Insert [Fonts] section into ASS file
   return {
     content: insertFontsSection(assContent, fontsSection),
-    embeddedCount: fontEntries.length,
+    embeddedCount: fontSection.count,
     warnings,
   };
 }

--- a/src/features/hdr-convert/HdrConvert.tsx
+++ b/src/features/hdr-convert/HdrConvert.tsx
@@ -34,7 +34,8 @@ import { useFileContext } from "../../lib/FileContext";
 import type { Status } from "../../lib/StatusContext";
 import { useTabStatus } from "../../lib/useTabStatus";
 import { useFolderDrop } from "../../lib/useFolderDrop";
-import { countExistingFiles } from "../../lib/output-collisions";
+import { findExistingOutputKeys } from "../../lib/output-collisions";
+import { assertOutputDoesNotReplaceSelectedInput } from "../../lib/path-validation";
 import { useClickOutside } from "../../lib/useClickOutside";
 import { useLogPanel } from "../../lib/useLogPanel";
 import { LogPanel } from "../../lib/LogPanel";
@@ -93,7 +94,8 @@ const COMMON_FONTS_SET = new Set(COMMON_FONTS);
 
 export default function HdrConvert() {
   const { t } = useI18n();
-  const { hdrFiles, setHdrFiles, clearFile, isFileInUse } = useFileContext();
+  const { hdrFiles, setHdrFiles, clearFile, isFileInUse, findLoadedInputConflictKeys } =
+    useFileContext();
   const [eotf, setEotf] = useState<Eotf>("PQ");
   const [brightness, setBrightness] = useState(DEFAULT_BRIGHTNESS);
   const [brightnessText, setBrightnessText] = useState(String(DEFAULT_BRIGHTNESS));
@@ -319,6 +321,10 @@ export default function HdrConvert() {
     // / loop throw) clears it.
     if (busyRef.current) return;
     busyRef.current = true;
+    pickGenRef.current += 1;
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setProcessing(true);
     try {
       // Validate brightness
       if (brightness < MIN_BRIGHTNESS || brightness > MAX_BRIGHTNESS) {
@@ -327,46 +333,42 @@ export default function HdrConvert() {
       }
 
       const paths = hdrFiles.filePaths;
+      const selectedInputKeys = new Set(paths.map(normalizeOutputKey));
 
-      // Pre-flight overwrite check. Template-derived output paths are
-      // deterministic — re-clicking Convert (e.g., the user came back to
-      // the window after minimizing and forgot the run already finished)
-      // would silently overwrite previous outputs. Stat each projected
-      // path; if any already exist, surface a single ask() dialog before
-      // entering the busy state. Failed-to-resolve paths skip pre-flight
-      // (the main loop will log per-file errors as before).
-      // silent skip on resolve failure is
-      // intentional and bounded. The pre-flight's job is to count
-      // existing outputs for the overwrite-confirm dialog; an
-      // unresolvable path doesn't contribute to that count by
-      // construction (no projected output → can't possibly collide).
-      // The main processing loop below re-runs `resolveOutputPath`
-      // per file inside its own try/catch, surfacing the resolution
-      // error with full file context (which the dialog summary
-      // couldn't fit anyway). Collecting these errors here for a
-      // pre-dialog surface would mean a second display shape ("X
-      // files could not be resolved, Y files would be overwritten")
-      // that adds UI complexity without telling the user anything
-      // new — the unresolvable paths will surface as red error rows
-      // in the log panel once processing starts. Skip is the right
-      // failure mode at this layer.
+      // Invalid targets are reported per file; selected sources never enter overwrite preflight.
       const projectedOutputs: string[] = [];
       for (const filePath of paths) {
         try {
-          projectedOutputs.push(resolveOutputPath(filePath, activeTemplate, eotf));
+          const outputPath = resolveOutputPath(filePath, activeTemplate, eotf);
+          assertOutputDoesNotReplaceSelectedInput(outputPath, selectedInputKeys);
+          projectedOutputs.push(outputPath);
         } catch {
-          // See pre-loop WHY comment above: intentional silent skip,
-          // not an oversight. Main loop logs per-file with context.
+          // Report this target with its input context in the processing loop.
         }
       }
+      let existingOutputs: ReadonlySet<string>;
+      let conflictingOutputs: ReadonlySet<string>;
       try {
-        const existingCount = await countExistingFiles(projectedOutputs);
+        conflictingOutputs = await findLoadedInputConflictKeys(projectedOutputs, controller.signal);
+        if (controller.signal.aborted) {
+          setLastActionResult("cancelled");
+          return;
+        }
+        existingOutputs = await findExistingOutputKeys(
+          projectedOutputs.filter((path) => !conflictingOutputs.has(normalizeOutputKey(path)))
+        );
+        if (controller.signal.aborted) {
+          addLog(t("msg_cancelled"), "info");
+          setLastActionResult("cancelled");
+          return;
+        }
+        const existingCount = existingOutputs.size;
         if (existingCount > 0) {
           const confirmed = await ask(t("msg_overwrite_confirm", existingCount, paths.length), {
             title: t("dialog_overwrite_title"),
             kind: "warning",
           });
-          if (!confirmed) {
+          if (!confirmed || controller.signal.aborted) {
             addLog(t("msg_cancelled"), "info");
             setLastActionResult("cancelled");
             return;
@@ -378,12 +380,6 @@ export default function HdrConvert() {
         return;
       }
 
-      // Construct the AbortController at the boundary into busy state —
-      // pre-flight bail-out paths must not leak unaborted controllers.
-      // busyRef above is the synchronous gate for double clicks; the
-      // controller is only allocated once we're committed to a run.
-      abortRef.current = new AbortController();
-      setProcessing(true);
       setProgress({ processed: 0, total: paths.length });
 
       try {
@@ -436,6 +432,8 @@ export default function HdrConvert() {
             let outputPath: string;
             try {
               outputPath = resolveOutputPath(filePath, activeTemplate, eotf);
+              assertOutputDoesNotReplaceSelectedInput(outputPath, selectedInputKeys);
+              assertOutputDoesNotReplaceSelectedInput(outputPath, conflictingOutputs);
             } catch (e) {
               addLog(t("msg_skipped", fileName, sanitizeError(e)), "error");
               continue;
@@ -503,7 +501,7 @@ export default function HdrConvert() {
             if (abortRef.current?.signal.aborted) break;
 
             // Write output
-            await writeText(outputPath, assContent);
+            await writeText(outputPath, assContent, existingOutputs.has(normalizedOut));
             // FontEmbed and BatchRename also sanitize display names
             // before logging. fileNameFromPath already strips
             // C0/C1/DEL + BiDi via stripUnicodeControls, so this is
@@ -546,14 +544,15 @@ export default function HdrConvert() {
           setLastActionResult("error");
         }
       } finally {
-        setProcessing(false);
         setProgress(null);
       }
     } finally {
+      setProcessing(false);
       busyRef.current = false;
     }
   }, [
     hdrFiles,
+    findLoadedInputConflictKeys,
     processing,
     brightnessInvalid,
     templateInvalid,
@@ -697,7 +696,7 @@ export default function HdrConvert() {
           className="flex-none px-5 rounded-lg font-medium text-sm transition-colors"
           style={{
             background: processing ? "var(--bg-input)" : "var(--accent)",
-            color: processing ? "var(--text-muted)" : "white",
+            color: processing ? "var(--text-muted)" : "var(--accent-text)",
             height: "38px",
           }}
         >
@@ -724,7 +723,7 @@ export default function HdrConvert() {
           className="flex-none px-6 rounded-lg font-medium text-sm transition-colors"
           style={{
             background: convertDisabled ? "var(--bg-input)" : "var(--accent)",
-            color: convertDisabled ? "var(--text-muted)" : "white",
+            color: convertDisabled ? "var(--text-muted)" : "var(--accent-text)",
             height: "38px",
             minWidth: "120px",
           }}

--- a/src/features/hdr-convert/ass-processor.test.ts
+++ b/src/features/hdr-convert/ass-processor.test.ts
@@ -133,20 +133,20 @@ describe("processAssContent — inline color tags", () => {
     expect(output).not.toContain("00FFFFFF");
   });
 
-  it("ignores 7-digit hex values (invalid ASS format)", () => {
+  it("leaves the unsupported seven-digit inline alpha spelling unchanged", () => {
     const input = makeAss("{\\1c&HFFFFFFF&}Hello");
     const output = processAssContent(input, 203, "PQ");
-    // 7-digit should pass through — regex matches exactly 6 or 8 digits.
+    // Keep this unsupported inline alpha spelling intact, without converting a prefix.
     // Assert on the EXACT token so the test fails if the transformer ever
     // accidentally matches 6/8 digits inside a 7-digit run; `toContain`
     // alone would still pass with a leftover 6-digit match.
     expect(output).toContain("{\\1c&HFFFFFFF&}");
   });
 
-  it("ignores short color values (< 6 hex digits)", () => {
+  it("transforms short color values without requiring leading zeros", () => {
     const input = makeAss("{\\1c&HFF&}Hello");
     const output = processAssContent(input, 203, "PQ");
-    expect(output).toContain("{\\1c&HFF&}Hello");
+    expect(output).toContain("{\\1c&H385388&}Hello");
   });
 
   it("leaves non-color tags unchanged", () => {
@@ -225,5 +225,62 @@ describe("processAssContent — pre-split line-count probe", () => {
     // probe runs unconditionally and slows the small-file fast path.
     const small = ["[Script Info]", "ScriptType: v4.00+", "", "[Events]", ""].join("\n");
     expect(() => processAssContent(small, 1000, "PQ")).not.toThrow();
+  });
+});
+
+describe("equivalent color representations", () => {
+  it.each(["0", "F", "FF", "F00", "FF00", "1FF00"])(
+    "converts inline %s exactly like its six-digit form",
+    (hex) => {
+      expect(processAssContent(makeAss(`{\\c&H${hex}&}text`))).toBe(
+        processAssContent(makeAss(`{\\c&H${hex.padStart(6, "0")}&}text`))
+      );
+    }
+  );
+
+  it.each(["0", "F", "FF", "F00", "FF00", "1FF00", "FFF0000"])(
+    "converts style hex %s exactly like its eight-digit form",
+    (hex) => {
+      const colors = `&h${hex},&H0,&H0,&H0`;
+      const canonical = `&H${hex.padStart(8, "0")},&H00000000,&H00000000,&H00000000`;
+      expect(processAssContent(makeAss("text", colors))).toBe(
+        processAssContent(makeAss("text", canonical))
+      );
+    }
+  );
+
+  function makeSsa(color: string): string {
+    return [
+      "[Script Info]",
+      "ScriptType: v4.00",
+      "[V4 Styles]",
+      "Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, TertiaryColour, BackColour, Bold, Italic, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, AlphaLevel, Encoding",
+      `Style: Default,Arial,20,${color},${color},0,${color},0,0,1,2,0,2,10,10,10,0,1`,
+      "[Events]",
+      "Format: Marked, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text",
+      "Dialogue: Marked=0,0:00:01.00,0:00:02.00,Default,,0,0,0,,text",
+    ].join("\n");
+  }
+
+  it.each([0, 255, 16777215, -2147483648, 4294967295])(
+    "converts SSA integer color %s with its 32-bit alpha intact",
+    (color) => {
+      const expected = makeSsa(`&H${(color >>> 0).toString(16).padStart(8, "0")}`);
+      expect(processAssContent(makeSsa(String(color)))).toBe(processAssContent(expected));
+    }
+  );
+
+  it.each(["4294967296", "-2147483649", "99999999999", "12x", "&H123456789"])(
+    "preserves out-of-range or malformed style color %s",
+    (color) => {
+      expect(processAssContent(makeSsa(color))).toBe(makeSsa(color));
+    }
+  );
+
+  it("does not convert prefixes of overlong or malformed inline colors", () => {
+    for (const hex of ["123456789", "FFFFFG", ""]) {
+      const tag = `{\\c&H${hex}&}text`;
+      expect(processAssContent(makeAss(tag))).toContain(tag);
+    }
   });
 });

--- a/src/features/hdr-convert/ass-processor.ts
+++ b/src/features/hdr-convert/ass-processor.ts
@@ -103,8 +103,8 @@ export function parseAssColor(assColor: string): {
   // inputs pad with leading zeros (alpha defaults opaque). Inputs LONGER than
   // 8 are NOT rejected: padStart is a no-op and the slices below take the
   // FIRST 8 chars, silently ignoring the overflow. This is a caller-trusted
-  // contract, not a guard — every production caller bounds the input to 6 or
-  // 8 hex upstream (the color-tag matchers + the 6/8-hex GUI color field). A
+  // contract, not a guard — production callers bound color inputs to at most
+  // 8 hex digits or normalize a 32-bit integer first. A
   // future caller passing >8 hex would get the leading-8 prefix as
   // wrong-but-valid; validate at that caller if one ever appears.
   const stripped = assColor.replace(/^&H/i, "").padStart(8, "0");
@@ -140,26 +140,21 @@ function transformColorString(assColor: string, targetBrightness: number, eotf: 
   return formatAssColor(hr, hg, hb, alpha);
 }
 
-// Matches: \c&HBBGGRR, \1c&HBBGGRR, \2c&HAABBGGRR, etc.
-// Groups: (1) prefix like "\c&H" or "\1c&H", (2) 6 or 8 hex digits.
-// Strict 6/8 length is per ASS spec — any other count (e.g. a 7-digit
-// run from a malformed file) is intentionally left un-transformed
-// rather than risk corrupting unknown content.
-// Lookahead ensures the color ends at a valid ASS delimiter. `\r\n` are
-// included so a color tag at end-of-line (within a multi-line ASS input
-// before line-splitting) still matches instead of being left untransformed.
-//
-// Hoisted to module scope so a 50k-dialogue file doesn't re-compile this
-// regex per line.
-const COLOR_TAG_RE = /(\\[0-9]?c&H)([0-9a-fA-F]{6}|[0-9a-fA-F]{8})(?=[&}),\\\r\n]|$)/g;
+// FFmpeg emits short BGR values without leading zeros. Keep the existing
+// eight-digit alpha extension, but do not match prefixes of longer values.
+const COLOR_TAG_RE = /(\\[0-9]?c&H)([0-9a-fA-F]{1,6}|[0-9a-fA-F]{8})(?=[&}),\\\r\n]|$)/g;
+const COLOR_FIELD_RE = /^&H[0-9A-Fa-f]{1,8}$/i;
+const DECIMAL_COLOR_FIELD_RE = /^[+-]?\d{1,10}$/;
 
-// hoisted from inside transformStyleLine
-// to match COLOR_TAG_RE's module-scope precedent. Previously the
-// regex literal compiled per style-line; with thousands of styled
-// dialogues a per-call recompile is wasted work, and `no-misleading-
-// character-class` / consistency reads better when the two regexes
-// sit side by side.
-const COLOR_FIELD_RE = /^&H(?:[0-9A-Fa-f]{6}|[0-9A-Fa-f]{8})$/;
+function normalizeStyleColor(value: string): string | null {
+  if (COLOR_FIELD_RE.test(value)) return value;
+  if (!DECIMAL_COLOR_FIELD_RE.test(value)) return null;
+  const color = Number(value);
+  if (color < -2147483648 || color > 4294967295) return null;
+  // SSA stores colors as signed or unsigned 32-bit integers; canonical hex
+  // preserves their bit pattern, including alpha, through the shared converter.
+  return `&H${(color >>> 0).toString(16).padStart(8, "0")}`;
+}
 
 /**
  * Transform inline color tags in a dialogue event text.
@@ -204,23 +199,13 @@ function transformStyleLine(
     throw new Error(`Style line has too many fields: ${fields.length} (max ${MAX_STYLE_FIELDS})`);
   }
 
-  // Only transform fields that actually look like ASS colors. A
-  // crafted Format line with empty middle fields would shift the index
-  // we computed from the Format header against this Style line; if the
-  // shifted slot lands on something that isn't a color, transformColorString
-  // would produce garbage and we'd silently corrupt the output. Validate
-  // the `&Hxxxxxx` or `&Hxxxxxxxx` shape (6 or 8 hex digits — RGB or
-  // ABGR with alpha) before transforming. A previous `{2,8}` form
-  // accepted 2-, 3-, 4-, 5-, and 7-digit values that the inline
-  // `\cN&Hxxxxxx` tag regex (`COLOR_TAG_RE`) correctly
-  // rejected — the asymmetry let a malformed Style field through that
-  // wouldn't have been transformed if inlined as `\c&H...`. The regex
-  // now lives at module scope — see `COLOR_FIELD_RE` definition.
+  // Normalize only declared color fields; unrelated numeric metadata stays intact.
   for (const idx of styleColorIndices) {
     if (idx < fields.length && fields[idx]) {
       const raw = fields[idx];
       const trimmed = raw.trim();
-      if (COLOR_FIELD_RE.test(trimmed)) {
+      const color = normalizeStyleColor(trimmed);
+      if (color !== null) {
         // preserve any leading/trailing whitespace
         // padding from the original field so byte-for-byte file
         // structure (excluding the color hex itself) survives the
@@ -232,7 +217,7 @@ function transformStyleLine(
         const trailingLen = raw.length - raw.trimEnd().length;
         const leading = raw.slice(0, leadingLen);
         const trailing = trailingLen > 0 ? raw.slice(raw.length - trailingLen) : "";
-        const transformed = transformColorString(trimmed, targetBrightness, eotf);
+        const transformed = transformColorString(color, targetBrightness, eotf);
         fields[idx] = `${leading}${transformed}${trailing}`;
       }
     }

--- a/src/features/hdr-convert/srt-converter.test.ts
+++ b/src/features/hdr-convert/srt-converter.test.ts
@@ -491,3 +491,40 @@ describe("SRT pipeline integration — composed (braces + color tags)", () => {
     expect(doc).toContain("green");
   });
 });
+
+describe("unknown HTML stripping", () => {
+  function convert(text: string): string {
+    return convertTextCueSubtitleToAss(`1\n00:00:01,000 --> 00:00:02,000\n${text}\n`)
+      .content.split("\n")
+      .at(-1)!;
+  }
+
+  it("strips unknown complete tags while keeping supported tags and unmatched tails", () => {
+    expect(convert("<unknown>before</unknown><b>bold</b><br>after <<unfinished")).toBe(
+      "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,before{\\b1}bold{\\b0}\\Nafter <<unfinished"
+    );
+  });
+
+  it("retains the existing first-opener-to-next-closer behavior", () => {
+    expect(convert("a<outer<inner>b<>c>tail<")).toBe(
+      "Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,abc>tail<"
+    );
+  });
+
+  it("handles repeated unmatched openers at the accepted cue boundary across a batch", () => {
+    const text = "<".repeat(64000);
+    const input = Array.from(
+      { length: 8 },
+      (_, i) => `${i + 1}\n00:00:01,000 --> 00:00:02,000\n${text}`
+    ).join("\n\n");
+    const result = convertTextCueSubtitleToAss(input);
+    expect(result.skippedCount).toBe(0);
+    const dialogues = result.content.split("\n").filter((line) => line.startsWith("Dialogue:"));
+    expect(dialogues).toHaveLength(8);
+    for (const line of dialogues)
+      expect(line).toBe(`Dialogue: 0,0:00:01.00,0:00:02.00,Default,,0,0,0,,${text}`);
+    expect(() => convertTextCueSubtitleToAss(`1\n00:00:01,000 --> 00:00:02,000\n${text}<`)).toThrow(
+      /64000-character limit/
+    );
+  });
+});

--- a/src/features/hdr-convert/srt-converter.ts
+++ b/src/features/hdr-convert/srt-converter.ts
@@ -242,6 +242,23 @@ export const DEFAULT_STYLE: StyleConfig = {
 
 // ── ASS Document Builder ─────────────────────────────────
 
+function stripUnknownHtmlTags(text: string): string {
+  const parts: string[] = [];
+  let cursor = 0;
+  while (cursor < text.length) {
+    const open = text.indexOf("<", cursor);
+    if (open < 0) break;
+    const close = text.indexOf(">", open + 1);
+    // An unmatched opener leaves the entire tail literal. Retrying at each
+    // following '<' would repeatedly scan that tail and make the work quadratic.
+    if (close < 0) break;
+    parts.push(text.slice(cursor, open));
+    cursor = close + 1;
+  }
+  parts.push(text.slice(cursor));
+  return parts.join("");
+}
+
 /**
  * Build a minimal ASS document from parsed subtitle entries.
  * This creates a properly formatted ASS file with styles and events.
@@ -306,26 +323,27 @@ export function buildAssDocument(
     // `{\1c&H…}` tags into literal text, silently defeating SRT→HDR color
     // conversion. See escapeSrtUserText's docstring for the required
     // pipeline ordering.
-    const cleanText = entry.text
-      // Normalize ALL line-break variants (LF, CRLF, bare CR, NEL,
-      // LINE SEPARATOR U+2028, PARAGRAPH SEPARATOR U+2029) to the ASS
-      // `\N` hard break. A bare `\r` would otherwise break the
-      // one-line-per-Dialogue invariant; U+2028 smuggles a line break
-      // past naive renderers.
-      .replace(/\r\n|\r|\n|\u0085|\u2028|\u2029/g, "\\N")
-      // Convert `<br>` / `<br/>` to ASS hard break BEFORE the
-      // unknown-tag strip below. SRT is HTML-ish in many real-world
-      // exports (legacy tools, fan-sub edits); without this step
-      // intentional line breaks get silently absorbed by the
-      // `<[^>]*>` strip pass and the cue collapses to a single line.
-      .replace(/<br\s*\/?>/gi, "\\N")
-      .replace(/<b>/gi, "{\\b1}")
-      .replace(/<\/b>/gi, "{\\b0}")
-      .replace(/<i>/gi, "{\\i1}")
-      .replace(/<\/i>/gi, "{\\i0}")
-      .replace(/<u>/gi, "{\\u1}")
-      .replace(/<\/u>/gi, "{\\u0}")
-      .replace(/<[^>]*>/g, ""); // strip remaining unknown HTML tags
+    const cleanText = stripUnknownHtmlTags(
+      entry.text
+        // Normalize ALL line-break variants (LF, CRLF, bare CR, NEL,
+        // LINE SEPARATOR U+2028, PARAGRAPH SEPARATOR U+2029) to the ASS
+        // `\N` hard break. A bare `\r` would otherwise break the
+        // one-line-per-Dialogue invariant; U+2028 smuggles a line break
+        // past naive renderers.
+        .replace(/\r\n|\r|\n|\u0085|\u2028|\u2029/g, "\\N")
+        // Convert `<br>` / `<br/>` to ASS hard break BEFORE the
+        // unknown-tag strip below. SRT is HTML-ish in many real-world
+        // exports (legacy tools, fan-sub edits); without this step
+        // intentional line breaks get silently absorbed by the
+        // `<[^>]*>` strip pass and the cue collapses to a single line.
+        .replace(/<br\s*\/?>/gi, "\\N")
+        .replace(/<b>/gi, "{\\b1}")
+        .replace(/<\/b>/gi, "{\\b0}")
+        .replace(/<i>/gi, "{\\i1}")
+        .replace(/<\/i>/gi, "{\\i0}")
+        .replace(/<u>/gi, "{\\u1}")
+        .replace(/<\/u>/gi, "{\\u0}")
+    );
     lines.push(`Dialogue: 0,${startTime},${endTime},Default,,0,0,0,,${cleanText}`);
   }
 

--- a/src/features/style-edit/StyleEdit.tsx
+++ b/src/features/style-edit/StyleEdit.tsx
@@ -746,7 +746,7 @@ export default function StyleEdit() {
           className="flex-none px-5 rounded-lg font-medium text-sm transition-colors"
           style={{
             background: analyzing || writing ? "var(--bg-input)" : "var(--accent)",
-            color: analyzing || writing ? "var(--text-muted)" : "white",
+            color: analyzing || writing ? "var(--text-muted)" : "var(--accent-text)",
             height: "38px",
           }}
         >
@@ -769,7 +769,7 @@ export default function StyleEdit() {
           className="flex-none px-6 rounded-lg font-medium text-sm transition-colors"
           style={{
             background: writeDisabled ? "var(--accent-disabled-bg)" : "var(--accent)",
-            color: writeDisabled ? "var(--accent-disabled-text)" : "white",
+            color: writeDisabled ? "var(--accent-disabled-text)" : "var(--accent-text)",
             height: "38px",
             minWidth: "120px",
           }}

--- a/src/features/timing-shift/TimingShift.tsx
+++ b/src/features/timing-shift/TimingShift.tsx
@@ -21,7 +21,8 @@ import { useFileContext } from "../../lib/FileContext";
 import type { Status } from "../../lib/StatusContext";
 import { useTabStatus } from "../../lib/useTabStatus";
 import { useFolderDrop } from "../../lib/useFolderDrop";
-import { countExistingFiles } from "../../lib/output-collisions";
+import { findExistingOutputKeys } from "../../lib/output-collisions";
+import { assertOutputDoesNotReplaceSelectedInput } from "../../lib/path-validation";
 import { useClickOutside } from "../../lib/useClickOutside";
 import { useLogPanel } from "../../lib/useLogPanel";
 import { LogPanel } from "../../lib/LogPanel";
@@ -127,7 +128,8 @@ function PreviewRow({
 
 export default function TimingShift() {
   const { t } = useI18n();
-  const { timingFiles, setTimingFiles, clearFile, isFileInUse } = useFileContext();
+  const { timingFiles, setTimingFiles, clearFile, isFileInUse, findLoadedInputConflictKeys } =
+    useFileContext();
 
   const [previewState, setPreviewState] = useState<TimingPreviewState>(() =>
     emptyTimingPreviewState()
@@ -430,33 +432,48 @@ export default function TimingShift() {
     // for the same idiom. Released in the outer finally below.
     if (busyRef.current) return;
     busyRef.current = true;
+    pickGenRef.current += 1;
+    const controller = new AbortController();
+    abortRef.current = controller;
+    setBusy(true);
     try {
       const paths = filePaths;
+      const selectedInputKeys = new Set(paths.map(normalizeOutputKey));
 
-      // Pre-flight overwrite check — same project-wide pattern as HDR
-      // Convert. Template-derived output paths would silently overwrite
-      // a previous run otherwise; one ask() before the batch is the
-      // single safety net. Per-file try mirrors HDR Convert's shape: a
-      // single bad path must not fail the entire batch with no
-      // attribution — resolution failures fall through to the main
-      // loop's per-file error logging and the pre-flight existence
-      // check just skips them.
+      // Invalid targets are reported per file; selected sources never enter overwrite preflight.
       const projectedOutputs: string[] = [];
       for (const filePath of paths) {
         try {
-          projectedOutputs.push(deriveShiftedPath(filePath));
+          const outputPath = deriveShiftedPath(filePath);
+          assertOutputDoesNotReplaceSelectedInput(outputPath, selectedInputKeys);
+          projectedOutputs.push(outputPath);
         } catch {
           // Re-thrown with per-file context inside the main loop below.
         }
       }
+      let existingOutputs: ReadonlySet<string>;
+      let conflictingOutputs: ReadonlySet<string>;
       try {
-        const existingCount = await countExistingFiles(projectedOutputs);
+        conflictingOutputs = await findLoadedInputConflictKeys(projectedOutputs, controller.signal);
+        if (controller.signal.aborted) {
+          setLastActionResult("cancelled");
+          return;
+        }
+        existingOutputs = await findExistingOutputKeys(
+          projectedOutputs.filter((path) => !conflictingOutputs.has(normalizeOutputKey(path)))
+        );
+        if (controller.signal.aborted) {
+          addLog(t("msg_timing_cancelled"), "info");
+          setLastActionResult("cancelled");
+          return;
+        }
+        const existingCount = existingOutputs.size;
         if (existingCount > 0) {
           const confirmed = await ask(t("msg_overwrite_confirm", existingCount, paths.length), {
             title: t("dialog_overwrite_title"),
             kind: "warning",
           });
-          if (!confirmed) {
+          if (!confirmed || controller.signal.aborted) {
             addLog(t("msg_timing_cancelled"), "info");
             setLastActionResult("cancelled");
             return;
@@ -468,10 +485,6 @@ export default function TimingShift() {
         return;
       }
 
-      // Construct AbortController at the boundary into busy state — see
-      // HdrConvert::handleConvert for rationale.
-      abortRef.current = new AbortController();
-      setBusy(true);
       setProgress({ processed: 0, total: paths.length });
 
       try {
@@ -510,6 +523,8 @@ export default function TimingShift() {
 
           try {
             const outputPath = deriveShiftedPath(filePath);
+            assertOutputDoesNotReplaceSelectedInput(outputPath, selectedInputKeys);
+            assertOutputDoesNotReplaceSelectedInput(outputPath, conflictingOutputs);
 
             // Within-batch dedup. Two inputs that resolve to the same
             // output path (different paths on disk pointing at the same
@@ -555,7 +570,7 @@ export default function TimingShift() {
 
             if (abortRef.current?.signal.aborted) break;
 
-            await writeText(outputPath, result.content);
+            await writeText(outputPath, result.content, existingOutputs.has(normalizedOut));
             // Match the sibling features: sanitize output display names
             // before writing them into the visible log.
             const outName = sanitizeForDialog(fileNameFromPath(outputPath));
@@ -586,15 +601,16 @@ export default function TimingShift() {
           setLastActionResult("error");
         }
       } finally {
-        setBusy(false);
         setProgress(null);
       }
     } finally {
+      setBusy(false);
       busyRef.current = false;
     }
   }, [
     fileCount,
     filePaths,
+    findLoadedInputConflictKeys,
     effectiveOffsetMs,
     thresholdMs,
     thresholdInvalid,
@@ -755,7 +771,7 @@ export default function TimingShift() {
           className="flex-none px-5 rounded-lg font-medium text-sm transition-colors"
           style={{
             background: busy ? "var(--bg-input)" : "var(--accent)",
-            color: busy ? "var(--text-muted)" : "white",
+            color: busy ? "var(--text-muted)" : "var(--accent-text)",
             height: "38px",
           }}
         >
@@ -782,7 +798,7 @@ export default function TimingShift() {
           className="flex-none px-6 rounded-lg font-medium text-sm transition-colors"
           style={{
             background: saveDisabled ? "var(--bg-input)" : "var(--accent)",
-            color: saveDisabled ? "var(--text-muted)" : "white",
+            color: saveDisabled ? "var(--text-muted)" : "var(--accent-text)",
             height: "38px",
             minWidth: "120px",
           }}

--- a/src/frontend-notices.d.ts
+++ b/src/frontend-notices.d.ts
@@ -1,0 +1,4 @@
+declare module "virtual:frontend-notices" {
+  const text: string;
+  export default text;
+}

--- a/src/i18n/strings.ts
+++ b/src/i18n/strings.ts
@@ -126,8 +126,8 @@ export const strings: Record<string, StringEntry> = {
   licenses_open: { en: "Licenses", zh: "许可证" },
   licenses_title: { en: "About & Licenses", zh: "关于与许可证" },
   licenses_intro: {
-    en: "Offline copies of the application license and notices for bundled fonts and adapted interface icons.",
-    zh: "应用许可证、捆绑字体及改编界面图标声明的离线副本。",
+    en: "Offline copies of the application license and notices for JavaScript dependencies, bundled fonts, and adapted interface icons.",
+    zh: "应用许可证、JavaScript 依赖、捆绑字体及改编界面图标声明的离线副本。",
   },
   licenses_exact_text_note: {
     en: "Legal texts below are embedded verbatim in English. Chinese UI text is an informal navigation aid, not a legal translation.",
@@ -151,6 +151,10 @@ export const strings: Record<string, StringEntry> = {
   licenses_feather_summary: {
     en: "Some interface glyphs are adapted from Feather Icons. Copyright © 2013–2023 Cole Bemis.",
     zh: "部分界面图标改编自 Feather Icons。版权所有 © 2013–2023 Cole Bemis。",
+  },
+  licenses_frontend_summary: {
+    en: "Complete license texts for the JavaScript dependencies and generated runtime helpers included with this app. Native dependency attribution is listed separately in the README.",
+    zh: "随应用提供的 JavaScript 依赖与生成的运行时辅助代码的完整许可证。原生依赖署名单独列于 README。",
   },
 
   // ── Theme ───────────────────────────────────────────────

--- a/src/index.css
+++ b/src/index.css
@@ -68,7 +68,7 @@
   /* Text — near-black with violet undertone */
   --text-primary: #1e1a2e;
   --text-secondary: #3f3857;
-  --text-muted: #6b6380;
+  --text-muted: #4b425e;
 
   /* Structure */
   --border: #9d85c4;
@@ -76,6 +76,7 @@
 
   /* Hero accent — deep violet */
   --accent: #6d28d9;
+  --accent-text: #fff;
   --accent-hover: #5b21b6;
   --accent-disabled-bg: #c2b0dd;
   --accent-disabled-text: #6b6380;
@@ -169,8 +170,8 @@
 
   /* Text — warm off-white with violet undertone */
   --text-primary: #e8e5f0;
-  --text-secondary: #a5a0b5;
-  --text-muted: #6b6575;
+  --text-secondary: #c3bed0;
+  --text-muted: #bfb8cc;
 
   /* Structure */
   --border: #7c63a8;
@@ -178,6 +179,7 @@
 
   /* Hero accent — amethyst */
   --accent: #a78bfa;
+  --accent-text: #1e1a2e;
   --accent-hover: #c4b5fd;
   --accent-disabled-bg: #1e1a26;
   --accent-disabled-text: #4e4658;

--- a/src/lib/FileContext.tsx
+++ b/src/lib/FileContext.tsx
@@ -22,6 +22,7 @@
 import { createContext, useCallback, useContext, useMemo, useState, type ReactNode } from "react";
 
 import { pathsEqualOnFs } from "./path-validation";
+import { findSelectedInputConflictKeys, SELECTED_INPUT_CONFLICT_BATCH_LIMIT } from "./tauri-api";
 
 // ── Types ────────────────────────────────────────────────
 
@@ -91,6 +92,11 @@ interface FileContextValue {
    * Returns the tab ID if in use, or null if free.
    */
   isFileInUse: (path: string, excludeTab?: TabId) => TabId | null;
+  /** Protect loaded subtitle sources across all tabs before confirming outputs. */
+  findLoadedInputConflictKeys: (
+    outputPaths: readonly string[],
+    signal?: AbortSignal
+  ) => Promise<ReadonlySet<string>>;
 }
 
 const FileContext = createContext<FileContextValue | null>(null);
@@ -103,6 +109,42 @@ export function FileProvider({ children }: { children: ReactNode }) {
   const [fontsFiles, setFontsFiles] = useState<FontsFilesState | null>(null);
   const [renameFiles, setRenameFiles] = useState<BatchRenameFilesState | null>(null);
   const [styleFiles, setStyleFiles] = useState<StyleFilesState | null>(null);
+
+  const loadedSubtitlePaths = useMemo(
+    () => [
+      ...new Set([
+        ...(hdrFiles?.filePaths ?? []),
+        ...(timingFiles?.filePaths ?? []),
+        ...(fontsFiles?.filePaths ?? []),
+        ...(renameFiles?.subtitlePaths ?? []),
+        ...(styleFiles?.filePaths ?? []),
+      ]),
+    ],
+    [hdrFiles, timingFiles, fontsFiles, renameFiles, styleFiles]
+  );
+
+  const findLoadedInputConflictKeys = useCallback(
+    async (outputPaths: readonly string[], signal?: AbortSignal): Promise<ReadonlySet<string>> => {
+      const outputs = [...new Set(outputPaths)];
+      const conflicts = new Set<string>();
+      const chunkSize = SELECTED_INPUT_CONFLICT_BATCH_LIMIT;
+      // This bounds each IPC request without imposing a combined selection cap
+      // on independent tabs. Sources are the context snapshot for this run.
+      for (let outputStart = 0; outputStart < outputs.length; outputStart += chunkSize) {
+        const outputChunk = outputs.slice(outputStart, outputStart + chunkSize);
+        for (let inputStart = 0; inputStart < loadedSubtitlePaths.length; inputStart += chunkSize) {
+          if (signal?.aborted) return conflicts;
+          const found = await findSelectedInputConflictKeys(
+            loadedSubtitlePaths.slice(inputStart, inputStart + chunkSize),
+            outputChunk
+          );
+          for (const key of found) conflicts.add(key);
+        }
+      }
+      return conflicts;
+    },
+    [loadedSubtitlePaths]
+  );
 
   const isFileInUse = useCallback(
     (path: string, excludeTab?: TabId): TabId | null => {
@@ -186,8 +228,18 @@ export function FileProvider({ children }: { children: ReactNode }) {
       setStyleFiles,
       clearFile,
       isFileInUse,
+      findLoadedInputConflictKeys,
     }),
-    [hdrFiles, timingFiles, fontsFiles, renameFiles, styleFiles, clearFile, isFileInUse]
+    [
+      hdrFiles,
+      timingFiles,
+      fontsFiles,
+      renameFiles,
+      styleFiles,
+      clearFile,
+      isFileInUse,
+      findLoadedInputConflictKeys,
+    ]
   );
 
   return <FileContext.Provider value={value}>{children}</FileContext.Provider>;

--- a/src/lib/batch-write-handlers.test.tsx
+++ b/src/lib/batch-write-handlers.test.tsx
@@ -1,0 +1,728 @@
+/// <reference types="node" />
+import { resolve } from "node:path";
+import { readFileSync } from "node:fs";
+import { isValidElement, type ReactElement, type ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import TimingShift from "../features/timing-shift/TimingShift";
+import HdrConvert from "../features/hdr-convert/HdrConvert";
+import FontEmbed from "../features/font-embed/FontEmbed";
+import BatchRename from "../features/batch-rename/BatchRename";
+import {
+  useFileContext,
+  type FontsFilesState,
+  type BatchRenameFilesState,
+  type HdrFileState,
+  type TimingFilesState,
+  type StyleFilesState,
+} from "./FileContext";
+import { SELECTED_INPUT_CONFLICT_BATCH_LIMIT } from "./tauri-api";
+
+const state = vi.hoisted(() => ({
+  values: [] as unknown[],
+  cursor: 0,
+  paths: [] as string[],
+  files: new Map<string, string>(),
+  attempts: [] as { path: string; overwrite: boolean }[],
+  probe: undefined as undefined | ((path: string) => Promise<boolean>),
+  conflictProbe: undefined as undefined | (() => Promise<string[]>),
+  aliasConflicts: [] as string[],
+  aliases: new Map<string, string>(),
+  conflictCalls: [] as { inputPaths: string[]; outputPaths: string[] }[],
+  readProbe: undefined as undefined | ((path: string) => Promise<void>),
+  onRead: undefined as undefined | ((path: string) => void),
+  onWrite: undefined as undefined | ((path: string) => void),
+  onDrop: undefined as undefined | ((paths: string[]) => Promise<void>),
+  effects: [] as (() => unknown)[],
+  fontsFiles: null as FontsFilesState | null,
+  renameFiles: null as BatchRenameFilesState | null,
+  hdrFiles: undefined as HdrFileState | null | undefined,
+  timingFiles: undefined as TimingFilesState | null | undefined,
+  styleFiles: null as StyleFilesState | null,
+  setHdrFiles: vi.fn(),
+  setTimingFiles: vi.fn(),
+  ask: vi.fn(),
+  open: vi.fn(),
+  log: vi.fn(),
+}));
+
+// Run the real component handlers and file adapters with explicit rerenders.
+// Browser effects/layout and the native filesystem are separate test boundaries.
+vi.mock("react", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react")>()),
+  useState: (initial: unknown) => {
+    const slot = state.cursor++;
+    if (!(slot in state.values))
+      state.values[slot] = typeof initial === "function" ? initial() : initial;
+    return [
+      state.values[slot],
+      (next: unknown) => {
+        state.values[slot] = typeof next === "function" ? next(state.values[slot]) : next;
+      },
+    ];
+  },
+  useRef: (initial: unknown) => {
+    const slot = state.cursor++;
+    if (!(slot in state.values)) state.values[slot] = { current: initial };
+    return state.values[slot];
+  },
+  useMemo: (compute: () => unknown) => compute(),
+  useCallback: (callback: unknown) => callback,
+  useEffect: (effect: () => unknown) => {
+    state.effects.push(effect);
+  },
+}));
+vi.mock("@tauri-apps/api/core", () => ({
+  Channel: class {},
+  invoke: async (command: string, args: Record<string, unknown>) => {
+    const path = String(args.path);
+    if (command === "safe_find_selected_input_conflicts") {
+      const inputPaths = args.inputPaths as string[];
+      const outputPaths = args.outputPaths as string[];
+      state.conflictCalls.push({ inputPaths, outputPaths });
+      if (inputPaths.length > 5000 || outputPaths.length > 5000)
+        throw new Error("Native batch limit");
+      if (state.conflictProbe) return state.conflictProbe();
+      const canonical = (value: string) => state.aliases.get(value) ?? value;
+      const selected = new Set(inputPaths.map(canonical));
+      return outputPaths.filter(
+        (output) => selected.has(canonical(output)) || state.aliasConflicts.includes(output)
+      );
+    }
+    if (command === "safe_output_path_exists") {
+      return state.probe ? state.probe(path) : state.files.has(path);
+    }
+    if (command === "read_text_detect_encoding") {
+      await state.readProbe?.(path);
+      state.onRead?.(path);
+      const text = state.files.get(path);
+      if (text === undefined) throw new Error("Missing input");
+      return { text, encoding: "UTF-8", encodingId: "utf-8", inferredWithoutBom: false };
+    }
+    if (command === "safe_write_text_file") {
+      state.onWrite?.(path);
+      state.attempts.push({ path, overwrite: args.overwrite === true });
+      if (state.files.has(path) && !args.overwrite) throw new Error("Destination already exists");
+      state.files.set(path, String(args.content));
+      return;
+    }
+    if (command === "safe_copy_file" || command === "safe_rename_file") {
+      const destination = String(args.dst);
+      state.onWrite?.(destination);
+      state.attempts.push({ path: destination, overwrite: args.overwrite === true });
+      if (state.files.has(destination) && !args.overwrite)
+        throw new Error("Destination already exists");
+      const source = String(args.src);
+      const content = state.files.get(source);
+      if (content === undefined) throw new Error("Missing input");
+      state.files.set(destination, content);
+      if (command === "safe_rename_file") state.files.delete(source);
+      return;
+    }
+    if (command === "resolve_user_font" || command === "lookup_font_family") return null;
+    if (command === "find_system_font") return { path: "/fonts/fixture.ttf", index: 0 };
+    if (command === "subset_font_bytes") return new Uint8Array([1, 2, 3]).buffer;
+    throw new Error(`Unexpected native command: ${command}`);
+  },
+}));
+vi.mock("@tauri-apps/plugin-dialog", () => ({
+  ask: (...args: unknown[]) => state.ask(...args),
+  open: (...args: unknown[]) => state.open(...args),
+}));
+vi.mock("../i18n/useI18n", () => ({ useI18n: () => ({ t: (key: string) => key }) }));
+vi.mock("./FileContext", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("./FileContext")>();
+  return {
+    ...actual,
+    useFileContext: () => {
+      const selection = {
+        filePaths: state.paths,
+        fileNames: state.paths.map((path) => path.split("/").at(-1)!),
+        firstFileContent: "",
+      };
+      // Exercise the real provider's ownership snapshot and batching method;
+      // isolate its hook slots from the feature component being rendered.
+      const savedValues = state.values;
+      const savedCursor = state.cursor;
+      let context: ReturnType<typeof actual.useFileContext>;
+      try {
+        state.values = [
+          state.hdrFiles === undefined ? selection : state.hdrFiles,
+          state.timingFiles === undefined ? selection : state.timingFiles,
+          state.fontsFiles,
+          state.renameFiles,
+          state.styleFiles,
+        ];
+        state.cursor = 0;
+        context = actual.FileProvider({ children: null }).props.value;
+      } finally {
+        state.values = savedValues;
+        state.cursor = savedCursor;
+      }
+      return {
+        ...context,
+        setFontsFiles: (value: FontsFilesState | null) => {
+          state.fontsFiles = value;
+        },
+        setRenameFiles: (value: BatchRenameFilesState | null) => {
+          state.renameFiles = value;
+        },
+        clearFile: vi.fn(),
+        setTimingFiles: state.setTimingFiles,
+        setHdrFiles: state.setHdrFiles,
+      };
+    },
+  };
+});
+vi.mock("./useFolderDrop", () => ({
+  useFolderDrop: (options: { onPaths: typeof state.onDrop }) => {
+    state.onDrop = options.onPaths;
+  },
+}));
+vi.mock("./useClickOutside", () => ({ useClickOutside: () => {} }));
+vi.mock("./useTabStatus", () => ({ useTabStatus: () => {} }));
+vi.mock("./useLogPanel", () => ({
+  useLogPanel: () => ({
+    logs: [],
+    addLog: state.log,
+    clearLogs: vi.fn(),
+    logScrollRef: { current: null },
+  }),
+}));
+
+type Props = {
+  children?: ReactNode;
+  title?: string;
+  disabled?: boolean;
+  value?: string;
+  onClick?: () => unknown;
+  onChange?: () => unknown;
+};
+function elements(node: ReactNode): ReactElement<Props>[] {
+  if (Array.isArray(node)) return node.flatMap(elements);
+  if (!isValidElement<Props>(node)) return [];
+  return [node, ...elements(node.props.children)];
+}
+const subtitle = "1\n00:00:01,000 --> 00:00:02,000\nhello\n";
+const inputPath = (name: string) => resolve("handler-fixtures", name).replaceAll("\\", "/");
+
+beforeEach(() => {
+  state.values = [];
+  state.cursor = 0;
+  state.paths = [inputPath("episode.srt")];
+  state.files = new Map([[state.paths[0]!, subtitle]]);
+  state.attempts = [];
+  state.probe = undefined;
+  state.conflictProbe = undefined;
+  state.aliasConflicts = [];
+  state.onRead = undefined;
+  state.readProbe = undefined;
+  state.aliases = new Map();
+  state.conflictCalls = [];
+  state.onWrite = undefined;
+  state.onDrop = undefined;
+  state.effects = [];
+  state.fontsFiles = null;
+  state.renameFiles = null;
+  state.hdrFiles = undefined;
+  state.timingFiles = undefined;
+  state.styleFiles = null;
+  state.setHdrFiles.mockReset().mockImplementation((value: HdrFileState | null) => {
+    state.hdrFiles = value;
+  });
+  state.setTimingFiles.mockReset().mockImplementation((value: TimingFilesState | null) => {
+    state.timingFiles = value;
+  });
+  state.ask.mockReset().mockResolvedValue(true);
+  state.open.mockReset().mockResolvedValue(null);
+  state.log.mockReset();
+});
+
+const assSubtitle = `[Script Info]
+ScriptType: v4.00+
+[V4+ Styles]
+Format: Name, Fontname, Fontsize, Bold, Italic
+Style: Default,Fixture,20,0,0
+[Events]
+Format: Layer, Start, End, Style, Text
+Dialogue: 0,0:00:01.00,0:00:02.00,Default,Hello
+`;
+
+describe("loaded subtitle protection", () => {
+  it("keeps the shared IPC chunk limit equal to the native limit", () => {
+    const source = readFileSync(resolve("src-tauri/src/dropzone.rs"), "utf8");
+    const nativeLimit = Number(source.match(/MAX_RESULT_FILES: usize = (\d+);/)?.[1]);
+    expect(SELECTED_INPUT_CONFLICT_BATCH_LIMIT).toBe(nativeLimit);
+  });
+
+  it("includes every tab's subtitle paths and excludes rename videos", async () => {
+    const names = ["hdr.srt", "timing.vtt", "fonts.ass", "sidecar.sup", "style.ssa"];
+    const paths = names.map(inputPath);
+    state.hdrFiles = { filePaths: [paths[0]!], fileNames: [names[0]!] };
+    state.timingFiles = { filePaths: [paths[1]!], fileNames: [names[1]!], firstFileContent: "" };
+    state.fontsFiles = { filePaths: [paths[2]!], fileNames: [names[2]!], firstFileContent: "" };
+    state.renameFiles = {
+      subtitlePaths: [paths[3]!],
+      subtitleNames: [names[3]!],
+      videoPaths: [inputPath("video.mkv")],
+      videoNames: ["video.mkv"],
+    };
+    state.styleFiles = { filePaths: [paths[4]!], fileNames: [names[4]!] };
+    await useFileContext().findLoadedInputConflictKeys(paths);
+    expect(state.conflictCalls).toEqual([{ inputPaths: paths, outputPaths: paths }]);
+  });
+
+  it("deduplicates and batches more than 5000 combined inputs and outputs without dropping the last source", async () => {
+    const paths = Array.from({ length: 5001 }, (_, index) => inputPath(`source-${index}.ass`));
+    state.hdrFiles = { filePaths: paths.slice(0, 5000), fileNames: [] };
+    state.timingFiles = {
+      filePaths: [paths[0]!, paths[5000]!],
+      fileNames: [],
+      firstFileContent: "",
+    };
+    const result = await useFileContext().findLoadedInputConflictKeys([...paths, paths[0]!]);
+    expect(result.size).toBe(5001);
+    expect(
+      state.conflictCalls.map((call) => [call.inputPaths.length, call.outputPaths.length])
+    ).toEqual([
+      [5000, 5000],
+      [1, 5000],
+      [5000, 1],
+      [1, 1],
+    ]);
+  });
+
+  it("stops checking further chunks after cancellation", async () => {
+    state.hdrFiles = {
+      filePaths: Array.from({ length: 5001 }, (_, index) => inputPath(`source-${index}.ass`)),
+      fileNames: [],
+    };
+    state.timingFiles = null;
+    const controller = new AbortController();
+    state.conflictProbe = async () => {
+      controller.abort();
+      return [];
+    };
+    await useFileContext().findLoadedInputConflictKeys(
+      [inputPath("output.ass")],
+      controller.signal
+    );
+    expect(state.conflictCalls).toHaveLength(1);
+  });
+});
+
+describe.each(["Font Embed", "Batch Copy", "Batch Rename"] as const)(
+  "%s write preparation",
+  (kind) => {
+    const isFont = kind === "Font Embed";
+    const isRename = kind === "Batch Rename";
+    const button = isFont ? "btn_embed" : "btn_rename_run";
+    const source = (number = 1) => inputPath(`sub EP${number.toString().padStart(2, "0")}.ass`);
+    const output = (number = 1) =>
+      inputPath(
+        isFont
+          ? `sub EP${number.toString().padStart(2, "0")}.embedded.ass`
+          : `video EP${number.toString().padStart(2, "0")}.ass`
+      );
+
+    function render() {
+      state.cursor = 0;
+      state.effects = [];
+      return elements(
+        isFont ? FontEmbed({ cacheStatus: null, cacheProbeFailed: false }) : BatchRename()
+      );
+    }
+    function labeled(label: string) {
+      const match = render().find(
+        (entry) => entry.type === "button" && entry.props.children === label
+      );
+      expect(match, label).toBeDefined();
+      return match!.props;
+    }
+    async function prepare(count = 1, extraInput?: string) {
+      const paths = Array.from({ length: count }, (_, index) => source(index + 1));
+      if (extraInput) paths.push(extraInput);
+      for (const path of paths) state.files.set(path, assSubtitle);
+      if (isFont) {
+        render();
+        await state.onDrop!(paths);
+      } else {
+        state.renameFiles = {
+          subtitlePaths: paths,
+          subtitleNames: paths.map((path) => path.split("/").at(-1)!),
+          videoPaths: Array.from({ length: count }, (_, index) =>
+            inputPath(`video EP${(index + 1).toString().padStart(2, "0")}.mkv`)
+          ),
+          videoNames: Array.from(
+            { length: count },
+            (_, index) => `video EP${(index + 1).toString().padStart(2, "0")}.mkv`
+          ),
+        };
+        render();
+        // Seed the real pairing state with its mount effects; subsequent renders
+        // keep the manual state, as React does while the selection is unchanged.
+        for (const effect of state.effects) effect();
+        if (isRename)
+          render().find((entry) => entry.type === "input" && entry.props.value === "rename")!.props
+            .onChange!();
+      }
+      expect(labeled(button).disabled).toBe(false);
+    }
+
+    it("creates the predicted output and preserves or moves the source as selected", async () => {
+      await prepare();
+      await labeled(button).onClick!();
+      expect(state.attempts).toEqual([{ path: output(), overwrite: false }]);
+      expect(state.files.get(output())).toContain("Hello");
+      expect(state.files.get(source())).toBe(isRename ? undefined : assSubtitle);
+      expect(state.ask).toHaveBeenCalledTimes(isRename ? 1 : 0);
+    });
+
+    it("only grants replacement to the existing output covered by acceptance", async () => {
+      await prepare(2);
+      state.files.set(output(), "approved old output");
+      state.onWrite = (path) => {
+        if (path === output()) state.files.set(output(2), "late file");
+      };
+      await labeled(button).onClick!();
+      expect(state.ask).toHaveBeenCalledTimes(isRename ? 2 : 1);
+      expect(state.attempts).toEqual([
+        { path: output(), overwrite: true },
+        { path: output(2), overwrite: false },
+      ]);
+      expect(state.files.get(output())).toContain("Hello");
+      expect(state.files.get(output(2))).toBe("late file");
+      expect(state.files.get(source(2))).toBe(assSubtitle);
+    });
+
+    it.each([false, true])(
+      "protects a source loaded in Style Edit (directory alias=%s)",
+      async (alias) => {
+        await prepare();
+        const name = output().split("/").at(-1)!;
+        const selected = alias ? inputPath(`style-alias/${name}`) : output();
+        if (alias) state.aliases.set(output(), selected);
+        state.styleFiles = { filePaths: [selected], fileNames: [name] };
+        state.files.set(output(), assSubtitle);
+        await labeled(button).onClick!();
+        expect(state.attempts).toEqual([]);
+        expect(state.files.get(output())).toBe(assSubtitle);
+        expect(state.files.get(source())).toBe(assSubtitle);
+        expect(state.ask).not.toHaveBeenCalled();
+        state.styleFiles = null;
+        await labeled(button).onClick!();
+        expect(state.attempts).toEqual([{ path: output(), overwrite: true }]);
+      }
+    );
+
+    it("keeps selected source bytes even when they match a projected destination", async () => {
+      await prepare(1, output());
+      await labeled(button).onClick!();
+      expect(state.files.get(source())).toBe(assSubtitle);
+      expect(state.files.get(output())).toBe(assSubtitle);
+      expect(
+        state.attempts.some((attempt) => attempt.path === source() || attempt.path === output())
+      ).toBe(false);
+      expect(state.ask).not.toHaveBeenCalled();
+    });
+
+    it("declining overwrite preserves the destination and returns to idle", async () => {
+      await prepare();
+      state.files.set(output(), "previous output");
+      if (isRename) state.ask.mockResolvedValueOnce(true);
+      state.ask.mockResolvedValue(false);
+      await labeled(button).onClick!();
+      expect(state.attempts).toEqual([]);
+      expect(state.files.get(output())).toBe("previous output");
+      expect(state.files.get(source())).toBe(assSubtitle);
+      expect(labeled(button).disabled).toBe(false);
+    });
+
+    it("blocks an existing alias of a selected source before asking about overwrite", async () => {
+      await prepare();
+      state.files.set(output(), assSubtitle);
+      state.aliasConflicts = [output()];
+      await labeled(button).onClick!();
+      expect(state.attempts).toEqual([]);
+      expect(state.ask).not.toHaveBeenCalled();
+      expect(state.files.get(source())).toBe(assSubtitle);
+      expect(state.files.get(output())).toBe(assSubtitle);
+      expect(labeled(button).disabled).toBe(false);
+    });
+
+    it("keeps unrelated batch outputs when one output aliases a selected source", async () => {
+      await prepare(2);
+      state.files.set(output(), assSubtitle);
+      state.aliasConflicts = [output()];
+      await labeled(button).onClick!();
+      expect(state.attempts).toEqual([{ path: output(2), overwrite: false }]);
+      expect(state.ask).toHaveBeenCalledTimes(isRename ? 1 : 0);
+      expect(state.files.get(source())).toBe(assSubtitle);
+      expect(state.files.get(output())).toBe(assSubtitle);
+      expect(state.files.get(output(2))).toContain("Hello");
+    });
+
+    it("shows busy controls before delayed preparation and cancels without a write", async () => {
+      await prepare();
+      let finishProbe!: () => void;
+      state.conflictProbe = () =>
+        new Promise<string[]>((resolveProbe) => {
+          finishProbe = () => resolveProbe([]);
+        });
+      const pending = labeled(button).onClick!();
+      expect(render().find((entry) => entry.props.title === "btn_clear_file")?.props.disabled).toBe(
+        true
+      );
+      labeled("btn_cancel").onClick!();
+      finishProbe();
+      await pending;
+      expect(state.attempts).toEqual([]);
+      expect(state.ask).not.toHaveBeenCalled();
+      expect(labeled(button).disabled).toBe(false);
+    });
+
+    it("honors Cancel while confirmation is pending even if the dialog later accepts", async () => {
+      await prepare();
+      state.files.set(output(), "previous output");
+      let finishAsk: undefined | (() => void);
+      state.ask.mockImplementation(
+        () =>
+          new Promise<boolean>((resolveAsk) => {
+            finishAsk = () => resolveAsk(true);
+          })
+      );
+      const pending = labeled(button).onClick!();
+      await vi.waitFor(() => expect(finishAsk).toBeTypeOf("function"));
+      expect(render().find((entry) => entry.props.title === "btn_clear_file")?.props.disabled).toBe(
+        true
+      );
+      labeled("btn_cancel").onClick!();
+      finishAsk!();
+      await pending;
+      expect(state.attempts).toEqual([]);
+      expect(state.files.get(output())).toBe("previous output");
+      expect(state.files.get(source())).toBe(assSubtitle);
+      expect(labeled(button).disabled).toBe(false);
+    });
+
+    it("ignores a file picker that completes after the current batch starts", async () => {
+      await prepare();
+      const originalSelection = isFont ? state.fontsFiles : state.renameFiles;
+      let finishPick!: (paths: string[]) => void;
+      state.open.mockImplementation(
+        () =>
+          new Promise<string[]>((resolvePick) => {
+            finishPick = resolvePick;
+          })
+      );
+      const pendingPick = labeled(isFont ? "btn_select_files" : "btn_select_rename_inputs")
+        .onClick!();
+      await labeled(button).onClick!();
+      finishPick([inputPath("later EP09.ass")]);
+      await pendingPick;
+      if (isFont) expect(state.fontsFiles).toBe(originalSelection);
+      else expect(state.renameFiles?.subtitlePaths).toEqual([isRename ? output() : source()]);
+      expect(state.attempts).toEqual([{ path: output(), overwrite: false }]);
+    });
+
+    it("ignores a pending output-directory pick after starting with the accepted directory", async () => {
+      await prepare();
+      const initialDirectory = inputPath("accepted-output");
+      render().find(
+        (entry) =>
+          entry.type === "input" && entry.props.value === (isFont ? "chosen_dir" : "copy_to_chosen")
+      )!.props.onChange!();
+      state.open.mockResolvedValueOnce(initialDirectory);
+      await labeled("btn_pick_chosen_dir").onClick!();
+      let finishPick!: (path: string) => void;
+      state.open.mockImplementation(
+        () =>
+          new Promise<string>((resolvePick) => {
+            finishPick = resolvePick;
+          })
+      );
+      const pendingPick = labeled("btn_pick_chosen_dir").onClick!();
+      await labeled(button).onClick!();
+      finishPick(inputPath("later-output"));
+      await pendingPick;
+      await labeled(button).onClick!();
+      const expectedPath = `${initialDirectory}/${output().split("/").at(-1)!}`;
+      expect(state.attempts).toEqual([
+        { path: expectedPath, overwrite: false },
+        { path: expectedPath, overwrite: true },
+      ]);
+      expect(state.files.get(source())).toBe(assSubtitle);
+    });
+  }
+);
+
+describe.each([
+  {
+    name: "Time Shift",
+    component: TimingShift,
+    button: "btn_save",
+    batchButton: "btn_save_all",
+    suffix: ".shifted.srt",
+  },
+  {
+    name: "HDR Convert",
+    component: HdrConvert,
+    button: "btn_convert",
+    batchButton: "btn_convert",
+    suffix: ".hdr.ass",
+  },
+])("$name write preparation", ({ component, button, batchButton, suffix }) => {
+  function render() {
+    state.cursor = 0;
+    return elements(component());
+  }
+  function labeled(label: string) {
+    const match = render().find(
+      (entry) => entry.type === "button" && entry.props.children === label
+    );
+    expect(match, label).toBeDefined();
+    return match!.props;
+  }
+  const output = (stem = "episode") => inputPath(stem + suffix);
+
+  it("writes a new output exclusively and preserves its input", async () => {
+    await labeled(button).onClick!();
+    expect(state.attempts).toEqual([{ path: output(), overwrite: false }]);
+    expect(state.files.get(output())).not.toBe(subtitle);
+    expect(state.files.get(state.paths[0]!)).toBe(subtitle);
+    expect(state.ask).not.toHaveBeenCalled();
+  });
+
+  it("allows replacement of an ordinary output only after acceptance", async () => {
+    state.files.set(output(), "previous output");
+    await labeled(button).onClick!();
+    expect(state.ask).toHaveBeenCalledOnce();
+    expect(state.attempts).toEqual([{ path: output(), overwrite: true }]);
+    expect(state.files.get(output())).not.toBe("previous output");
+  });
+
+  it.each([false, true])(
+    "protects a source loaded in Batch Rename (directory alias=%s)",
+    async (alias) => {
+      const name = output().split("/").at(-1)!;
+      const selected = alias ? inputPath(`rename-alias/${name}`) : output();
+      if (alias) state.aliases.set(output(), selected);
+      state.renameFiles = {
+        subtitlePaths: [selected],
+        subtitleNames: [name],
+        videoPaths: [],
+        videoNames: [],
+      };
+      state.files.set(output(), subtitle);
+      await labeled(button).onClick!();
+      expect(state.attempts).toEqual([]);
+      expect(state.files.get(output())).toBe(subtitle);
+      expect(state.files.get(state.paths[0]!)).toBe(subtitle);
+      expect(state.ask).not.toHaveBeenCalled();
+      state.renameFiles = null;
+      await labeled(button).onClick!();
+      expect(state.attempts).toEqual([{ path: output(), overwrite: true }]);
+    }
+  );
+
+  it("preserves every selected source even with overwrite accepted", async () => {
+    state.paths.push(output());
+    state.files.set(output(), subtitle);
+    await labeled(batchButton).onClick!();
+    for (const path of state.paths) expect(state.files.get(path)).toBe(subtitle);
+    expect(state.attempts.some((attempt) => state.paths.includes(attempt.path))).toBe(false);
+    expect(state.ask).not.toHaveBeenCalled();
+  });
+
+  it("does not grant a late destination permission when another output was approved", async () => {
+    const secondInput = inputPath("second.srt");
+    state.paths.push(secondInput);
+    state.files.set(secondInput, subtitle);
+    state.files.set(output(), "approved old output");
+    state.onRead = (path) => {
+      if (path === secondInput) state.files.set(output("second"), "late file");
+    };
+    await labeled(batchButton).onClick!();
+    expect(state.ask).toHaveBeenCalledOnce();
+    expect(state.attempts).toEqual([
+      { path: output(), overwrite: true },
+      { path: output("second"), overwrite: false },
+    ]);
+    expect(state.files.get(output("second"))).toBe("late file");
+  });
+
+  it("declining overwrite preserves the destination and restores the idle controls", async () => {
+    state.files.set(output(), "previous output");
+    state.ask.mockResolvedValue(false);
+    await labeled(button).onClick!();
+    expect(state.attempts).toEqual([]);
+    expect(state.files.get(output())).toBe("previous output");
+    expect(labeled(button).disabled).toBe(false);
+  });
+
+  it("ignores a file picker that returns after the current batch begins", async () => {
+    let finishPick!: (paths: string[]) => void;
+    state.open.mockImplementation(
+      () =>
+        new Promise<string[]>((resolvePick) => {
+          finishPick = resolvePick;
+        })
+    );
+    const pendingPick = labeled("btn_select_files").onClick!();
+    await labeled(button).onClick!();
+    finishPick([inputPath("later.srt")]);
+    await pendingPick;
+    expect(state.setHdrFiles).not.toHaveBeenCalled();
+    expect(state.setTimingFiles).not.toHaveBeenCalled();
+    expect(state.attempts).toEqual([{ path: output(), overwrite: false }]);
+  });
+
+  it("disables Clear during delayed preparation and allows Cancel to stop the accepted operation", async () => {
+    let finishProbe!: () => void;
+    state.conflictProbe = () =>
+      new Promise<string[]>((resolveProbe) => {
+        finishProbe = () => resolveProbe([]);
+      });
+    const pending = labeled(button).onClick!();
+    const clear = render().find((entry) => entry.props.title === "btn_clear_file");
+    expect(clear?.props.disabled).toBe(true);
+    labeled("btn_cancel").onClick!();
+    finishProbe();
+    await pending;
+    expect(state.attempts).toEqual([]);
+    expect(state.ask).not.toHaveBeenCalled();
+    expect(labeled(button).disabled).toBe(false);
+  });
+});
+
+it("ignores Timing's initial file read if saving starts before that read returns", async () => {
+  const later = inputPath("later.srt");
+  state.files.set(later, subtitle);
+  state.open.mockResolvedValueOnce([later]);
+  let finishRead!: () => void;
+  let markReadStarted!: () => void;
+  const readStarted = new Promise<void>((resolveRead) => {
+    markReadStarted = resolveRead;
+  });
+  state.readProbe = (path) =>
+    path === later
+      ? new Promise<void>((resolveRead) => {
+          finishRead = resolveRead;
+          markReadStarted();
+        })
+      : Promise.resolve();
+  function labeled(label: string) {
+    state.cursor = 0;
+    const match = elements(TimingShift()).find(
+      (entry) => entry.type === "button" && entry.props.children === label
+    );
+    expect(match, label).toBeDefined();
+    return match!.props;
+  }
+  const pendingPick = labeled("btn_select_files").onClick!();
+  await readStarted;
+  await labeled("btn_save").onClick!();
+  finishRead();
+  await pendingPick;
+  expect(state.setTimingFiles).not.toHaveBeenCalled();
+  expect(state.attempts).toEqual([{ path: inputPath("episode.shifted.srt"), overwrite: false }]);
+});

--- a/src/lib/font-output-budget.test.ts
+++ b/src/lib/font-output-budget.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it, vi } from "vitest";
+import { applyFontEmbed } from "../cli-engine-entry";
+import { runChain } from "../features/chain/chain-runtime";
+
+vi.mock("../features/font-embed/ass-uuencode", async (importOriginal) => {
+  const original = await importOriginal<typeof import("../features/font-embed/ass-uuencode")>();
+  return {
+    ...original,
+    FontSectionBuilder: class extends original.FontSectionBuilder {
+      constructor() {
+        super(100);
+      }
+    },
+  };
+});
+
+const content = "[Script Info]\nTitle: Budget test\n[Events]\n";
+const font = { fontName: "sample.ttf", dataB64: "AQIDBAUGBwgJCgsMDQ4PEBESExQ=" };
+const adapters = {
+  standalone: (fonts: (typeof font)[]) => applyFontEmbed({ content, fonts }).content,
+  chain: (fonts: (typeof font)[]) =>
+    runChain({
+      content,
+      inputPath: "C:\\subtitles\\sample.ass",
+      plan: {
+        outputTemplate: "{name}.embedded.ass",
+        steps: [
+          {
+            kind: "embed",
+            params: {
+              fontDirs: [],
+              recursiveFontDirs: [],
+              fontFiles: [],
+              noSystemFonts: true,
+              onMissing: "fail",
+              subsets: fonts,
+            },
+          },
+        ],
+      },
+    }).content,
+};
+
+describe.each(Object.entries(adapters))("%s embedded font output budget", (_name, embed) => {
+  it("embeds a valid subset below the aggregate budget", () => {
+    expect(embed([font])).toContain("fontname: sample.ttf\n");
+  });
+
+  it("rejects cumulative output before decoding subsequent entries", () => {
+    expect(() => embed([font, font, { fontName: "later.ttf", dataB64: "invalid!" }])).toThrow(
+      "100-byte encoded output limit"
+    );
+  });
+});

--- a/src/lib/license-notices.test.ts
+++ b/src/lib/license-notices.test.ts
@@ -1,10 +1,11 @@
 /// <reference types="node" />
 
 import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
 import { describe, expect, it } from "vitest";
 import { LICENSE_NOTICES, type LicenseNoticeId } from "./license-notices";
 
-const LEGAL_TEXT_SHA256: Record<LicenseNoticeId, string> = {
+const LEGAL_TEXT_SHA256: Record<Exclude<LicenseNoticeId, "frontend">, string> = {
   ssahdrify: "605e9047a563c5c8396ffb18232aa4304ec56586aee537c45064c6fb425e44ad",
   inter: "262481e844521b326f5ecd053e59b98c8b2da78c8ee1bdbb6e8174305e54935a",
   "smiley-sans": "9401f4050f1b66c26b6ccdc8b0e14a3c1cc37aac122eda84386f25854a9bec72",
@@ -14,8 +15,22 @@ const LEGAL_TEXT_SHA256: Record<LicenseNoticeId, string> = {
 describe("embedded license notices", () => {
   it("preserves every complete legal payload byte-for-byte", () => {
     for (const notice of LICENSE_NOTICES) {
+      if (notice.id === "frontend") continue;
       const digest = createHash("sha256").update(notice.text, "utf8").digest("hex");
       expect(digest).toBe(LEGAL_TEXT_SHA256[notice.id]);
+    }
+  });
+
+  it("embeds the complete installed React-family notices in the offline viewer", () => {
+    const frontend = LICENSE_NOTICES.find((notice) => notice.id === "frontend");
+    for (const name of ["react", "react-dom", "scheduler", "react-window"]) {
+      const file = name === "react-window" ? "LICENSE.md" : "LICENSE";
+      const license = readFileSync(
+        new URL(`../../node_modules/${name}/${file}`, import.meta.url),
+        "utf8"
+      ).replace(/\r\n/gu, "\n");
+      expect(frontend?.text).toContain(license);
+      expect(frontend?.text).toContain(`Source: https://www.npmjs.com/package/${name}/v/`);
     }
   });
 

--- a/src/lib/license-notices.ts
+++ b/src/lib/license-notices.ts
@@ -2,8 +2,9 @@ import projectLicenseText from "../../LICENSE?raw";
 import featherLicenseText from "../assets/licenses/feather-LICENSE.txt?raw";
 import interLicenseText from "../assets/fonts/inter/LICENSE.txt?raw";
 import smileySansLicenseText from "../assets/fonts/smiley-sans/LICENSE.txt?raw";
+import frontendLicenseText from "virtual:frontend-notices";
 
-export type LicenseNoticeId = "ssahdrify" | "inter" | "smiley-sans" | "feather";
+export type LicenseNoticeId = "ssahdrify" | "inter" | "smiley-sans" | "feather" | "frontend";
 
 export interface LicenseNotice {
   id: LicenseNoticeId;
@@ -14,6 +15,13 @@ export interface LicenseNotice {
 }
 
 export const LICENSE_NOTICES: readonly LicenseNotice[] = [
+  {
+    id: "frontend",
+    name: "JavaScript dependencies",
+    licenseId: "Multiple licenses",
+    source: "https://github.com/koagaroon/ssaHdrify-tauri",
+    text: frontendLicenseText,
+  },
   {
     id: "ssahdrify",
     name: "SSA HDRify",

--- a/src/lib/output-collisions.ts
+++ b/src/lib/output-collisions.ts
@@ -1,18 +1,9 @@
 /**
- * Output-path collision detection.
- *
- * Feature tabs that auto-derive output paths from templates (HDR Convert
- * today; Tab 4 Batch Rename + Time Shift / Font Embed batch in later
- * stages) can silently overwrite previously-written files when the user
- * re-runs without realizing — they had no chance to opt in. The
- * antidote is a pre-flight pass that asks the OS whether each projected
- * output already exists; the consumer pairs the count with a confirm
- * dialog before entering its busy state.
- *
- * Save-As-style flows (single file picked through a native save dialog)
- * already have OS-level overwrite confirmation and don't need this util.
+ * Snapshot existing destinations before requesting overwrite consent.
+ * Each writer uses that snapshot to choose replacement or exclusive creation.
  */
 import { outputPathExists } from "./tauri-api";
+import { normalizeOutputKey } from "./dedup-helpers";
 
 /** Maximum concurrent fs::stat probes. Real-world batch sizes top out
  *  around 26 (typical anime episode count), so 32 covers the common
@@ -22,24 +13,17 @@ import { outputPathExists } from "./tauri-api";
  *  calls into Tauri's command pump and briefly hang the runtime. */
 const MAX_CONCURRENT_STAT = 32;
 
-/**
- * Count how many of the given paths already exist on disk. Stat checks
- * run in parallel (capped at `MAX_CONCURRENT_STAT`) so batch latency is
- * a small number of round-trips regardless of path count.
- *
- * Stat failures are counted as EXISTING (fail-safe). An earlier
- * version counted them as non-existent, which meant a transient FS
- * error during pre-flight could suppress the overwrite-confirm dialog
- * and let the batch silently overwrite real files. The current
- * behavior — bias toward showing the dialog — is the conservative
- * one: a false-positive collision warning is annoying
- * (user clicks "Yes, overwrite"), but a false-negative miss destroys
- * data. `errorCount` continues to be logged for diagnosis.
- */
+/** Count unique existing destination keys; failed stat checks count as existing. */
 export async function countExistingFiles(paths: string[]): Promise<number> {
-  if (paths.length === 0) return 0;
+  return (await findExistingOutputKeys(paths)).size;
+}
+
+/** Snapshot destinations covered by an overwrite prompt. Paths absent from
+ * this snapshot must still use exclusive creation if they appear later. */
+export async function findExistingOutputKeys(paths: string[]): Promise<ReadonlySet<string>> {
+  const uniquePaths = [...new Map(paths.map((path) => [normalizeOutputKey(path), path])).values()];
   let errorCount = 0;
-  let existingCount = 0;
+  const existingKeys = new Set<string>();
   // Worker-pool pattern: keep up to MAX_CONCURRENT_STAT probes in flight;
   // each worker pulls the next index off a shared cursor. Order doesn't
   // matter for the count, so no result reassembly needed.
@@ -47,25 +31,25 @@ export async function countExistingFiles(paths: string[]): Promise<number> {
   const worker = async () => {
     while (true) {
       const idx = cursor++;
-      if (idx >= paths.length) return;
+      if (idx >= uniquePaths.length) return;
+      const path = uniquePaths[idx]!;
       try {
-        if (await outputPathExists(paths[idx]!)) {
-          existingCount += 1;
+        if (await outputPathExists(path)) {
+          existingKeys.add(normalizeOutputKey(path));
         }
       } catch {
-        // Count as existing (fail-safe). See function-level docblock
-        // for the WHY.
+        // A failed probe must not silently authorize replacement.
         errorCount += 1;
-        existingCount += 1;
+        existingKeys.add(normalizeOutputKey(path));
       }
     }
   };
-  const workerCount = Math.min(MAX_CONCURRENT_STAT, paths.length);
+  const workerCount = Math.min(MAX_CONCURRENT_STAT, uniquePaths.length);
   await Promise.all(Array.from({ length: workerCount }, () => worker()));
   if (errorCount > 0) {
     console.warn(
       `[ssaHdrify] countExistingFiles: ${errorCount} stat failure(s) treated as existing (fail-safe overwrite-confirm bias).`
     );
   }
-  return existingCount;
+  return existingKeys;
 }

--- a/src/lib/path-validation.ts
+++ b/src/lib/path-validation.ts
@@ -631,6 +631,15 @@ export function assertSafeOutputFilename(
   }
 }
 
+export function assertOutputDoesNotReplaceSelectedInput(
+  outputPath: string,
+  selectedInputKeys: ReadonlySet<string>
+): void {
+  if (selectedInputKeys.has(normalizeOutputKey(outputPath))) {
+    throw new Error("Output path matches a selected input file; choose a different output name");
+  }
+}
+
 /**
  * Validate a full output path against the input path's directory.
  * Throws on traversal, directory escape, MAX_PATH overflow, and

--- a/src/lib/release-contract.test.ts
+++ b/src/lib/release-contract.test.ts
@@ -8,6 +8,25 @@ async function readText(relativePath: string): Promise<string> {
 }
 
 describe("release configuration contract", () => {
+  it("permits native IPC without allowing external network connections", async () => {
+    const config = JSON.parse(await readText("../../src-tauri/tauri.conf.json")) as {
+      app: { security: { csp: string; devCsp: string } };
+    };
+    const sources = (csp: string, directive: string) =>
+      csp
+        .split(";")
+        .map((value) => value.trim().split(/\s+/u))
+        .find((parts) => parts[0] === directive)
+        ?.slice(1) ?? [];
+    expect(new Set(sources(config.app.security.csp, "connect-src"))).toEqual(
+      new Set(["ipc:", "http://ipc.localhost", "https://ipc.localhost"])
+    );
+    expect(sources(config.app.security.csp, "script-src")).toEqual(["'self'"]);
+    expect(sources(config.app.security.csp, "object-src")).toEqual(["'none'"]);
+    expect(sources(config.app.security.devCsp, "connect-src")).toEqual(
+      expect.arrayContaining(["ipc:", "http://ipc.localhost", "https://ipc.localhost"])
+    );
+  });
   it("keeps manifest and lockfile versions synchronized", async () => {
     const packageJson = JSON.parse(await readText("../../package.json")) as {
       version: string;

--- a/src/lib/subtitle-parser.test.ts
+++ b/src/lib/subtitle-parser.test.ts
@@ -92,10 +92,7 @@ describe("parseSubtitle", () => {
     const result = parseSubtitle(content);
     expect(result.format).toBe("ass");
     expect(result.captions).toHaveLength(2);
-    // ASS timing only — the parseAss `text` field is the post-comma
-    // remainder which still includes the Style field; the timing
-    // operations don't care about text content. Anchor on the
-    // load-bearing fields.
+    expect(result.captions.map((caption) => caption.text)).toEqual(["Hello", "World"]);
     expect(result.captions[0]!.start).toBe(1000);
     expect(result.captions[0]!.end).toBe(2500);
     expect(result.captions[1]!.start).toBe(3000);
@@ -109,7 +106,7 @@ describe("parseSubtitle", () => {
       "Dialogue: 0,0:00:01.00,0:00:02.00,Default,Hello\r\n";
 
     const result = parseSubtitle(content);
-    expect(result.captions[0]!.text).toBe("Default,Hello");
+    expect(result.captions[0]!.text).toBe("Hello");
     expect(result.captions[0]!.text).not.toContain("\r");
   });
 
@@ -858,5 +855,117 @@ describe("parseSubtitle / shiftSubtitle — oversized-ASS-Dialogue placeholder a
     expect(result.captions[0]!.skipped).toBe(true);
     expect(result.captions[0]!.text).toBe("");
     expect(result.captions[1]!.text).toBe("NORMAL");
+  });
+});
+
+describe("ASS declared event formats", () => {
+  const header = "[Script Info]\nScriptType: v4.00+\n[Events]\n";
+
+  it("uses named Start for threshold decisions and preserves reordered fields", () => {
+    const content =
+      header +
+      "Format: Layer, End, Style, Start, Text\r\n" +
+      "Dialogue: -1,0:00:02.00,Default,0:00:01.00,early, with comma\r\n" +
+      "\tDialogue: 2, 0:00:04.00 ,Default,\t0:00:03.00 ,late\n";
+    const result = shiftSubtitle(content, 1000, 1500);
+    expect(result.captions.map(({ start, end, text }) => ({ start, end, text }))).toEqual([
+      { start: 1000, end: 2000, text: "early, with comma" },
+      { start: 3000, end: 4000, text: "late" },
+    ]);
+    expect(result.output).toBe(
+      content.replace(" 0:00:04.00 ", " 0:00:05.00 ").replace("\t0:00:03.00 ", "\t0:00:04.00 ")
+    );
+  });
+
+  it("shifts negative and nonnegative Layer events together", () => {
+    const content =
+      header +
+      "Format: Layer, Start, End, Text\n" +
+      [-1, 0, 2147483647]
+        .map((layer) => `Dialogue: ${layer},0:00:01.00,0:00:02.00,text`)
+        .join("\n");
+    const result = shiftSubtitle(content, 1000);
+    expect(result.captions).toHaveLength(3);
+    expect(result.output).toBe(
+      content.replaceAll("0:00:02.00", "0:00:03.00").replaceAll("0:00:01.00", "0:00:02.00")
+    );
+  });
+
+  it.each([false, true])(
+    "keeps the declared columns for threshold decisions with repeated Events=%s",
+    (repeatHeader) => {
+      const first = "Dialogue: 0,0:00:05.00,0:00:04.00,first 0:00:04.00";
+      const second = "Dialogue: 0,0:00:04.00,0:00:03.00,second";
+      const content =
+        header +
+        `Format: Layer, End, Start, Text\r\n${first}\r\n` +
+        (repeatHeader ? "[Events]\r\n" : "") +
+        second;
+      const result = shiftSubtitle(content, 1000, 3500);
+      expect(result.captions.map(({ start, end }) => ({ start, end }))).toEqual([
+        { start: 4000, end: 5000 },
+        { start: 3000, end: 4000 },
+      ]);
+      expect(result.output).toBe(
+        content.replace(first, "Dialogue: 0,0:00:06.00,0:00:05.00,first 0:00:04.00")
+      );
+    }
+  );
+
+  it("supports shortened formats without Layer and preserves comments and unrelated sections", () => {
+    const content =
+      header +
+      "Format: End, Start, Text\n" +
+      "Comment: 0:00:02.00,0:00:01.00,unchanged\n" +
+      "Dialogue: 0:00:02.00,0:00:01.00,visible\n" +
+      "[Other]\nFormat: invalid\nDialogue: 0:00:02.00,0:00:01.00,metadata\n";
+    const result = shiftSubtitle(content, 1000);
+    expect(result.captions).toHaveLength(1);
+    expect(result.output).toBe(
+      content.replace(
+        "Dialogue: 0:00:02.00,0:00:01.00,visible",
+        "Dialogue: 0:00:03.00,0:00:02.00,visible"
+      )
+    );
+  });
+
+  it("uses each declaration locally and keeps oversized placeholders aligned", () => {
+    const big = "X".repeat(64001);
+    const content =
+      header +
+      "Format: End, Start, Text\n" +
+      `Dialogue: 0:00:02.00,0:00:01.00,${big}\n` +
+      "Format: Start, End, Text\nDialogue: 0:00:03.00,0:00:04.00,normal";
+    const result = shiftSubtitle(content, 1000);
+    expect(result.captions[0]!.skipped).toBe(true);
+    expect(result.output).toBe(
+      content.replace(
+        "Dialogue: 0:00:03.00,0:00:04.00,normal",
+        "Dialogue: 0:00:04.00,0:00:05.00,normal"
+      )
+    );
+  });
+
+  it.each(["Start, Start, End, Text", "End, Text", "Start, End", "Text, Start, End"])(
+    "refuses ambiguous or unsupported event declaration %s",
+    (format) => {
+      expect(() =>
+        parseSubtitle(header + `Format: ${format}\nDialogue: 0,0:00:01.00,0:00:02.00,text`)
+      ).toThrow(/unique Start, End, and final Text/);
+    }
+  );
+
+  it("accepts 1024 declared fields and rejects the next field before splitting events", () => {
+    const fields = ["Start", "End", ...Array<string>(1021).fill("Metadata"), "Text"];
+    const values = [
+      "0:00:01.00",
+      "0:00:02.00",
+      ...Array<string>(1021).fill("unused"),
+      "text,comma",
+    ];
+    const content = header + `Format: ${fields.join(",")}\nDialogue: ${values.join(",")}`;
+    expect(shiftSubtitle(content, 1000).captions[0]!.text).toBe("text,comma");
+    fields.splice(2, 0, "Extra");
+    expect(() => parseSubtitle(header + `Format: ${fields.join(",")}`)).toThrow(/too many fields/);
   });
 });

--- a/src/lib/subtitle-parser.ts
+++ b/src/lib/subtitle-parser.ts
@@ -10,7 +10,6 @@
  * Only implements what we need: parse timestamps, shift them, rebuild.
  * Does NOT attempt full semantic parsing of style tags etc.
  */
-import { stripUnicodeControls } from "./unicode-controls";
 
 export interface Caption {
   /** Raw line(s) from the original file for this caption block */
@@ -637,136 +636,128 @@ function buildVtt(content: string, captions: Caption[]): string {
 
 // ── ASS/SSA Parser (timing only) ─────────────────────────
 
-// Single source of truth for the Dialogue line regex.
-// `i`: ASS renderers are case-insensitive on `Dialogue:` — real-world tooling
-// sometimes emits `DIALOGUE:`. Leading `[\t ]*` tolerates indentation
-// WITHOUT spanning lines: with the `m` flag, `\s*` here would have let the
-// engine consume any number of newlines + blank-line whitespace at each line
-// anchor before failing to match `Dialogue:` and backtracking — a crafted
-// file like `[Script Info]\n` + thousands of empty lines without any
-// Dialogue line drove O(n^2) regex work — ReDoS via quadratic
-// backtracking on attacker-controlled subtitle inputs. The
-// captured whitespace is preserved via the prefix group so buildAss round-
-// trips it exactly. A factory (not a shared instance) is used so each call
-// gets a fresh `lastIndex` — guarding against pollution if a previous
-// parseAss call threw mid-loop.
-// hour fields bounded to {1,12} digits,
-// matching `parseAssTime`. Unbounded `\d+` would let pathological
-// `999…9:00:00.00` (100+ hour digits) saturate parseInt to Infinity
-// before the time-math even runs. 12 digits is identical to the SRT /
-// VTT / display-time bound used elsewhere in this file.
-const DIALOGUE_PATTERN = String.raw`^([\t ]*Dialogue:[\t ]*(?:\d{1,12}|Marked[\t ]*=[\t ]*-?\d{1,12}),)(\d{1,12}:\d{2}:\d{2}\.\d{2}),( *)(\d{1,12}:\d{2}:\d{2}\.\d{2}),(.*)$`;
-const DIALOGUE_FLAGS = "gim";
+const MAX_ASS_EVENT_FIELDS = 1024;
+const ASS_TIME_FIELD = /^[\t ]*(\d{1,12}:\d{2}:\d{2}\.\d{2})[\t ]*$/;
 
-function createDialogueRe(): RegExp {
-  return new RegExp(DIALOGUE_PATTERN, DIALOGUE_FLAGS);
+interface AssDialogue {
+  raw: string;
+  offset: number;
+  start: { offset: number; value: string };
+  end: { offset: number; value: string };
+  text: string;
+}
+
+// A missing Format keeps the historical timing-only fallback. Declared formats
+// follow libass's named columns; supported declarations keep Text last because
+// it may contain commas. A declaration remains active across section headers.
+function* assDialogues(content: string): Generator<AssDialogue> {
+  let inEvents = false;
+  let fields = ["layer", "start", "end", "text"];
+  let startIndex = 1;
+  let endIndex = 2;
+  for (const sourceLine of iterateSourceLines(content)) {
+    const line = sourceLine.body;
+    const section = /^[\t ]*\[([^\]]+)\][\t ]*$/.exec(line);
+    if (section) {
+      inEvents = section[1]!.toLowerCase() === "events";
+      continue;
+    }
+    if (!inEvents) continue;
+    const format = /^[\t ]*Format:[\t ]*(.*)$/i.exec(line);
+    if (format) {
+      fields = format[1]!
+        .split(",", MAX_ASS_EVENT_FIELDS + 1)
+        .map((field) => field.trim().toLowerCase());
+      if (fields.length > MAX_ASS_EVENT_FIELDS) {
+        throw new Error(`ASS/SSA event Format has too many fields (max ${MAX_ASS_EVENT_FIELDS})`);
+      }
+      if (
+        ["start", "end", "text"].some(
+          (name) => fields.filter((field) => field === name).length !== 1
+        ) ||
+        fields.at(-1) !== "text"
+      ) {
+        throw new Error(
+          "ASS/SSA event Format must contain unique Start, End, and final Text fields"
+        );
+      }
+      startIndex = fields.indexOf("start");
+      endIndex = fields.indexOf("end");
+      continue;
+    }
+    const prefix = /^[\t ]*Dialogue:[\t ]*/i.exec(line);
+    if (!prefix) continue;
+    const offsets = [prefix[0].length];
+    let fieldStart = offsets[0]!;
+    for (let i = 1; i < fields.length; i++) {
+      const comma = line.indexOf(",", fieldStart);
+      if (comma < 0) break;
+      fieldStart = comma + 1;
+      offsets.push(fieldStart);
+    }
+    if (offsets.length !== fields.length) continue;
+    const timingField = (index: number) => {
+      const offset = offsets[index]!;
+      const field = line.slice(offset, offsets[index + 1]! - 1);
+      const time = ASS_TIME_FIELD.exec(field);
+      return time
+        ? { offset: offset + field.length - field.trimStart().length, value: time[1]! }
+        : null;
+    };
+    const start = timingField(startIndex);
+    const end = timingField(endIndex);
+    if (!start || !end) continue;
+    yield { raw: line, offset: sourceLine.start, start, end, text: line.slice(offsets.at(-1)!) };
+  }
 }
 
 function parseAss(content: string): Caption[] {
   const captions: Caption[] = [];
-  const dialogueRe = createDialogueRe();
-  let match;
-  while ((match = dialogueRe.exec(content)) !== null) {
+  for (const dialogue of assDialogues(content)) {
     if (captions.length >= MAX_PARSED_ENTRIES) {
-      // Match the SRT/SUB sibling errors which include the actual
-      // count for diagnosis. Strict `>=` here means "we just refused
-      // to add the next one"; report N+ to make the boundary clear
-      // (we can't get the exact dialogue count without one more
-      // iteration, and that's the bound we just refused to cross).
       throw new Error(`Too many subtitle entries: ${captions.length}+ (max ${MAX_PARSED_ENTRIES})`);
     }
-    const text = match[5]!;
-    if (text.length > MAX_CAPTION_TEXT_LEN) {
-      // Emit a skipped placeholder rather than continuing past the
-      // match. buildAss walks the same `dialogueRe` over the original
-      // content and consumes captions sequentially; if parseAss
-      // silently dropped this entry the index would drift and every
-      // subsequent Dialogue line would receive the wrong timestamps.
-      //
-      // Retention: the upstream 50 MB file-read cap (Rust IPC,
-      // `MAX_TEXT_SIZE` in encoding.rs) bounds total retained raw
-      // size; clearing `text` to `""` keeps the parsed-content path
-      // clean so downstream feature layers count `c.skipped` rather
-      // than inspecting `c.text` for the oversized class.
-      //
-      // The `raw: match[0]` field below IS load-bearing — it retains
-      // the entire original Dialogue line (potentially multi-MB for a
-      // single oversized caption) because `buildAss`'s positional
-      // walk over `dialogueRe` matches the SAME bytes when
-      // rebuilding output; substituting `raw` with a truncated
-      // string would break drift detection (parsedAss[i].raw must
-      // equal originalContent.match(dialogueRe)[i]). Worst-case
-      // retention: a single 50 MB Dialogue line + `MAX_PARSED_ENTRIES`
-      // other captions at ≤ MAX_CAPTION_TEXT_LEN (64 KB). Sum stays
-      // bounded by the file-read cap; the surface is documented, not
-      // closed.
-      captions.push({
-        raw: match[0],
-        start: parseAssTime(match[2]!),
-        end: parseAssTime(match[4]!),
-        text: "",
-        skipped: true,
-      });
-      continue;
-    }
+    const skipped = dialogue.text.length > MAX_CAPTION_TEXT_LEN;
+    // Retain oversized entries as placeholders so the shared rebuild walk
+    // preserves their bytes without shifting the following event's timestamps.
     captions.push({
-      raw: match[0],
-      start: parseAssTime(match[2]!),
-      end: parseAssTime(match[4]!),
-      text,
+      raw: dialogue.raw,
+      start: parseAssTime(dialogue.start.value),
+      end: parseAssTime(dialogue.end.value),
+      text: skipped ? "" : dialogue.text,
+      ...(skipped ? { skipped: true } : {}),
     });
   }
   return captions;
 }
 
 function buildAss(content: string, captions: Caption[]): string {
-  // For ASS, we replace timestamps in-place rather than rebuilding.
-  const dialogueRe = createDialogueRe();
-  let idx = 0;
-  const result = content.replace(dialogueRe, (original, prefix, _start, space, _end, rest) => {
-    if (idx < captions.length) {
-      const c = captions[idx++]!;
-      // Skipped placeholder (oversized text in parseAss): preserve the
-      // original Dialogue line verbatim. Advancing idx is what keeps
-      // the next non-skipped caption aligned with the next Dialogue
-      // match downstream.
-      if (c.skipped) return original;
-      return `${prefix}${formatAssTime(c.start)},${space}${formatAssTime(c.end)},${rest}`;
+  const parts: string[] = [];
+  let cursor = 0;
+  let index = 0;
+  for (const dialogue of assDialogues(content)) {
+    const caption = captions[index++];
+    if (!caption || caption.raw !== dialogue.raw) {
+      throw new Error("buildAss/parseAss drift: dialogue entries no longer match");
     }
-    return original;
-  });
-  // A mismatch means the input changed shape between parseAss and buildAss
-  // (or the two sides drifted): the output would carry wrong timestamps.
-  // Hard-fail rather than warn; silent timing drift is the worst kind.
-  if (idx !== captions.length) {
-    // This branch should be unreachable: parseAss + buildAss share
-    // the same dialogueRe and walk identical positions. If we get
-    // here, it means the regex consumed the input differently
-    // between the two passes — typically a sign of stateful regex
-    // contamination or a future behavior-changing edit to one but
-    // not the other. The error string is intentionally diagnostic-
-    // grade rather than user-facing because it's a developer
-    // invariant: it surfaces to the user only as the prefix
-    // before the colon ("buildAss/parseAss drift:"), which the
-    // shift-flow's addLog wraps with msg_timing_error and the
-    // file name. If users start reporting it, that's the signal
-    // to investigate parser/regex divergence in this file.
-    const firstUnconsumed = captions[idx]?.raw ?? "(no raw line captured)";
-    // Defense-in-depth: sanitize the excerpt before interpolating
-    // into the error string. The branch is documented unreachable,
-    // but if a crafted ASS does reach here the raw caption text
-    // could carry U+202E (Trojan-Source) or other BiDi marks; the
-    // error message lands in addLog / stderr where reversed display
-    // misleads the user about which file is failing.
-    const raw =
-      firstUnconsumed.length > 120 ? `${firstUnconsumed.slice(0, 120)}…` : firstUnconsumed;
-    const excerpt = stripUnicodeControls(raw);
+    if (caption.skipped) continue;
+    const replacements = [
+      { field: dialogue.start, value: formatAssTime(caption.start) },
+      { field: dialogue.end, value: formatAssTime(caption.end) },
+    ].sort((a, b) => a.field.offset - b.field.offset);
+    for (const replacement of replacements) {
+      const offset = dialogue.offset + replacement.field.offset;
+      parts.push(content.slice(cursor, offset), replacement.value);
+      cursor = offset + replacement.field.value.length;
+    }
+  }
+  if (index !== captions.length) {
     throw new Error(
-      `buildAss/parseAss drift: consumed ${idx}/${captions.length} shifted entries; ` +
-        `first unconsumed entry index=${idx}, raw="${excerpt}"`
+      `buildAss/parseAss drift: consumed ${index}/${captions.length} shifted entries`
     );
   }
-  return result;
+  parts.push(content.slice(cursor));
+  return parts.join("");
 }
 
 // ── SUB (MicroDVD) Parser ─────────────────────────────────

--- a/src/lib/tauri-api.test.ts
+++ b/src/lib/tauri-api.test.ts
@@ -18,6 +18,7 @@
  *      the return. This pins the async-after-resolve regression.
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { normalizeOutputKey } from "./dedup-helpers";
 
 interface MockChannel {
   onmessage: ((msg: unknown) => void) | null;
@@ -49,6 +50,7 @@ import {
   pickAssFiles,
   pickFontFiles,
   outputPathExists,
+  findSelectedInputConflictKeys,
   pickRenameInputs,
   preflightFontDirectory,
   preflightFontFiles,
@@ -57,6 +59,9 @@ import {
   scanFontFiles,
   subsetFont,
   writeStyleEditOutput,
+  writeText,
+  copyPath,
+  renamePath,
 } from "./tauri-api";
 
 beforeEach(() => {
@@ -72,6 +77,50 @@ describe("outputPathExists", () => {
     expect(invokeMock).toHaveBeenCalledWith("safe_output_path_exists", {
       path: "D:/Anime/out.ass",
     });
+  });
+});
+
+describe("selected-input aliases", () => {
+  it("checks the whole batch once and returns normalized conflicting output keys", async () => {
+    const inputs = ["D:/Subtitles/source.ass"];
+    const outputs = ["D:/Alias/source.ass", "D:/Subtitles/new.ass"];
+    invokeMock.mockResolvedValueOnce([outputs[0], outputs[0]]);
+    const keys = await findSelectedInputConflictKeys(inputs, outputs);
+    expect(invokeMock).toHaveBeenCalledExactlyOnceWith("safe_find_selected_input_conflicts", {
+      inputPaths: inputs,
+      outputPaths: outputs,
+    });
+    expect([...keys]).toEqual([normalizeOutputKey(outputs[0]!)]);
+  });
+
+  it("propagates unresolved-input failures rather than approving the outputs", async () => {
+    invokeMock.mockRejectedValueOnce(new Error("Failed to resolve selected input"));
+    await expect(findSelectedInputConflictKeys(["D:/missing.ass"], ["D:/out.ass"])).rejects.toThrow(
+      "Failed to resolve selected input"
+    );
+  });
+});
+
+describe("per-destination overwrite permission", () => {
+  it.each([false, true])(
+    "passes explicit overwrite=%s through every ordinary write operation",
+    async (overwrite) => {
+      await writeText("D:/Subtitles/output.ass", "subtitle", overwrite);
+      await copyPath("D:/Subtitles/input.ass", "D:/Subtitles/output.ass", overwrite);
+      await renamePath("D:/Subtitles/input.ass", "D:/Subtitles/output.ass", overwrite);
+      expect(invokeMock.mock.calls.map((call) => call[1].overwrite)).toEqual([
+        overwrite,
+        overwrite,
+        overwrite,
+      ]);
+    }
+  );
+
+  it("defaults all ordinary writes to exclusive creation", async () => {
+    await writeText("D:/Subtitles/output.ass", "subtitle");
+    await copyPath("D:/Subtitles/input.ass", "D:/Subtitles/output.ass");
+    await renamePath("D:/Subtitles/input.ass", "D:/Subtitles/output.ass");
+    expect(invokeMock.mock.calls.map((call) => call[1].overwrite)).toEqual([false, false, false]);
   });
 });
 

--- a/src/lib/tauri-api.ts
+++ b/src/lib/tauri-api.ts
@@ -8,6 +8,7 @@ import { strings } from "../i18n/strings";
 import { fileNameFromPath } from "./path-validation";
 import { VIDEO_EXTS, SUBTITLE_EXTS, RENAME_SUBTITLE_EXTS } from "./rename-extensions";
 import { decodeBase64Bytes } from "./base64-bytes";
+import { normalizeOutputKey } from "./dedup-helpers";
 
 // ── File Dialogs ──────────────────────────────────────────
 
@@ -214,6 +215,20 @@ export async function readTextDetectEncoding(path: string): Promise<ReadTextResu
 export async function outputPathExists(path: string): Promise<boolean> {
   return invoke<boolean>("safe_output_path_exists", { path });
 }
+
+export const SELECTED_INPUT_CONFLICT_BATCH_LIMIT = 5_000;
+
+/** Resolve existing path aliases once before overwrite consent for a batch. */
+export async function findSelectedInputConflictKeys(
+  inputPaths: readonly string[],
+  outputPaths: readonly string[]
+): Promise<ReadonlySet<string>> {
+  const conflicts = await invoke<string[]>("safe_find_selected_input_conflicts", {
+    inputPaths,
+    outputPaths,
+  });
+  return new Set(conflicts.map(normalizeOutputKey));
+}
 /** Write a text file with explicit UTF-8.
  *
  *  Routes through the Rust-side `safe_write_text_file` command (not
@@ -225,11 +240,9 @@ export async function outputPathExists(path: string): Promise<boolean> {
  *  regular-file destinations it removes the file first and re-creates
  *  via `OpenOptions::create_new(true)` for an atomic guard.
  *
- *  Overwrite is hardcoded to true here: every callsite preflights
- *  collisions via `countExistingFiles` in `src/lib/output-collisions.ts`
- *  and asks the user before invoking writeText. */
-export async function writeText(path: string, content: string): Promise<void> {
-  await invoke("safe_write_text_file", { path, content, overwrite: true });
+ *  Overwrite applies only to a destination covered by accepted preflight. */
+export async function writeText(path: string, content: string, overwrite = false): Promise<void> {
+  await invoke("safe_write_text_file", { path, content, overwrite });
 }
 
 export interface StyleEditWriteRequest {
@@ -265,8 +278,8 @@ export async function writeStyleEditOutput(request: StyleEditWriteRequest): Prom
  *  or let a symlinked destination redirect the move outside the user-
  *  selected output dir. The command refuses if either endpoint is a
  *  reparse point. */
-export async function renamePath(from: string, to: string): Promise<void> {
-  await invoke("safe_rename_file", { src: from, dst: to, overwrite: true });
+export async function renamePath(from: string, to: string, overwrite = false): Promise<void> {
+  await invoke("safe_rename_file", { src: from, dst: to, overwrite });
 }
 
 /** Copy a file. Source is preserved. Used by Batch Rename's two copy
@@ -279,8 +292,8 @@ export async function renamePath(from: string, to: string): Promise<void> {
  *  malicious or accidental shortcut in a downloaded fan-sub pack can
  *  abuse to read a sensitive source (e.g. `~/.ssh/id_rsa`) and copy
  *  it into the user's video directory under a subtitle-looking name. */
-export async function copyPath(from: string, to: string): Promise<void> {
-  await invoke("safe_copy_file", { src: from, dst: to, overwrite: true });
+export async function copyPath(from: string, to: string, overwrite = false): Promise<void> {
+  await invoke("safe_copy_file", { src: from, dst: to, overwrite });
 }
 
 // ── Path Utilities ───────────────────────────────────────

--- a/src/lib/theme-contrast.test.ts
+++ b/src/lib/theme-contrast.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const css = readFileSync(new URL("../index.css", import.meta.url), "utf8");
+const darkStart = css.indexOf('[data-theme="dark"]');
+const themes = { light: css.slice(css.indexOf(":root {"), darkStart), dark: css.slice(darkStart) };
+function luminance(hex: string): number {
+  const expanded = hex.length === 3 ? [...hex].map((c) => c + c).join("") : hex;
+  return [0.2126, 0.7152, 0.0722].reduce((sum, weight, i) => {
+    const channel = parseInt(expanded.slice(i * 2, i * 2 + 2), 16) / 255;
+    return (
+      sum + weight * (channel <= 0.04045 ? channel / 12.92 : ((channel + 0.055) / 1.055) ** 2.4)
+    );
+  }, 0);
+}
+function contrast(theme: string, foreground: string, background: string): number {
+  const color = (name: string) => theme.match(new RegExp(`--${name}:\\s*#([0-9a-f]+)`))![1]!;
+  const a = luminance(color(foreground)),
+    b = luminance(color(background));
+  return (Math.max(a, b) + 0.05) / (Math.min(a, b) + 0.05);
+}
+
+describe("enabled text contrast", () => {
+  for (const [name, theme] of Object.entries(themes)) {
+    it(`${name} action labels and informative text meet normal-text contrast`, () => {
+      expect(contrast(theme, "accent-text", "accent")).toBeGreaterThanOrEqual(4.5);
+      for (const foreground of ["text-secondary", "text-muted"]) {
+        for (const background of ["bg-app", "bg-header", "bg-panel", "bg-input"]) {
+          expect(
+            contrast(theme, foreground, background),
+            `${foreground} on ${background}`
+          ).toBeGreaterThanOrEqual(4.5);
+        }
+      }
+    });
+  }
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 // Shared resolver between this config and scripts/build-engine.mjs.
 // See scripts/lib/app-version.mjs for the version-precedence logic.
 import { resolveAppVersion } from "./scripts/lib/app-version.mjs";
+import { buildFrontendNotices } from "./scripts/lib/frontend-notices.mjs";
 
 // ESM-safe equivalent of CommonJS __dirname — Vite injects a shim today, but
 // relying on import.meta.url keeps this config portable across strict-ESM
@@ -21,10 +22,31 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
  * sanitization allowlist + fallback ladder.
  */
 const APP_VERSION = resolveAppVersion(__dirname);
+const frontendNotices = buildFrontendNotices(__dirname);
+const noticesModule = "virtual:frontend-notices";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [react(), tailwindcss()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    {
+      name: "frontend-notices",
+      resolveId(id) {
+        if (id === noticesModule) return "\0" + noticesModule;
+      },
+      load(id) {
+        if (id === "\0" + noticesModule) return `export default ${JSON.stringify(frontendNotices)}`;
+      },
+      generateBundle() {
+        this.emitFile({
+          type: "asset",
+          fileName: "third-party-notices.txt",
+          source: frontendNotices,
+        });
+      },
+    },
+  ],
   define: {
     __APP_VERSION__: JSON.stringify(APP_VERSION),
   },


### PR DESCRIPTION
Batch outputs could replace selected sources, accept replacement permission too broadly, or race newly created rename destinations. Protect loaded GUI sources across tabs and CLI batch inputs, compare existing path aliases, and retain exclusive writes for destinations outside the accepted preflight. Preparation starts visibly and cancelled or stale pickers cannot replace an active selection.

Also correct ASS timing-field handling and repeated section headers, escaped literal braces, short/decimal colors, malformed HTML scan cost, and shift-only chain extensions. Bound retained font analysis, encoded font output, cache traversal, and mounted subtitle options; improve informative text contrast. Include generated offline frontend license notices and detect unsupported workflow action-key syntax explicitly.

Update the typescript-eslint development toolchain to the verified stable 8.70.0 release; retain unrelated dependency pins.

Validation:
- TypeScript 7 and TypeScript 6 checks, ESLint/Prettier, Stylelint, production frontend build, and npm audit pass.
- 982 frontend/script tests and 522 Rust tests pass. Eight optional tests requiring local font or cache fixtures remain ignored by the existing suite.
- Locked all-target Clippy and installed Rust 1.91.1 compatibility check pass.
- Windows filesystem tests include late destination collisions and a real directory junction; actual GUI-handler tests cover cancellation, aliases, cross-tab sources, and per-destination overwrite permission.
- Built license viewer checked in Chrome under the configured production CSP in both themes; emitted notice text matches the generated inventory exactly. This browser check does not exercise native WebView IPC. Unix-only rename code was source-reviewed; execution checks here were on Windows.

Application version and release configuration are unchanged. No release is requested.


